### PR TITLE
Fix to failing test due to capybara update

### DIFF
--- a/spec/features/creating_a_quadrant_stamp_primer_panel_plate_spec.rb
+++ b/spec/features/creating_a_quadrant_stamp_primer_panel_plate_spec.rb
@@ -85,6 +85,8 @@ RSpec.feature 'Creating a quadrant stamp plate', js: true do
                   body: '{}')
   end
 
+  let(:parent1_plate_old_api) { json(:plate, barcode_number: '2', state: 'passed', uuid: parent_uuid) }
+
   background do
     stub_api_get('barcode_printers', body: json(:barcode_printer_collection))
     create :purpose_config, name: 'Primer Panel example', uuid: parent_purpose_uuid
@@ -97,6 +99,7 @@ RSpec.feature 'Creating a quadrant stamp plate', js: true do
     stub_v2_plate(parent)
     stub_v2_plate(parent2)
     stub_v2_plate(child_plate)
+    stub_api_get(parent.uuid, body: parent1_plate_old_api)
   end
 
   scenario 'creates multiple plates' do


### PR DESCRIPTION
Required v1 API stub for plate lookup.