### PR TITLE
Fix deployed version with strings

### DIFF
--- a/lib/deployed_version.rb
+++ b/lib/deployed_version.rb
@@ -49,10 +49,10 @@ module Deployed
     end
 
     def version_label
-      if major.zero? && minor.zero? && extra.zero?
-        'WIP'
-      else
+      if version_hash
         "#{major}.#{minor}.#{extra}"
+      else
+        'WIP'
       end
     end
 
@@ -74,7 +74,7 @@ module Deployed
     end
 
     def version(rank)
-      version_hash ? version_hash[rank] : 0
+      version_hash ? version_hash[rank] : '0' # String, as it matches what we'd get from the regex
     end
 
     def execute_command(cmd)


### PR DESCRIPTION
The rexep was returning strings for version numbers, which don't
respond to zero?
Two changes:
1) Consistently use strings for version numbering. Provides more
flexibility, especially for minor numbers. (Eg. allows for release
candidate markings)
2) Switch based on the presence of a release_hash
Rather than checking for the default 0.0.0 release, we just check if
we have a release hash at all.