### PR TITLE
Order wells into column order before naming

### DIFF
--- a/app/models/labware_creators/pooled_tubes_by_submission.rb
+++ b/app/models/labware_creators/pooled_tubes_by_submission.rb
@@ -56,9 +56,8 @@ module LabwareCreators
     end
 
     def name_for(pool_details)
-      wells = pool_details['wells']
-      # Wells SHOULD already be sorted
-      "#{stock_plate_barcode} #{wells.first}:#{wells.last}"
+      first, last = WellHelpers.first_and_last_in_columns(pool_details['wells'])
+      "#{stock_plate_barcode} #{first}:#{last}"
     end
 
     def stock_plate_barcode

--- a/lib/well_helpers.rb
+++ b/lib/well_helpers.rb
@@ -11,6 +11,15 @@ module WellHelpers
     @column_order ||= COLUMNS_RANGE.map { |c| ROWS_RANGE.map { |r| "#{r}#{c}" } }.flatten.freeze
   end
 
+  # Returns an array of all well names in row order
+  # Sequencescape returns some wells in column order. THis is primarily used to help
+  # us mimic Sequencescape output in tests.
+  #
+  # @return [Array] well names in row order ie. A1, A2, A3 ...
+  def self.row_order
+    @row_order ||= ROWS_RANGE.map { |r| COLUMNS_RANGE.map { |c| "#{r}#{c}" } }.flatten.freeze
+  end
+
   # Returns the index of the well by column
   # @param [String] well The well name eg. A1
   # @return [Int] the index, eg. 0
@@ -37,10 +46,43 @@ module WellHelpers
     column_order[index]
   end
 
-  def self.formatted_range(wells)
+  #
+  # Returns a new array sorted into column order
+  # eg. sort_in_column_order(['A1', 'A2', 'B1']) => ['A1', 'B1', 'A2']
+  #
+  # @param [Array<String>] wells Array of well names to sort
+  #
+  # @return [Array<String>] Array of well names sorted in column order
+  #
+  def self.sort_in_column_order(wells)
     wells.sort_by { |well| index_of(well) }
+  end
+
+  #
+  # Compacts the provided well range into an easy to read summary.
+  # eg. formatted_range(['A1', 'B1', 'C1','A2','A5','B5']) => 'A1-C1,A2,A5-B5'
+  # Mostly this will just be start_well-end_well
+  #
+  # @param [Array<String>] wells Array of well names to format
+  #
+  # @return [String] A name describing the range
+  #
+  def self.formatted_range(wells)
+    sort_in_column_order(wells)
          .slice_when { |previous_well, next_well| index_of(next_well) - index_of(previous_well) > 1 }
          .map { |range| [range.first, range.last].uniq.join('-') }
          .join(', ')
+  end
+
+  #
+  # Extracts the first and last well (as sorted in column order) from the array
+  #
+  # @param [Array<String>] wells Array of well names to sort
+  #
+  # @return [Array<string>] ['first_well_name','last_well_name']
+  #
+  def self.first_and_last_in_columns(wells)
+    sorted = sort_in_column_order(wells)
+    [sorted.first, sorted.last]
   end
 end

--- a/lib/well_helpers.rb
+++ b/lib/well_helpers.rb
@@ -69,9 +69,9 @@ module WellHelpers
   #
   def self.formatted_range(wells)
     sort_in_column_order(wells)
-         .slice_when { |previous_well, next_well| index_of(next_well) - index_of(previous_well) > 1 }
-         .map { |range| [range.first, range.last].uniq.join('-') }
-         .join(', ')
+      .slice_when { |previous_well, next_well| index_of(next_well) - index_of(previous_well) > 1 }
+      .map { |range| [range.first, range.last].uniq.join('-') }
+      .join(', ')
   end
 
   #

--- a/spec/factories/plate_factories.rb
+++ b/spec/factories/plate_factories.rb
@@ -32,7 +32,7 @@ FactoryGirl.define do
       pool_hash = {}
       pool_sizes.each_with_index do |size, index|
         pool_hash["pool-#{index + 1}-uuid"] = {
-          'wells' => wells.shift(size),
+          'wells' => wells.shift(size).sort_by { |well|  WellHelpers.row_order.index(well) },
           'insert_size' => { from: 100, to: 300 },
           'library_type' => { name: library_type },
           'request_type' => request_type,

--- a/spec/factories/plate_factories.rb
+++ b/spec/factories/plate_factories.rb
@@ -32,7 +32,7 @@ FactoryGirl.define do
       pool_hash = {}
       pool_sizes.each_with_index do |size, index|
         pool_hash["pool-#{index + 1}-uuid"] = {
-          'wells' => wells.shift(size).sort_by { |well|  WellHelpers.row_order.index(well) },
+          'wells' => wells.shift(size).sort_by { |well| WellHelpers.row_order.index(well) },
           'insert_size' => { from: 100, to: 300 },
           'library_type' => { name: library_type },
           'request_type' => request_type,

--- a/spec/factory_outputs/plate_factory_spec.rb
+++ b/spec/factory_outputs/plate_factory_spec.rb
@@ -13,7 +13,7 @@ describe 'plate factory' do
          iteration: 1,
          label: { "prefix": 'RNA-seq dUTP eukaryotic PCR', "text": 'ILC Stock' },
          location: 'Library creation freezer',
-         pool_sizes: [8, 8],
+         pool_sizes: [9, 9],
          priority: 0,
          stock_plate: {
            "barcode": {
@@ -115,7 +115,7 @@ describe 'plate factory' do
         "pools": {
           "pool-1-uuid": {
             "wells": [
-              "A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"
+              "A1", "A2", "B1", "C1", "D1", "E1", "F1", "G1", "H1"
             ],
             "insert_size": {
               "from": 100,
@@ -129,7 +129,7 @@ describe 'plate factory' do
           },
           "pool-2-uuid": {
             "wells": [
-              "A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"
+              "A3", "B2", "B3", "C2", "D2", "E2", "F2", "G2", "H2"
             ],
             "insert_size": {
               "from": 100,

--- a/spec/models/labware_creators/pooled_tubes_by_submission_spec.rb
+++ b/spec/models/labware_creators/pooled_tubes_by_submission_spec.rb
@@ -44,14 +44,14 @@ describe LabwareCreators::PooledTubesBySubmission do
       stub_api_post(
         'specific_tube_creations',
         payload: {
-           specific_tube_creation: {
-             user: user_uuid,
-             parent: parent_uuid,
-             child_purposes: [purpose_uuid, purpose_uuid],
-             tube_attributes: [{ name: 'DN5 A1:C1' }, { name: 'DN5 D1:A2' }]
-           }
+          specific_tube_creation: {
+            user: user_uuid,
+            parent: parent_uuid,
+            child_purposes: [purpose_uuid, purpose_uuid],
+            tube_attributes: [{ name: 'DN5 A1:C1' }, { name: 'DN5 D1:A2' }]
+          }
         },
-        body: json(:specific_tube_creation, uuid: tube_creation_request_uuid, children_count: 2, )
+        body: json(:specific_tube_creation, uuid: tube_creation_request_uuid, children_count: 2, names: ['DN5 A1:C1', 'DN5 D1:A2'])
       )
     end
 

--- a/spec/models/labware_creators/pooled_tubes_by_submission_spec.rb
+++ b/spec/models/labware_creators/pooled_tubes_by_submission_spec.rb
@@ -19,7 +19,7 @@ describe LabwareCreators::PooledTubesBySubmission do
   let(:purpose_uuid) { SecureRandom.uuid }
   let(:purpose)      { json :purpose, uuid: purpose_uuid }
   let(:parent_uuid)  { SecureRandom.uuid }
-  let(:parent)       { json :plate, uuid: parent_uuid, pool_sizes: [3, 3], stock_plate_barcode: 5 }
+  let(:parent)       { json :plate, uuid: parent_uuid, pool_sizes: [3, 6], stock_plate_barcode: 5 }
 
   let(:form_attributes) do
     {
@@ -48,7 +48,7 @@ describe LabwareCreators::PooledTubesBySubmission do
              user: user_uuid,
              parent: parent_uuid,
              child_purposes: [purpose_uuid, purpose_uuid],
-             tube_attributes: [{ name: 'DN5 A1:C1' }, { name: 'DN5 D1:F1' }]
+             tube_attributes: [{ name: 'DN5 A1:C1' }, { name: 'DN5 D1:A2' }]
            }
         },
         body: json(:specific_tube_creation, uuid: tube_creation_request_uuid, children_count: 2, )
@@ -57,7 +57,7 @@ describe LabwareCreators::PooledTubesBySubmission do
 
     # Find out what tubes we've just made!
     let!(:tube_creation_children_request) do
-      stub_api_get(tube_creation_request_uuid, 'children', body: json(:tube_collection, names: ['DN5 A1:C1', 'DN5 D1:F1']))
+      stub_api_get(tube_creation_request_uuid, 'children', body: json(:tube_collection, names: ['DN5 A1:C1', 'DN5 D1:A2']))
     end
 
     # The API needs to pull back the transfer template to know what actions it can perform


### PR DESCRIPTION
While the wells were sorted, they were sorted in row order,
not column order. This updates the tests to match Sequencescape
and ensures that the tested ranges behave differently.