### PR TITLE
Add Sanger_tailed_artic_v1_xxx library types to pipelines

### DIFF
--- a/config/pipelines/high_throughput_heron_384_tailed.yml
+++ b/config/pipelines/high_throughput_heron_384_tailed.yml
@@ -2,7 +2,9 @@
 Heron-384 Tailed A: # Heron 384-well pipeline specific to PCR 1 plate
   filters:
     request_type_key: limber_heron_lthr
-    library_type: PCR amplicon tailed adapters 384
+    library_type:
+    - PCR amplicon tailed adapters 384
+    - Sanger_tailed_artic_v1_384
   library_pass: LTHR-384 Lib PCR pool
   relationships:
     LTHR-384 RT: LTHR-384 PCR 1

--- a/config/pipelines/high_throughput_heron_96_tailed.yml
+++ b/config/pipelines/high_throughput_heron_96_tailed.yml
@@ -2,7 +2,9 @@
 Heron-96 Tailed A: # Heron 96-well pipeline specific to PCR 1 plate
   filters:
     request_type_key: limber_heron_lthr
-    library_type: PCR amplicon tailed adapters 96
+    library_type:
+    - PCR amplicon tailed adapters 96
+    - Sanger_tailed_artic_v1_96
   library_pass: LTHR Lib PCR pool
   relationships:
     LTHR RT: LTHR PCR 1


### PR DESCRIPTION
Fixes #544

- Add Sanger_tailed_artic_v1_96 to high_throughput_heron_96_tailed
- Add Sanger_tailed_artic_v1_384 to high_throughput_heron_384_tailed

Closes #

Changes proposed in this pull request:

*
*
* ...
