### PR TITLE
Improve error message on quad stamp page

### DIFF
--- a/app/javascript/multi-stamp/components/MultiStamp.spec.js
+++ b/app/javascript/multi-stamp/components/MultiStamp.spec.js
@@ -219,7 +219,7 @@ describe('MultiStamp', () => {
     expect(wrapper.vm.transfersError).toEqual('excess transfers')
   })
 
-  it('display "Duplicated transfers" when scanned plate contains duplicated requests', () => {
+  it('displays the correct error message when scanned plate contains duplicated requests', () => {
     const requests1 = [
       requestFactory({uuid: 'req-1-uuid'}),
       requestFactory({uuid: 'req-2-uuid'})
@@ -236,6 +236,6 @@ describe('MultiStamp', () => {
     wrapper.setData({ requestsWithPlatesFiltered: wrapper.vm.requestsWithPlates })
 
     expect(wrapper.vm.duplicatedTransfers.length).toEqual(1)
-    expect(wrapper.vm.transfersError).toEqual('Duplicated transfers')
+    expect(wrapper.vm.transfersError).toEqual('This would result in multiple transfers into the same well. Check if the source plates (DN1S) have more than one active submission.')
   })
 })

--- a/app/javascript/multi-stamp/components/MultiStamp.vue
+++ b/app/javascript/multi-stamp/components/MultiStamp.vue
@@ -215,7 +215,7 @@ export default {
         var sourceBarcodes = new Set()
         this.duplicatedTransfers.forEach(transfer => {
           sourceBarcodes.add(transfer.plateObj.plate.labware_barcode.human_barcode)
-        });
+        })
 
         const msg = 'This would result in multiple transfers into the same well. Check if the source plates ('
                     + [...sourceBarcodes].join(', ')

--- a/app/javascript/multi-stamp/components/MultiStamp.vue
+++ b/app/javascript/multi-stamp/components/MultiStamp.vue
@@ -212,7 +212,16 @@ export default {
     transfersError() {
       const errorMessages = []
       if (this.duplicatedTransfers.length > 0) {
-        errorMessages.push('Duplicated transfers')
+        var problemSourcePlateBarcodes = new Set()
+        var i;
+        for(i = 0; i < this.duplicatedTransfers.length; i++){
+          const transfer = this.duplicatedTransfers[i]
+          problemSourcePlateBarcodes.add(transfer.plateObj.plate.labware_barcode.human_barcode)
+        }
+        const msg = 'This would result in multiple transfers into the same well. Check if the source plates ('
+                    + [...problemSourcePlateBarcodes].join(', ')
+                    + ') have more than one active submission.'
+        errorMessages.push(msg)
       }
       if (this.excessTransfers.length > 0) {
         errorMessages.push('excess transfers')

--- a/app/javascript/multi-stamp/components/MultiStamp.vue
+++ b/app/javascript/multi-stamp/components/MultiStamp.vue
@@ -212,14 +212,13 @@ export default {
     transfersError() {
       const errorMessages = []
       if (this.duplicatedTransfers.length > 0) {
-        var problemSourcePlateBarcodes = new Set()
-        var i;
-        for(i = 0; i < this.duplicatedTransfers.length; i++){
-          const transfer = this.duplicatedTransfers[i]
-          problemSourcePlateBarcodes.add(transfer.plateObj.plate.labware_barcode.human_barcode)
-        }
+        var sourceBarcodes = new Set()
+        this.duplicatedTransfers.forEach(transfer => {
+          sourceBarcodes.add(transfer.plateObj.plate.labware_barcode.human_barcode)
+        });
+
         const msg = 'This would result in multiple transfers into the same well. Check if the source plates ('
-                    + [...problemSourcePlateBarcodes].join(', ')
+                    + [...sourceBarcodes].join(', ')
                     + ') have more than one active submission.'
         errorMessages.push(msg)
       }

--- a/app/javascript/shared/transfersLayouts.js
+++ b/app/javascript/shared/transfersLayouts.js
@@ -25,7 +25,7 @@ const quadrantOffsets = {
 // valid transfers and an array of duplicated transfers (i.e. a transfer whose
 // both source and destination match a transfer already present in the
 // validTransfers array will be put in the duplicatedTransfer array).
-// For eaach request, the target well is calculated using quadrantTargetFor
+// For each request, the target well is calculated using quadrantTargetFor
 // function with quadrantOffsets.
 //
 // Resulting plate eg. where P1-4 is Plate 1-4


### PR DESCRIPTION
Came out of UAT of GPL-851 'choose workflow' page handles characters from scanner badly.

Improves error message 'duplicated transfers' on quad stamp page, giving more information about the root cause of the problem.

R&D discussed whether the behaviour - where you can't process two active submissions in parallel - was OK, and concluded it was OK for now at least.