### PR TITLE
Tube preview displays uncreated tubes

### DIFF
--- a/app/models/sibling.rb
+++ b/app/models/sibling.rb
@@ -7,13 +7,14 @@ class Sibling
   # The state in which a sibling must be to allow pooling.
   READY_STATE = 'passed'
 
-  attr_reader :name, :uuid, :state, :barcode
+  attr_reader :name, :uuid, :state, :barcode, :sanger_barcode
 
   def initialize(options)
     if options.respond_to?(:[])
       @name = options['name']
       @uuid = options['uuid']
       @barcode = options['ean13_barcode']
+      @sanger_barcode = SBCF::SangerBarcode.from_machine(options['ean13_barcode'])
       @state = options['state']
     else
       missing_sibling
@@ -36,5 +37,6 @@ class Sibling
   def missing_sibling
     @name  = 'Other'
     @state = 'Not Present'
+    @sanger_barcode = 'Not Present'
   end
 end

--- a/app/views/tube_creation/final_tube.html.erb
+++ b/app/views/tube_creation/final_tube.html.erb
@@ -11,7 +11,7 @@
         <ul id="scanned_tube_list" class="robot tubev list-group">
           <% @labware_creator.each_sibling do |sibling| %>
           <li id="listElement[<%= sibling.barcode %>]" class="<%= sibling.ready? ? 'wait-tube' : 'bad-tube' %> sibling-tube list-group-item" data-barcode="<%= sibling.barcode %>">
-            <h3>Tube: <%= sibling.name %> <small><%= SBCF::SangerBarcode.from_machine(sibling.barcode) %></small></h3>
+            <h3>Tube: <%= sibling.name %> <small><%= sibling.sanger_barcode %></small></h3>
             <input value="0" name="tube[parents][<%= sibling.barcode %>]" id="tube[parents][<%= sibling.barcode %>]" type="hidden">
             <div class="tube_validation_report"><%= sibling.message %></div>
           </li>


### PR DESCRIPTION
Uncreated tubes don't have barcodes, this ensures
they display correctly.