### PR TITLE
Add missing library types to limber pipelines

### DIFF
--- a/config/pipelines/high_throughput_heron.yml
+++ b/config/pipelines/high_throughput_heron.yml
@@ -4,6 +4,7 @@ Heron 96 A: # Heron 96-well pipeline specific to PCR 1 plate
     request_type_key: limber_heron
     library_type:
     - PCR amplicon ligated adapters
+    - PCR with TruSeq tails amplicon
     - Sanger_artic_v3_96
     - Sanger_artic_v4_96
   library_pass: LHR Lib PCR
@@ -17,6 +18,7 @@ Heron 96 B: # Heron 96-well pipeline specific to PCR 2 plate
     request_type_key: limber_heron
     library_type:
     - PCR amplicon ligated adapters
+    - PCR with TruSeq tails amplicon
     - Sanger_artic_v3_96
     - Sanger_artic_v4_96
   library_pass: LHR Lib PCR

--- a/config/pipelines/high_throughput_heron_384.yml
+++ b/config/pipelines/high_throughput_heron_384.yml
@@ -2,7 +2,9 @@
 Heron-384 A: # Heron 384-well pipeline specific to PCR 1 plate
   filters:
     request_type_key: limber_heron
-    library_type: PCR amplicon ligated adapters 384
+    library_type:
+    - PCR amplicon ligated adapters 384
+    - PCR with TruSeq tails amplicon 384
   library_pass: LHR-384 Lib PCR
   relationships:
     LHR-384 RT: LHR-384 PCR 1
@@ -14,7 +16,9 @@ Heron-384 A: # Heron 384-well pipeline specific to PCR 1 plate
 Heron-384 B: # Heron 384-well pipeline specific to PCR 2 plate (uses above relationships after cDNA plate)
   filters:
     request_type_key: limber_heron
-    library_type: PCR amplicon ligated adapters 384
+    library_type:
+    - PCR amplicon ligated adapters 384
+    - PCR with TruSeq tails amplicon 384
   relationships:
     LHR-384 RT: LHR-384 PCR 2
     LHR-384 PCR 2: LHR-384 cDNA


### PR DESCRIPTION
Hotfix

Hotfix addition of:
PCR with TruSeq tails amplicon
PCR with TruSeq tails amplicon 384

Added to Sequencescape in May, missed off limber config