### PR TITLE
Add webdrivers to manage chrome-driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
   apt:
     packages:
     - haveged
-    - chromium-chromedriver
 cache:
   bundler: true
   directories:
@@ -38,6 +37,8 @@ jobs:
     name: Karma
     script: xvfb-run -a yarn test
   - name: RSpec
+    before_script:
+    - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     script: xvfb-run -a bundle exec rspec
   - stage: build
     if: tag IS present

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ group :test do
   gem 'rspec-rails'
   gem 'simplecov', require: false
   gem 'simplecov-json', require: false
+  # Keep webdriver in sync with chrome to prevent frustrating CI failures
+  gem 'webdrivers', require: false
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,6 +346,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.1.2)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.6.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -401,6 +405,7 @@ DEPENDENCIES
   travis
   uglifier
   web-console
+  webdrivers
   webmock
   webpacker
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,8 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'webdrivers/chromedriver'
+Webdrivers::Chromedriver.update
 require 'factory_bot'
 require_relative 'support/contract_helper'
 require_relative 'support/api_url_helper'


### PR DESCRIPTION
Our travis ci builds are breaking due to a mismatch between the chrome
version and chromedriver.
See equivalent fix in sequencescape for details.