### PR TITLE
Check units of concentration and do  not convert to int

### DIFF
--- a/app/sequencescape/sequencescape/api/v2/well.rb
+++ b/app/sequencescape/sequencescape/api/v2/well.rb
@@ -5,7 +5,8 @@ class Sequencescape::Api::V2::Well < Sequencescape::Api::V2::Base
   has_many :qc_results
 
   def latest_concentration
-    qc_results.select { |qc| qc.key.casecmp('concentration').zero? }
+    qc_results.select { |qc| qc.key.casecmp('molarity').zero? || qc.key.casecmp('concentration').zero? }
+              .select { |qc| qc.units.casecmp('nM').zero? }
               .sort_by(&:created_at)
               .last
   end

--- a/app/views/exports/concentrations.csv.erb
+++ b/app/views/exports/concentrations.csv.erb
@@ -3,5 +3,5 @@
 
 <%= CSV.generate_line ['Well','Concentration','Pick','Pool'], row_sep: "" %>
 <% @plate.wells_in_columns.each do |well| %>
-<%= CSV.generate_line [well.position['name'], well.latest_concentration&.value&.to_i, (well.passed? ? 1 : 0), @pooling_ids[well.position['name']]], row_sep: '' %>
+<%= CSV.generate_line [well.position['name'], well.latest_concentration&.value, (well.passed? ? 1 : 0), @pooling_ids[well.position['name']]], row_sep: '' %>
 <% end %>

--- a/spec/factories/qc_result_factories.rb
+++ b/spec/factories/qc_result_factories.rb
@@ -3,7 +3,8 @@
 FactoryBot.define do
   factory :qc_result, class: Sequencescape::Api::V2::QcResult do
     key 'concentration'
-    value '1'
+    value '1.5'
+    units 'nM'
     created_at { Time.current }
 
     skip_create

--- a/spec/views/exports/concentrations.csv.erb_spec.rb
+++ b/spec/views/exports/concentrations.csv.erb_spec.rb
@@ -19,8 +19,8 @@ describe 'exports/concentrations.csv.erb' do
         ['Plate Barcode', 'DN1S'],
         [],
         %w[Well Concentration Pick Pool],
-        %w[A1 1 1 1],
-        %w[B1 1 1 2]
+        %w[A1 1.5 1 1],
+        %w[B1 1.5 1 2]
       ]
     end
 


### PR DESCRIPTION
- Units are expected to be in nM, wwe double check that
- We also add molarity to the key list
- Finally we avoid calling to_i, as we do NOT want to convert to a number