### PR TITLE
Gpl 679 single child presenter

### DIFF
--- a/app/models/concerns/presenters/statemachine/single_child_permissive.rb
+++ b/app/models/concerns/presenters/statemachine/single_child_permissive.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_dependency 'presenters/statemachine'
+module Presenters::Statemachine
+  module SingleChildPermissive # rubocop:todo Style/Documentation
+    extend ActiveSupport::Concern
+    included do
+      include Shared
+
+      # The state machine for plates which has knock-on effects on the plates that can be created
+      state_machine :state, initial: :pending do
+        StateTransitions.inject(self)
+
+        # These are the states, which are really the only things we need ...
+        state :pending do
+          include StateAllowsSingleChildCreation
+          include DoesNotAllowLibraryPassing
+        end
+
+        state :started do
+          include StateAllowsSingleChildCreation
+          include DoesNotAllowLibraryPassing
+        end
+
+        state :processed_1 do
+          include StateAllowsSingleChildCreation
+          include DoesNotAllowLibraryPassing
+        end
+
+        state :processed_2 do
+          include StateAllowsSingleChildCreation
+          include DoesNotAllowLibraryPassing
+        end
+
+        state :passed do
+          include StateAllowsSingleChildCreation
+          include DoesNotAllowLibraryPassing
+        end
+
+        state :qc_complete, human_name: 'QC Complete' do
+          include StateAllowsSingleChildCreation
+          include DoesNotAllowLibraryPassing
+        end
+
+        state :cancelled do
+          include StateDoesNotAllowChildCreation
+          include DoesNotAllowLibraryPassing
+        end
+
+        state :failed do
+          include StateDoesNotAllowChildCreation
+          include DoesNotAllowLibraryPassing
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/presenters/statemachine/state_allows_single_child_creation.rb
+++ b/app/models/concerns/presenters/statemachine/state_allows_single_child_creation.rb
@@ -4,7 +4,7 @@ module Presenters::Statemachine
   # Supports creation of a single child asset in this state
   module StateAllowsSingleChildCreation
     def control_additional_creation
-      yield if self.child_assets.nil? || self.child_assets.empty?
+      yield if child_assets.blank?
     end
   end
 end

--- a/app/models/concerns/presenters/statemachine/state_allows_single_child_creation.rb
+++ b/app/models/concerns/presenters/statemachine/state_allows_single_child_creation.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Presenters::Statemachine
+  # Supports creation of a single child asset in this state
+  module StateAllowsSingleChildCreation
+    def control_additional_creation
+      yield if self.child_assets.nil? || self.child_assets.empty?
+    end
+  end
+end

--- a/app/models/presenters/plate_presenter.rb
+++ b/app/models/presenters/plate_presenter.rb
@@ -108,9 +108,7 @@ class Presenters::PlatePresenter
     "#{human_barcode} - #{purpose_name}"
   end
 
-  def child_assets
-    child_plates
-  end
+  alias child_assets child_plates
 
   private
 

--- a/app/models/presenters/plate_presenter.rb
+++ b/app/models/presenters/plate_presenter.rb
@@ -108,6 +108,10 @@ class Presenters::PlatePresenter
     "#{human_barcode} - #{purpose_name}"
   end
 
+  def child_assets
+    child_plates
+  end
+
   private
 
   def libraries_passable?

--- a/app/models/presenters/presenter.rb
+++ b/app/models/presenters/presenter.rb
@@ -82,6 +82,10 @@ module Presenters::Presenter # rubocop:todo Style/Documentation
     "<#{self.class.name} labware:#{labware.uuid} ...>"
   end
 
+  def child_assets
+    nil
+  end
+
   private
 
   def active_pipelines

--- a/app/models/presenters/single_child_permissive_presenter.rb
+++ b/app/models/presenters/single_child_permissive_presenter.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Presenters
+  #
+  # Class SingleChildPermissivePresenter provides a presenter which allows creation of a single plate
+  # even when the plate is pending
+  #
+  class SingleChildPermissivePresenter < PlatePresenter
+    include Presenters::Statemachine::SingleChildPermissive
+
+    validates_with Validators::SuboptimalValidator
+  end
+end

--- a/config/purposes/pWGS_384_bottom.yml
+++ b/config/purposes/pWGS_384_bottom.yml
@@ -7,7 +7,7 @@ pWGS-384 Post Shear XP:
   :size: 384
 pWGS-384 End Prep:
   :asset_type: plate
-  :presenter_class: Presenters::PermissivePresenter
+  :presenter_class: Presenters::SingleChildPermissivePresenter
   :label_template: plate_6mm_double
   :size: 384
 pWGS-384 AL Lib:

--- a/spec/models/presenters/shared_labware_presenter_examples.rb
+++ b/spec/models/presenters/shared_labware_presenter_examples.rb
@@ -17,6 +17,10 @@ RSpec.shared_examples 'a labware presenter' do
     # If you don't expect to trigger any request, just use let(:expected_requests_for_summary) {}
     expect { |b| subject.summary(&b) }.to yield_successive_args(*summary_tab)
   end
+
+  it 'responds to child_assets' do
+    expect(subject).to respond_to(:child_assets)
+  end
 end
 
 RSpec.shared_examples 'a stock presenter' do

--- a/spec/models/presenters/single_child_permissive_presenter_spec.rb
+++ b/spec/models/presenters/single_child_permissive_presenter_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+RSpec.describe Presenters::SingleChildPermissivePresenter do
+  has_a_working_api
+
+  let(:purpose_name) { 'Example purpose' }
+  let(:labware) { create :v2_plate, state: state, purpose_name: purpose_name, pool_sizes: [1] }
+  let(:child_purpose) { 'Child purpose' }
+  let(:child_plate) { create :v2_plate, purpose_name: child_purpose }
+
+  subject do
+    Presenters::SingleChildPermissivePresenter.new(
+      api: api,
+      labware: labware
+    )
+  end
+
+  before(:each) do
+    create :purpose_config, uuid: 'child-purpose', name: child_purpose
+    create :purpose_config, uuid: 'other-purpose', name: 'Other purpose'
+    create :pipeline, relationships: { purpose_name => child_purpose }
+  end
+
+  context 'when pending' do
+    let(:state) { 'pending' }
+
+    it 'allows state change' do
+      expect { |b| subject.default_state_change(&b) }.to yield_control
+    end
+
+    it 'suggests child purposes' do
+      expect(subject.suggested_purposes).to be_an Array
+      expect(subject.suggested_purposes.first).to be_a LabwareCreators::CreatorButton
+      expect(subject.suggested_purposes.first.purpose_uuid).to eq('child-purpose')
+    end
+
+    context 'without child plates' do
+      before(:each) do
+        labware.child_plates = nil
+      end
+
+      it 'allows child creation' do
+        expect { |b| subject.control_additional_creation(&b) }.to yield_control
+      end
+    end
+
+    context 'with child plates' do
+      before(:each) do
+        labware.child_plates = [child_plate]
+      end
+
+      it 'does not allow child creation' do
+        expect { |b| subject.control_additional_creation(&b) }.to_not yield_control
+      end
+    end
+  end
+
+  context 'when passed' do
+    let(:state) { 'passed' }
+
+    it 'suggests child purposes' do
+      expect(subject.suggested_purposes).to be_an Array
+      expect(subject.suggested_purposes.first).to be_a LabwareCreators::CreatorButton
+      expect(subject.suggested_purposes.first.purpose_uuid).to eq('child-purpose')
+    end
+
+    context 'without child plates' do
+      before(:each) do
+        labware.child_plates = nil
+      end
+
+      it 'allows child creation' do
+        expect { |b| subject.control_additional_creation(&b) }.to yield_control
+      end
+    end
+
+    context 'with child plates' do
+      before(:each) do
+        labware.child_plates = [child_plate]
+      end
+
+      it 'does not allow child creation' do
+        expect { |b| subject.control_additional_creation(&b) }.to_not yield_control
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a SingleChildPermissivePresenter workflow: This gives the same behaviours per state as the PermissivePresenter, but with the added restriction that only a single child can be created for the labware (plate).

This is adopted, as per feedback from UAT, in the pWGS-384 pipeline where the End Prep and AL-Lib plates are created, started and passed in intertwined steps

PR directed at existing branch to better see the changes