### PR TITLE
RT670996 Added sort on order id to pools helper method

### DIFF
--- a/app/helpers/plate_helper.rb
+++ b/app/helpers/plate_helper.rb
@@ -19,30 +19,40 @@ module PlateHelper
     WellFailingPresenter.new(form, presenter)
   end
 
-  # Returns an array of all pre-capture pools sorted in column order based on the first
-  # well in the pool.
+  # Returns an array of all pre-capture pools for a plate, with wells sorted into plate well column order.
   # We rely on the fact that hashes maintain insert order, and walk the wells in column
-  # order. Each time we see a pre-capture pool for the first time, it gets inserted into the hash.
-  # This gets passed to our javascript via ajax.
+  # order. Each time we see a pre-capture pool for the first time, it gets inserted into the hash along with the
+  # request Order id.
+  # We then sort the pre-capture pool hashes within the array by their Order ids, to get the pools into the right
+  # sequence. Requests are grouped into Orders, each pre-capture pool has a different Order relating to the asset group
+  # name entered on the submission manifest. Asset groups are created in the sequence they are presented in the manifest.
+  # (Pre-capture pools are not created sequentially in the same order as the asset groups on the manifest).
+  # This sorted array gets passed to our javascript via ajax.
   # @note Javascript objects are not explicitly ordered, hence the need to pass an array here.
   #
   # @param current_plate [Sequencescape::Api::V2::Plate] The plate from which to extract the pre-cap pools
   #
   # @return [Array] An array of basic pool information
   # @example Example output
-  #   [{ pool_id: '123', wells: ['A1','B1','D1'] }, { pool_id: '122', wells: ['C1','E1','F1'] }]
+  #   [
+  #    { pool_id: 123, order_id: 401, wells: ['A1','B1','D1'] },
+  #    { pool_id: 122, order_id: 402, wells: ['C1','E1','F1'] }
+  #   ]
   def sorted_pre_cap_pool_json(current_plate)
-    current_plate.wells_in_columns.each_with_object({}) do |well, pool_store|
+    unsorted = current_plate.wells_in_columns.each_with_object({}) do |well, pool_store|
       next unless well.passed?
 
       well.incomplete_requests.each do |request|
         next unless request.pre_capture_pool
 
         pool_id = request.pre_capture_pool.id
-        pool_store[pool_id] ||= { pool_id: pool_id, wells: [] }
+        pool_store[pool_id] ||= { pool_id: pool_id, order_id: request.order_id, wells: [] }
         pool_store[pool_id][:wells] << well.location
       end
-    end.values.to_json.html_safe
+    end.values
+    # sort the pool hashes by Order id
+    sorted = unsorted.sort_by { |k| k[:order_id] }
+    sorted.to_json.html_safe
   end
 
   def pools_by_id(pools)

--- a/spec/helpers/plate_helpers_spec.rb
+++ b/spec/helpers/plate_helpers_spec.rb
@@ -5,19 +5,93 @@ require 'spec_helper'
 RSpec.describe PlateHelper do
   include PlateHelper
 
-  let(:pool) do
-    { 'pool1' => { 'wells' => %w[C3 D1 D2 D3 E1 E2 E3 F1 F2 F3 G1 G2 G3 H1 H2 H3 A1 A2 A3 B1 B2 B3 C1 C2] },
-      'pool2' => { 'wells' => %w[E7 F6 G6 H6 A7 B7 C7 D7 E6] },
-      'pool3' => { 'wells' => %w[C6 D4 D5 D6 E4 E5 F4 F5 G4 A4 A5 A6 B4 B5 B6 C4 C5 G5 H4 H5] } }
+  context '#pools_by_id' do
+    let(:pool) do
+      { 'pool1' => { 'wells' => %w[C3 D1 D2 D3 E1 E2 E3 F1 F2 F3 G1 G2 G3 H1 H2 H3 A1 A2 A3 B1 B2 B3 C1 C2] },
+        'pool2' => { 'wells' => %w[E7 F6 G6 H6 A7 B7 C7 D7 E6] },
+        'pool3' => { 'wells' => %w[C6 D4 D5 D6 E4 E5 F4 F5 G4 A4 A5 A6 B4 B5 B6 C4 C5 G5 H4 H5] } }
+    end
+
+    it 'orders pools by their correct id' do
+      pools = pools_by_id(pool)
+      expect(pools['A1']).to eq(1)
+      expect(pools['D3']).to eq(1)
+      expect(pools['A7']).to eq(3)
+      expect(pools['H6']).to eq(3)
+      expect(pools['A4']).to eq(2)
+      expect(pools['H4']).to eq(2)
+    end
   end
 
-  it 'orders pools by their correct id' do
-    pools = pools_by_id(pool)
-    expect(pools['A1']).to eq(1)
-    expect(pools['D3']).to eq(1)
-    expect(pools['A7']).to eq(3)
-    expect(pools['H6']).to eq(3)
-    expect(pools['A4']).to eq(2)
-    expect(pools['H4']).to eq(2)
+  context '#sorted_pre_cap_pool_json' do
+    # create 3 pre-cap pools with ids not in sequential order
+    let(:pre_cap_pool_1) { build :pre_capture_pool, id: 123, uuid: 'pre-cap-pool-1' }
+    let(:pre_cap_pool_2) { build :pre_capture_pool, id: 122, uuid: 'pre-cap-pool-2' }
+    let(:pre_cap_pool_3) { build :pre_capture_pool, id: 124, uuid: 'pre-cap-pool-3' }
+
+    # Create requests for plate wells in 3 different pre-capture pools in mixed sequence
+    # for A1
+    let(:isc_library_request_1_1) do
+      build :isc_library_request, pre_capture_pool: pre_cap_pool_1, submission_id: 1, order_id: 1
+    end
+    # for B1
+    let(:isc_library_request_3_1) do
+      build :isc_library_request, pre_capture_pool: pre_cap_pool_3, submission_id: 1, order_id: 3
+    end
+    # for C1
+    let(:isc_library_request_1_2) do
+      build :isc_library_request, pre_capture_pool: pre_cap_pool_1, submission_id: 1, order_id: 1
+    end
+    # for D1
+    let(:isc_library_request_2_1) do
+      build :isc_library_request, pre_capture_pool: pre_cap_pool_2, submission_id: 1, order_id: 2
+    end
+    # for E1
+    let(:isc_library_request_1_3) do
+      build :isc_library_request, pre_capture_pool: pre_cap_pool_1, submission_id: 1, order_id: 1
+    end
+    # for F1
+    let(:isc_library_request_3_2) do
+      build :isc_library_request, pre_capture_pool: pre_cap_pool_3, submission_id: 1, order_id: 3
+    end
+    # for G1
+    let(:isc_library_request_2_2) do
+      build :isc_library_request, pre_capture_pool: pre_cap_pool_2, submission_id: 1, order_id: 2
+    end
+    # for H1
+    let(:isc_library_request_2_3) do
+      build :isc_library_request, pre_capture_pool: pre_cap_pool_2, submission_id: 1, order_id: 2
+    end
+
+    # create the outer requests array to pass to the plate factory
+    let(:outer_requests) do
+      [
+        isc_library_request_1_1,
+        isc_library_request_3_1,
+        isc_library_request_1_2,
+        isc_library_request_2_1,
+        isc_library_request_1_3,
+        isc_library_request_3_2,
+        isc_library_request_2_2,
+        isc_library_request_2_3
+      ]
+    end
+
+    let(:plate_for_precap) { build :v2_plate_for_pooling, state: 'passed', pool_sizes: [8], outer_requests: outer_requests }
+
+    let(:expected_result) do
+      [
+        { 'pool_id' => 123, 'order_id' => '1', 'wells' => %w[A1 C1 E1] },
+        { 'pool_id' => 122, 'order_id' => '2', 'wells' => %w[D1 G1 H1] },
+        { 'pool_id' => 124, 'order_id' => '3', 'wells' => %w[B1 F1] }
+      ]
+    end
+
+    it 'sorts the pre cap pools correctly' do
+      pool_store_safebuffer = sorted_pre_cap_pool_json(plate_for_precap)
+      pool_store = JSON.parse(pool_store_safebuffer.to_str.gsub('=>', ':'))
+
+      expect(pool_store).to eq(expected_result)
+    end
   end
 end


### PR DESCRIPTION
Added sort on order id to pools helper method to order the pre-capture pools in the same order as on the manifest.
This commit fixes #302