### PR TITLE
Gpl142 5prime minimum diluent volume

### DIFF
--- a/app/models/utility/normalised_binning_calculator.rb
+++ b/app/models/utility/normalised_binning_calculator.rb
@@ -33,8 +33,14 @@ module Utility
     end
 
     def compute_vol_source_reqd(sample_conc)
-      # check calculated volume against minimum then maximum allowed volumes
+      # check calculated volume against minimum allowed volume
       min_checked_vol_reqd = [config.target_amount / sample_conc, config.minimum_source_volume].max
+      # we don't want the diluent volume to be below 1ul (robot restriction), so we have to round the source
+      # volume either to the maximum volume or to 1ul less than the maximum volume when in this range
+      if ((config.target_volume - 1.0)...config.target_volume).cover?(min_checked_vol_reqd)
+        min_checked_vol_reqd = min_checked_vol_reqd.round(half: :down)
+      end
+      # check calculated volume against maximum allowed volume
       [min_checked_vol_reqd, config.target_volume].min
     end
 

--- a/app/models/utility/normalised_binning_calculator.rb
+++ b/app/models/utility/normalised_binning_calculator.rb
@@ -37,9 +37,7 @@ module Utility
       min_checked_vol_reqd = [config.target_amount / sample_conc, config.minimum_source_volume].max
       # we don't want the diluent volume to be below 1ul (robot restriction), so we have to round the source
       # volume either to the maximum volume or to 1ul less than the maximum volume when in this range
-      if ((config.target_volume - 1.0)...config.target_volume).cover?(min_checked_vol_reqd)
-        min_checked_vol_reqd = min_checked_vol_reqd.round(half: :down)
-      end
+      min_checked_vol_reqd = min_checked_vol_reqd.round(half: :down) if ((config.target_volume - 1.0)...config.target_volume).cover?(min_checked_vol_reqd)
       # check calculated volume against maximum allowed volume
       [min_checked_vol_reqd, config.target_volume].min
     end

--- a/spec/models/utility/concentration_binning_calculator_spec.rb
+++ b/spec/models/utility/concentration_binning_calculator_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
 require 'support/shared_examples/dilution_calculations_shared_examples'
 
 RSpec.describe Utility::ConcentrationBinningCalculator do

--- a/spec/models/utility/fixed_normalisation_calculator_spec.rb
+++ b/spec/models/utility/fixed_normalisation_calculator_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
 require 'support/shared_examples/dilution_calculations_shared_examples'
 
 RSpec.describe Utility::FixedNormalisationCalculator do

--- a/spec/models/utility/normalised_binning_calculator_spec.rb
+++ b/spec/models/utility/normalised_binning_calculator_spec.rb
@@ -106,6 +106,50 @@ RSpec.describe Utility::NormalisedBinningCalculator do
           expect(subject.compute_vol_source_reqd(sample_conc)).to eq(0.2)
         end
       end
+
+      # conc would create a diluent vol of 0.1
+      context 'when sample concentration would create a diluent volume of less than 0.5' do
+        let(:sample_conc) { 2.5126 }
+
+        it 'rounds up the sample volume to the maximum and takes zero diluent' do
+          expect(subject.compute_vol_source_reqd(sample_conc)).to eq(20.0)
+        end
+      end
+
+      # conc would create a diluent vol of 0.5
+      context 'when sample concentration would create a diluent volume of exactly 0.5' do
+        let(:sample_conc) { 2.5641 }
+
+        it 'rounds up the sample volume to the maximum and takes zero diluent' do
+          expect(subject.compute_vol_source_reqd(sample_conc)).to eq(20.0)
+        end
+      end
+
+      # conc would create a diluent vol of 0.6
+      context 'when sample concentration would create a diluent volume of 0.6' do
+        let(:sample_conc) { 2.5773 }
+
+        it 'rounds down the sample volume and takes the minimum diluent of 1' do
+          expect(subject.compute_vol_source_reqd(sample_conc)).to eq(19.0)
+        end
+      end
+
+      # conc would create a diluent vol of 0.9
+      context 'when sample concentration would create a diluent volume of greater than 0.5 but less than 1.0' do
+        let(:sample_conc) { 2.6178 }
+
+        it 'rounds down the sample volume and takes the minimum diluent of 1' do
+          expect(subject.compute_vol_source_reqd(sample_conc)).to eq(19.0)
+        end
+      end
+
+      context 'when sample concentration would create a diluent volume greater than 1' do
+        let(:sample_conc) { 3.120 }
+
+        it 'does not round the sample volume required' do
+          expect(subject.compute_vol_source_reqd(sample_conc)).to eq(16.025641025641026)
+        end
+      end
     end
 
     describe '#compute_well_transfers' do

--- a/spec/models/utility/normalised_binning_calculator_spec.rb
+++ b/spec/models/utility/normalised_binning_calculator_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
 require 'support/shared_examples/dilution_calculations_shared_examples'
 
 RSpec.describe Utility::NormalisedBinningCalculator do


### PR DESCRIPTION
Chromium 5 prime dilution calculation for source volume to use should not result in a diluent volume of less than 1ul
If this would be the case the source volume is now rounded up/down to result in a diluent volume of 0 or 1 ul.