### PR TITLE
Ensure baited plates display bait colours

### DIFF
--- a/app/assets/stylesheets/limber/colours.scss
+++ b/app/assets/stylesheets/limber/colours.scss
@@ -405,6 +405,6 @@
 .colour-384 { @include shade-aliquot(#863B60, #FFFFFF); }
 }
 
-.destination-plate, .source-plate {
+.destination-plate, .source-plate, .plate-baited {
   @extend .pool-colours
 }

--- a/app/models/labware_creators/baited_plate.rb
+++ b/app/models/labware_creators/baited_plate.rb
@@ -14,6 +14,7 @@ module LabwareCreators
 
     self.page = 'baited_plate'
     self.aliquot_partial = 'baited_aliquot'
+    self.style_class = 'baited'
 
     delegate :number_of_columns, :number_of_rows, :size, to: :plate
 

--- a/app/views/plate_creation/baited_plate.html.erb
+++ b/app/views/plate_creation/baited_plate.html.erb
@@ -10,14 +10,11 @@
   <% end %>
 
   <%= sidebar do %>
-    <%= card do %>
-      <h3 class='card-header'>Instructions</h3>
-      <div class='card-body'>
+    <%= card title: 'Instructions' do %>
         <p class='card-text'>Carefully check the bait layout against your worksheet.</p>
         <p class='card-text'>Click on 'Create plate' button.</p>
-      </div>
-      <div class='card-body'>
-        <ul id="key" class="list-group">
+
+        <ul id="key" class="list-group pool-colours">
           <%- @labware_creator.baits.each do |bait| -%>
               <li class="list-group-item">
                 <div class="tube-view">
@@ -32,7 +29,6 @@
           <%= f.hidden_field :parent_uuid, as: :hidden, value: @labware_creator.parent_uuid %>
           <%= f.submit'Create plate', class: 'btn btn-outline-primary w-100', style: 'padding: 10px' %>
         <% end %>
-      </div>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
The adjustment of the way pooling colours are displayed
broke pool colours for places where it wasn't explicitly
declared.

Bait information should also be communicated through
additional chanels. This should probably be combined with the removal of
duplicate bait listing.