### PR TITLE
Migrate tube lookup to V2 api

### DIFF
--- a/app/models/asset_search_form.rb
+++ b/app/models/asset_search_form.rb
@@ -8,7 +8,7 @@ class AssetSearchForm
   include ActiveModel::Model
   # We include 'show_my_plates_only' to let us share pagination forms
   attr_accessor :show_my_plates_only, :include_used, :states, :total_results
-  attr_writer :purposes, :page
+  attr_writer :purposes, :page, :purpose_names
 
   class_attribute :form_partial
 
@@ -24,15 +24,17 @@ class AssetSearchForm
     @purposes || []
   end
 
+  def purpose_names
+    @purpose_names || Settings.purposes.values_at(purpose_uuids).pluck(:name)
+  end
+
   def page
     @page || 1
   end
 
-  # rubocop:todo Naming/MemoizedInstanceVariableName
   def total_pages
-    @total_page ||= (total_results || 0) / PER_PAGE
+    @total_pages ||= (total_results || 0) / PER_PAGE
   end
-  # rubocop:enable Naming/MemoizedInstanceVariableName
 
   def each_page
     1.upto(total_pages) do |page_number|

--- a/app/models/labware_creators/pooled_tubes_from_whole_tubes.rb
+++ b/app/models/labware_creators/pooled_tubes_from_whole_tubes.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module LabwareCreators
-  # Pools an entire plate into a single tube. Useful for MiSeqQC
+  # Pools one or more source tubes into a single tube.
+  # Provides an inbox list on the left hand side of the page listing
+  # available tubes (tubes of the correct type).
   class PooledTubesFromWholeTubes < Base
     class SubmissionFailure < StandardError; end
 

--- a/app/models/labware_creators/pooled_tubes_from_whole_tubes.rb
+++ b/app/models/labware_creators/pooled_tubes_from_whole_tubes.rb
@@ -11,7 +11,6 @@ module LabwareCreators
 
     self.page = 'pooled_tubes_from_whole_tubes'
     self.attributes += [{ barcodes: [] }]
-    self.default_transfer_template_name = 'Whole plate to tube'
 
     validate :parents_suitable
 
@@ -39,33 +38,28 @@ module LabwareCreators
 
     # TODO: This should probably be asynchronous
     def available_tubes
-      @search_options = OngoingTube.new(purposes: [parent.purpose.uuid], include_used: false, states: ['passed'])
-      @search_results = tube_search.all(
-        Limber::Tube,
-        @search_options.search_parameters
-      )
+      @search_options = OngoingTube.new(purpose_names: [parent.purpose.name], include_used: false)
+      @search_results = Sequencescape::Api::V2::Tube.find_all(@search_options.v2_search_parameters,
+                                                              includes: 'purpose', paginate: @search_options.v2_pagination)
     end
 
     def parents
-      @parents ||= api.search.find(Settings.searches['Find assets by barcode']).all(Limber::BarcodedAsset,
-                                                                                    barcode: barcodes)
+      @parents ||= Sequencescape::Api::V2::Tube.find_all({ barcode: barcodes }, includes: [])
     end
 
     def parents_suitable
-      missing_barcodes = barcodes - parents.map { |p| p.barcode.ean13 }
+      # Plate#barcode =~ ensures different 'flavours' of the same barcode still match.
+      # Ie. EAN13 encoded versions will match the Code39 encoded versions.
+      missing_barcodes = barcodes.reject { |scanned_bc| parents.any? { |p| p.barcode =~ scanned_bc } }
       errors.add(:barcodes, "could not be found: #{missing_barcodes}") unless missing_barcodes.empty?
     end
 
     private
 
     def transfer_request_attributes
-      parents.each_with_object([]) do |parent, transfer_requests|
-        transfer_requests << { source_asset: parent.uuid, target_asset: @child.uuid }
+      parents.map do |parent|
+        { source_asset: parent.uuid, target_asset: @child.uuid }
       end
-    end
-
-    def tube_search
-      api.search.find(Settings.searches.fetch('Find tubes'))
     end
   end
 end

--- a/app/models/ongoing_tube.rb
+++ b/app/models/ongoing_tube.rb
@@ -13,6 +13,17 @@ class OngoingTube < AssetSearchForm
     }
   end
 
+  def v2_search_parameters
+    {
+      purpose_name: purpose_names,
+      include_used: include_used == '1'
+    }
+  end
+
+  def v2_pagination
+    { number: page, size: 30 }
+  end
+
   def default_purposes
     Settings.purposes
             .select { |_uuid, settings| settings[:asset_type] == 'tube' }

--- a/app/sequencescape/sequencescape/api/v2/tube.rb
+++ b/app/sequencescape/sequencescape/api/v2/tube.rb
@@ -27,6 +27,13 @@ class Sequencescape::Api::V2::Tube < Sequencescape::Api::V2::Base
     Sequencescape::Api::V2::Tube.includes(*includes).find(options).first
   end
 
+  def self.find_all(options, includes: DEFAULT_INCLUDES, paginate: {})
+    Sequencescape::Api::V2::Tube.includes(*includes)
+                                .where(options)
+                                .paginate(paginate)
+                                .all
+  end
+
   # Dummied out for the moment. But no real reason not to add it to the API.
   def requests_as_source
     []

--- a/app/views/sequencescape/api/v2/tubes/_tube.html.erb
+++ b/app/views/sequencescape/api/v2/tubes/_tube.html.erb
@@ -1,0 +1,10 @@
+<li class="labware">
+  <%= link_to(tube, id: "tube_#{tube.barcode.ean13}", class: "list-group-item-action") do %>
+    <h3 class="barcode list-group-item-heading"><%= useful_barcode(tube.barcode) %> <%= state_badge(tube.state) %></h3>
+    <p><%= tube.name %>
+    <dl>
+      <dt>Created</dt><dd><%= tube.created_at.to_formatted_s(:date_created) %></dd>
+      <dt>Type</dt><dd><%= tube.purpose.name %></dd>
+    </dl>
+  <% end -%>
+</li>

--- a/script/limber
+++ b/script/limber
@@ -16,6 +16,7 @@ if ARGV[0].nil?
 end
 
 environment = ARGV[0]
+command = ARGV[1] || 's'
 
 def build_config # rubocop:todo Metrics/MethodLength
   $stdout.puts 'No configuration for environment'
@@ -53,7 +54,7 @@ begin
   $stdout.puts 'Building configuration'
   $stdout.puts `bundle exec rake config:generate`
   $stdout.puts 'Running application'
-  exec('bundle exec rails s')
+  exec("bundle exec rails #{command}")
 rescue Errno::ENOENT
   attempts = (attempts || 0) + 1
   file = File.open(CONFIG_FILE, 'w')

--- a/spec/models/labware_creators/pooled_tubes_from_whole_tubes_spec.rb
+++ b/spec/models/labware_creators/pooled_tubes_from_whole_tubes_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe LabwareCreators::PooledTubesFromWholeTubes do
   let(:purpose)       { json :purpose, uuid: purpose_uuid }
   let(:parent_uuid)   { SecureRandom.uuid }
   let(:parent2_uuid)  { SecureRandom.uuid }
-  let(:parent)        { associated :tube, uuid: parent_uuid, barcode_number: 1 }
-  let(:parent2)       { associated :tube, uuid: parent2_uuid, barcode_number: 2 }
+  let(:parent)        { create :v2_tube, uuid: parent_uuid, barcode_number: 1 }
+  let(:parent2)       { create :v2_tube, uuid: parent2_uuid, barcode_number: 2 }
   let(:child_uuid)    { SecureRandom.uuid }
   let(:template_uuid) { SecureRandom.uuid }
 
@@ -81,11 +81,6 @@ RSpec.describe LabwareCreators::PooledTubesFromWholeTubes do
                    body: json(:single_study_multiplexed_library_tube_collection, names: ['DN2+']))
     end
 
-    # Used to fetch the pools. This is the kind of thing we could pass through from a custom form
-    let(:stub_barcode_searches) do
-      stub_asset_search(barcodes, [parent, parent2])
-    end
-
     let(:transfer_creation_request) do
       stub_api_post('transfer_request_collections',
                     payload: { transfer_request_collection: {
@@ -99,7 +94,11 @@ RSpec.describe LabwareCreators::PooledTubesFromWholeTubes do
     end
 
     before do
-      stub_barcode_searches
+      allow(Sequencescape::Api::V2::Tube).to receive(:find_all).with(
+        { barcode: barcodes },
+        includes: []
+      ).and_return([parent, parent2])
+
       tube_creation_request
       tube_creation_children_request
       transfer_creation_request


### PR DESCRIPTION
The V1 API for tubes is incredibly slow, as it always renders the
full content of the tube. By contrast, V1 allows an utterly minimal
representation.

*Depends on* https://github.com/sanger/sequencescape/pull/3075

Closes #634

Changes proposed in this pull request:

*
*
* ...
