### PR TITLE
Fix limber isc sort bug

### DIFF
--- a/app/assets/stylesheets/limber/screen.scss
+++ b/app/assets/stylesheets/limber/screen.scss
@@ -275,6 +275,7 @@ form + .btn-block {
       @extend .badge;
       @extend .badge-info;
       @extend .badge-pill;
+      @extend .ml-2;
     }
     .pool-info {
       @extend .text-muted;
@@ -380,7 +381,6 @@ div.bad-plate {
 }
 
 div.wait-plate {
-  //@extend .has-warning;
   .form-control {
     background-repeat: no-repeat;
     background-position: center right 0.5625rem;

--- a/app/views/plates/show.json.erb
+++ b/app/views/plates/show.json.erb
@@ -4,7 +4,7 @@
     "uuid": "<%= @presenter.uuid %>",
     "state": "<%= @presenter.state %>",
     "purpose": "<%= @presenter.purpose_name %>",
-    "preCapGroups": <%= sorted_pre_cap_group_json %>,
+    "preCapPools": <%= sorted_pre_cap_pool_json(@presenter.labware) %>,
     "tags": <%= @presenter.tag_sequences.to_json.html_safe %>
   }
 }


### PR DESCRIPTION
Pre-capture pools in the ISC pipeline were no-longer being sorted in
column order. This was causing delays in the lab. Pre-capture pooling
is a pooling step part way through the process, in which tagged samples
from the PCR-XP plate are pooled together prior to bait application.

While hashes in ruby are ordered based on insert order, there is no
such provision in javascript objects. Thus the browser does not have
to maintain key order when loading a JSON object. Indeed, it appears
that both chomium and firefox are sorting keys in alphabetical order.
In this case, the keys were the pre-cap pool ids.

This bug has been longstanding, but has mostly been hidden as the
pool-ids were typically generated in column order. In the plates that
were causing the problems, this was not the case. This could be due to
changes in SSR behaviour, or more likely the asset refactor has changed
the order in which a query is sorted during submission processing.

This fix:
- Updates the helper function to return an array, not a hash to ensure
  order is maintained.
- Ensures the javascript maintains the data in an array format
- Changes the format of the data output by the helper function to reduce
  the need for subsequent processing by the javascript
- Renames some of the variable to better reflect what they actually
  contain
- Removes code associated with legacy behaviour which is no longer
  required
    * No need to pass through pool ids
    * No need to handle nested submission/pre-cap pool information
- Adapt coding style to meet current linter expectations