### PR TITLE
Fix for new library types GPL-494 and GPL-497

### DIFF
--- a/config/pipelines/high_throughput_heron.yml
+++ b/config/pipelines/high_throughput_heron.yml
@@ -15,7 +15,10 @@ Heron 96 A: # Heron 96-well pipeline specific to PCR 1 plate
 Heron 96 B: # Heron 96-well pipeline specific to PCR 2 plate
   filters:
     request_type_key: limber_heron
-    library_type: PCR amplicon ligated adapters
+    library_type:
+    - PCR amplicon ligated adapters
+    - Sanger_artic_v3_96
+    - Sanger_artic_v4_96
   library_pass: LHR Lib PCR
   relationships:
     LHR RT: LHR PCR 2


### PR DESCRIPTION
add these new library types to both branches of the pipeline, A and B

missed in https://github.com/sanger/limber/pull/450