### PR TITLE
GPL-289 Hi-C library type (Limber half)

### DIFF
--- a/config/pipelines/bespoke_pcr.yml
+++ b/config/pipelines/bespoke_pcr.yml
@@ -15,6 +15,7 @@ Bespoke PCR:
     - Ribozero RNA-seq (HMR)
     - TraDIS
     - Chromium Visium
+    - Hi-C
   library_pass: LBB Lib PCR-XP
   relationships:
     LBB Cherrypick: LBB Ligation


### PR DESCRIPTION
Make the Hi-C library type available to go down the Bespoke PCR pipeline