### PR TITLE
Log errors before returning

### DIFF
--- a/app/controllers/creation_controller.rb
+++ b/app/controllers/creation_controller.rb
@@ -69,6 +69,7 @@ class CreationController < ApplicationController
   end
 
   def create_failure
+    Rails.logger.error(@labware_creator.errors.full_messages)
     respond_to do |format|
       format.json do
         render json: { message: @labware_creator.errors.full_messages },


### PR DESCRIPTION
We still need to fix the JS error handling, but this gives us server side logging of the issues.