### PR TITLE
Apply sort order to stock plate retrieval

### DIFF
--- a/app/sequencescape/sequencescape/api/v2/plate.rb
+++ b/app/sequencescape/sequencescape/api/v2/plate.rb
@@ -97,7 +97,7 @@ class Sequencescape::Api::V2::Plate < Sequencescape::Api::V2::Base
   end
 
   def stock_plate
-    stock_plates.last
+    stock_plates.order(id: :asc).last
   end
 
   def workline_identifier

--- a/spec/models/sequencescape_submission_spec.rb
+++ b/spec/models/sequencescape_submission_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe SequencescapeSubmission do
     let(:obj) { described_class.new(attributes.merge(extra_barcodes: '1234 5678')) }
     it 'raises error if barcodes not found in service' do
       allow(Sequencescape::Api::V2).to receive(:additional_plates_for_presenter).and_return(nil)
-      expect { obj.extra_plates }.to raise_error
+      expect { obj.extra_plates }.to raise_error('Barcodes not found 1234 5678')
     end
     it 'returns the data obtained from service' do
       allow(Sequencescape::Api::V2).to receive(:additional_plates_for_presenter).and_return([plate])

--- a/spec/sequencescape/api/v2/plate_spec.rb
+++ b/spec/sequencescape/api/v2/plate_spec.rb
@@ -9,13 +9,17 @@ RSpec.describe Sequencescape::Api::V2::Plate do
   it { is_expected.to_not be_tube }
 
   describe '#stock_plate' do
-    let(:stock_plates) { create_list :v2_plate, 2 }
+    let(:stock_plates) { create_list :v2_stock_plate, 2 }
     let(:plate) do
       build :unmocked_v2_plate, barcode_number: 12_345, stock_plates: stock_plates
     end
+
     before do
-      allow(plate).to receive(:stock_plates).and_return(stock_plates)
+      ancestor_scope = instance_double('JsonApiClient::Query::Builder')
+      allow(plate).to receive(:stock_plates).and_return(ancestor_scope)
+      expect(ancestor_scope).to receive(:order).with(id: :asc).and_return(stock_plates)
     end
+
     it 'returns the last element of the stock plates list' do
       expect(plate.stock_plate).to eq(stock_plates.last)
     end


### PR DESCRIPTION
Stock plate ordering was not specified, so was dependant on the
behaviour of the sequencescape database. This was resulting in
stock plates appearing to change.

This brings the behaviour mostly in line with Sequencescape, although
uses id over created at. This has the advantage of higher resolution,
quicker speed, and not needing a new sort scope added.

That said, we should probably make the same change within sequencescape.

Fixes #619

Closes #

Changes proposed in this pull request:

*
*
* ...
