### PR TITLE
Filter passed requests from pre-capture pooling

### DIFF
--- a/app/helpers/plate_helper.rb
+++ b/app/helpers/plate_helper.rb
@@ -23,7 +23,7 @@ module PlateHelper
     current_plate.wells.each_with_object({}) do |well, pool_store|
       next unless well.passed?
 
-      well.active_requests.each do |request|
+      well.incomplete_requests.each do |request|
         next unless request.pre_capture_pool
 
         pool_store[request.pre_capture_pool.id] ||= []

--- a/app/sequencescape/sequencescape/api/v2/well.rb
+++ b/app/sequencescape/sequencescape/api/v2/well.rb
@@ -51,6 +51,10 @@ class Sequencescape::Api::V2::Well < Sequencescape::Api::V2::Base
     in_progress.presence || completed
   end
 
+  def incomplete_requests
+    associated_requests.reject(&:completed?)
+  end
+
   def multiple_requests?
     active_requests.many?
   end

--- a/spec/factories/plate_factories.rb
+++ b/spec/factories/plate_factories.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
           Array.new(size) do
             create request_factory,
                    pcr_cycles: pool_prc_cycles[index],
-                   state: library_state,
+                   state: library_state[index],
                    submission_id: index,
                    include_submissions: include_submissions,
                    order_id: index * 2,
@@ -45,7 +45,7 @@ FactoryBot.define do
       purpose { create :v2_purpose, name: purpose_name, uuid: purpose_uuid }
       pool_sizes []
       pool_prc_cycles { Array.new(pool_sizes.length, 10) }
-      library_state 'pending'
+      library_state { ['pending'] * pool_sizes.length }
       stock_plate { create :v2_stock_plate }
       ancestors { [stock_plate] }
       transfer_targets { {} }

--- a/spec/features/pooling_multiple_plates_spec.rb
+++ b/spec/features/pooling_multiple_plates_spec.rb
@@ -26,6 +26,8 @@ RSpec.feature 'Multi plate pooling', js: true do
   let(:example_plate_2)   do
     create :v2_plate_for_pooling,
            barcode_number: 2,
+           pool_sizes: [2, 2],
+           library_state: %w[started passed],
            state: 'passed',
            uuid: plate_uuid_2,
            well_factory: :v2_tagged_well,

--- a/spec/features/viewing_a_minimal_plate_spec.rb
+++ b/spec/features/viewing_a_minimal_plate_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature 'Viewing a plate', js: true do
   end
 
   feature 'with passed pools' do
-    let(:example_plate) { create :v2_stock_plate, uuid: plate_uuid, library_state: 'passed', pool_sizes: [5] }
+    let(:example_plate) { create :v2_stock_plate, uuid: plate_uuid, library_state: ['passed'], pool_sizes: [5] }
 
     scenario 'there is a warning' do
       fill_in_swipecard_and_barcode user_swipecard, plate_barcode
@@ -71,7 +71,7 @@ RSpec.feature 'Viewing a plate', js: true do
   end
 
   feature 'plates with 384 wells' do
-    let(:example_plate) { create :v2_stock_plate, uuid: plate_uuid, library_state: 'passed', size: 384, pool_sizes: [5, 12, 48, 48, 9, 35, 35, 5, 12, 48, 48, 9, 35, 35] }
+    let(:example_plate) { create :v2_stock_plate, uuid: plate_uuid, library_state: ['passed'], size: 384, pool_sizes: [5, 12, 48, 48, 9, 35, 35, 5, 12, 48, 48, 9, 35, 35] }
     scenario 'there is a warning' do
       fill_in_swipecard_and_barcode user_swipecard, plate_barcode
       expect(find('.asset-warnings')).to have_content(

--- a/spec/features/viewing_a_plate_spec.rb
+++ b/spec/features/viewing_a_plate_spec.rb
@@ -94,7 +94,7 @@ RSpec.feature 'Viewing a plate', js: true do
   end
 
   feature 'with passed pools' do
-    let(:example_plate) { create :v2_stock_plate, uuid: plate_uuid, library_state: 'passed', pool_sizes: [5] }
+    let(:example_plate) { create :v2_stock_plate, uuid: plate_uuid, library_state: ['passed'], pool_sizes: [5] }
 
     scenario 'there is a warning' do
       fill_in_swipecard_and_barcode user_swipecard, plate_barcode


### PR DESCRIPTION
This logic realy belongs at the front-end. But we can fix
that when we switch to pulling direct from Sequencescape