### PR TITLE
RT #690877 label printing bug

### DIFF
--- a/app/models/labels/plate_split.rb
+++ b/app/models/labels/plate_split.rb
@@ -8,7 +8,7 @@ class Labels::PlateSplit < Labels::PlateLabelXpBase
   end
 
   def qc_attributes
-    super[0].merge(top_right: stock_plate_barcode)
+    [super[0].merge(top_right: stock_plate_barcode)]
   end
 
   def stock_plate_barcode


### PR DESCRIPTION
return an array - this was missed when converting qc_attributes to an array in this pull request - https://github.com/sanger/limber/pull/371/files?file-filters%5B%5D= (GPL-294)
