### PR TITLE
GPL-467 Limber changes for new quant type in Heron 96 pipeline

### DIFF
--- a/config/purposes/heron.yml
+++ b/config/purposes/heron.yml
@@ -13,11 +13,15 @@ LHR PCR 2:
 LHR XP:
   :asset_type: plate
   :creator_class: LabwareCreators::MergedPlate
+  :label_template: plate_xp
   :merged_plate:
     source_purposes:
     - 'LHR PCR 1'
     - 'LHR PCR 2'
     help_text: 'Here we are merging the two Primer Panel PCR plates, creating a new XP plate.'
+  :file_links:
+  - name: Download Concentration (ng/ul) CSV
+    id: concentrations_ngul
 LHR End Prep:
   :asset_type: plate
 LHR Lib PCR:


### PR DESCRIPTION
Add label_template to heron purpose config, so that -QC label is printed out

- Also replace concentration file download in 'nM' with one in 'ng/ul'
