### PR TITLE
Issue649/gpl 901 restrict failing negative controls {heron}

### DIFF
--- a/app/assets/javascripts/tooltips.js
+++ b/app/assets/javascripts/tooltips.js
@@ -1,0 +1,3 @@
+jQuery(function () {
+  jQuery('[data-toggle="tooltip"]').tooltip()
+})

--- a/app/assets/stylesheets/limber/colours.scss
+++ b/app/assets/stylesheets/limber/colours.scss
@@ -12,7 +12,6 @@
 .good              { @include shade-aliquot($success, #FFFFFF); } // Used on well failure page
 .failed            { @include shade-aliquot($danger, #FFFFFF); }
 .cancelled         { @include shade-aliquot($danger, #FFFFFF); }
-.permanent-failure { @include shade-aliquot($danger, #FFFFFF); }
 
 /*
  * Colours from: https://stackoverflow.com/questions/33295120/how-to-generate-gif-256-colors-palette/33295456#33295456

--- a/app/assets/stylesheets/limber/plate.scss
+++ b/app/assets/stylesheets/limber/plate.scss
@@ -46,10 +46,14 @@
       display: inline-block;
       border: 2px $gray-800 solid;
       border-radius: 7px;
-      font-size: small;
 
       .tag {
         display: none;
+      }
+
+      // As the tag index gets longer, scale back the font size
+      .tag-3 {
+        font-size: 80%;
       }
 
       .tag:first-child {
@@ -103,7 +107,6 @@
   .good              { background-color: $success; } // Used on well failure page
   .failed            { background-color: $danger;  }
   .cancelled         { background-color: $danger;  }
-  .permanent-failure { background-color: $danger;  }
 }
 
 .tube-view {

--- a/app/assets/stylesheets/limber/screen.scss
+++ b/app/assets/stylesheets/limber/screen.scss
@@ -182,6 +182,9 @@ dl.metadata, dl#samples-information {
   input[type=checkbox]:checked + label .aliquot {
     background-color: red;
   }
+  input[type=checkbox]:disabled + label .aliquot {
+    opacity: 0.5;
+  }
 
   label {
     font-size: small;

--- a/app/helpers/labware_helper.rb
+++ b/app/helpers/labware_helper.rb
@@ -31,6 +31,10 @@ module LabwareHelper # rubocop:todo Style/Documentation
     container.passed? && container.control_info != 'negative'
   end
 
+  def prevent_quadrant_fail?(container)
+    !container.passed?
+  end
+
   def colours_by_location
     return @location_colours if @location_colours.present? # rubocop:todo Rails/HelperInstanceVariable
 

--- a/app/helpers/labware_helper.rb
+++ b/app/helpers/labware_helper.rb
@@ -27,12 +27,8 @@ module LabwareHelper # rubocop:todo Style/Documentation
   cycling_colours(:bait)    { |labware, _|            labware.bait }
   cycling_colours(:pooling) { |_labware, destination| destination }
 
-  def permanent_state(container)
-    container.state == 'failed' ? 'failed' : 'good'
-  end
-
   def failable?(container)
-    container.state == 'passed'
+    container.passed? && container.control_info != 'negative'
   end
 
   def colours_by_location

--- a/app/helpers/plate_helper.rb
+++ b/app/helpers/plate_helper.rb
@@ -4,10 +4,11 @@ module PlateHelper # rubocop:todo Style/Documentation
   # Proxy object wrapping the form alongside the presenter.
   # This allows us to use the shared plate partial, but pass the form
   # object through to the custom aliquot partial
+  # rubocop:disable Rails/HelperInstanceVariable
   class WellFailingPresenter < BasicObject
     def initialize(form, presenter)
-      @form = form # rubocop:disable Rails/HelperInstanceVariable
-      @_presenter = presenter # rubocop:disable Rails/HelperInstanceVariable
+      @form = form
+      @_presenter = presenter
     end
 
     def aliquot_partial
@@ -17,6 +18,7 @@ module PlateHelper # rubocop:todo Style/Documentation
     delegate_missing_to :_presenter
     attr_reader :form, :_presenter
   end
+  # rubocop:enable Rails/HelperInstanceVariable
 
   def fail_wells_presenter_from(form, presenter)
     WellFailingPresenter.new(form, presenter)

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -18,3 +18,4 @@ require('custom-tagged-plate')
 // Tag animations rotates the displayed tag Id in wells with multiple tags
 require('plain-javascript/tag-animations')
 require('plain-javascript/page-reloader')
+require('plain-javascript/quadrant-well-failing')

--- a/app/javascript/plain-javascript/quadrant-well-failing.js
+++ b/app/javascript/plain-javascript/quadrant-well-failing.js
@@ -22,8 +22,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // Check the box
     checkbox.checked = true
     if(checkbox.disabled) {
-      // If the box was disabled it, but record that it was previously disabled,
-      // as we'll need to revert this if we deselect other wells in the quadrant
+      // If the box was disabled then enable it, but record that it was
+      // previously disabled, as we'll need to revert this if we deselect other
+      // wells in the quadrant
       checkbox.disabled = false
       checkbox.dataset.wasDisabled = true
     }

--- a/app/javascript/plain-javascript/quadrant-well-failing.js
+++ b/app/javascript/plain-javascript/quadrant-well-failing.js
@@ -1,0 +1,47 @@
+document.addEventListener('DOMContentLoaded', () => {
+
+  const failureTable = 'well-failures'
+
+  document.getElementById('quadrant-helper')
+    .querySelectorAll('a[data-select-quadrant-index]')
+    .forEach((button) => {
+      button.addEventListener('click', ()=>{
+        selectQuadrant(button.dataset.selectQuadrantIndex)
+      })
+    })
+
+  const selectQuadrant = (quadrantIndex) => {
+    const checkboxes = document.getElementById(failureTable)
+      .querySelectorAll(`input[data-quadrant-index="${quadrantIndex}"]`)
+    checkboxes.forEach(failWell)
+  }
+
+  const failWell = (checkbox) => {
+    // Failed and cancelled wells can't even be failed in bulk.
+    if (checkbox.dataset.preventQuadrantFail==='true') { return }
+    // Check the box
+    checkbox.checked = true
+    if(checkbox.disabled) {
+      // If the box was disabled it, but record that it was previously disabled,
+      // as we'll need to revert this if we deselect other wells in the quadrant
+      checkbox.disabled = false
+      checkbox.dataset.wasDisabled = true
+    }
+    // If we deselect a well in the quadrant, then we want to make sure revert
+    // the failure of negative controls
+    checkbox.addEventListener('change', restoreDisabled, { once: true })
+  }
+
+  // Re-disable any control wells which had previously been enabled
+  const restoreDisabled = (event) => {
+    const quadrantIndex = event.target.dataset.quadrantIndex
+    const checkboxes = document.getElementById(failureTable)
+      .querySelectorAll(`input[data-quadrant-index="${quadrantIndex}"][data-was-disabled="true"]`)
+    checkboxes.forEach((boxToDisable)=>{
+      boxToDisable.disabled = true
+      boxToDisable.checked = false // Not strictly necessary, but otherwise the well
+      // remains red
+    })
+  }
+
+})

--- a/app/models/presenters/plate_presenter.rb
+++ b/app/models/presenters/plate_presenter.rb
@@ -109,6 +109,10 @@ module Presenters
 
     alias child_assets child_plates
 
+    def quadrants_helper
+      size == 384 ? 'quadrant_helper' : 'none'
+    end
+
     private
 
     def libraries_passable?

--- a/app/sequencescape/sequencescape/api/v2/well.rb
+++ b/app/sequencescape/sequencescape/api/v2/well.rb
@@ -87,10 +87,14 @@ class Sequencescape::Api::V2::Well < Sequencescape::Api::V2::Base # rubocop:todo
     false
   end
 
+  def control_info
+    aliquots[0]&.sample&.control_type
+  end
+
   def control_info_formatted
     return nil unless contains_control?
 
-    case aliquots[0].sample.control_type
+    case control_info
     when 'positive'
       '+'
     when 'negative'

--- a/app/views/aliquots/_tagged_aliquot.html.erb
+++ b/app/views/aliquots/_tagged_aliquot.html.erb
@@ -3,7 +3,7 @@
   class="aliquot <%= container.location %> <%= container.state %>"
   rel="<%= "details_#{id}" %>"
   data-pool="<%= container.respond_to?(:pool) ? container.pool_id : '' %>">
-  <% container.aliquots.each_with_index do |aliquot| %>
-    <%= content_tag(:span, aliquot.tag_index, class: 'tag') %>
+  <% container.aliquots.each do |aliquot| %>
+    <%= content_tag(:span, aliquot.tag_index, class: ['tag', "tag-#{aliquot.tag_index.to_s.length}"]) %>
   <% end %>
 </div>

--- a/app/views/aliquots/_well_failing_aliquot.html.erb
+++ b/app/views/aliquots/_well_failing_aliquot.html.erb
@@ -1,4 +1,7 @@
-<%= presenter.form.check_box(id, disabled: !failable?(container)) %>
+<%= presenter.form.check_box(id, disabled: !failable?(container), data: {
+  quadrant_index: container.quadrant_index,
+  prevent_quadrant_fail: prevent_quadrant_fail?(container)
+}) %>
 <%= presenter.form.label id do %>
   <div id="aliquot_<%= id %>"
        class="aliquot <%= container.state %>"

--- a/app/views/aliquots/_well_failing_aliquot.html.erb
+++ b/app/views/aliquots/_well_failing_aliquot.html.erb
@@ -1,6 +1,15 @@
-<%= presenter.form.check_box(id) if failable?(container) %>
+<%= presenter.form.check_box(id, disabled: !failable?(container)) %>
 <%= presenter.form.label id do %>
-  <div id="aliquot_<%= id %>" class="aliquot <%= permanent_state(container) %>" data-well="<%= id %>">
-    <%= id %>
+  <div id="aliquot_<%= id %>"
+       class="aliquot <%= container.state %>"
+       data-toggle="tooltip"
+       data-placement="top"
+       title="<%= id %>"
+       >
+    <% if container.respond_to?(:contains_control?) && container.contains_control? %>
+      <div class="control-type">
+        <%= container.control_info_formatted %>
+      </div>
+    <%end%>
   </div>
 <% end %>

--- a/app/views/application/_none.html.erb
+++ b/app/views/application/_none.html.erb
@@ -1,0 +1,3 @@
+<%# This file is intentionally left blank %>
+<%# This allows us to dynamically disable sections by using render 'none' %>
+<%# eg. `render presenter.advance_options #=> 'none' %>

--- a/app/views/plates/_fail_wells.html.erb
+++ b/app/views/plates/_fail_wells.html.erb
@@ -10,6 +10,8 @@
     <% end %>
     </fieldset>
     <div class="card-body">
+      <%= render presenter.quadrants_helper %>
+
       <p>Once the "Fail Selected Wells" button has been pressed failures can't be undone but further failed wells can be added. The 'Still charge customer' option will only affect the wells selected for failure at the same time. Previously and subsequently failed wells will retain their original options.</p>
 
       <div class = 'custom-control custom-checkbox'>

--- a/app/views/plates/_quadrant_helper.html.erb
+++ b/app/views/plates/_quadrant_helper.html.erb
@@ -1,0 +1,8 @@
+<div id="quadrant-helper">
+  <% 4.times do |index| %>
+    <a class="btn btn-sm btn-primary"
+       data-select-quadrant-index="<%= index %>"
+       href='#well-failures'
+    >Select Quadrant <%= index + 1 %></a>
+  <% end %>
+</div>

--- a/spec/features/failing_quadrants_spec.rb
+++ b/spec/features/failing_quadrants_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature 'Failing quadrants', js: true do
     2.times do # For both the initial find, and the redirect post state change
       stub_v2_plate(example_plate)
     end
-    # stub_api_get(plate_uuid, body: example_plate)
+
     stub_api_get(plate_uuid, 'wells',
                  body: json(:well_collection, default_state: 'passed', custom_state: { 'B2' => 'failed' }))
     stub_api_get('barcode_printers', body: json(:barcode_printer_collection))

--- a/spec/features/failing_quadrants_spec.rb
+++ b/spec/features/failing_quadrants_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.feature 'Failing wells', js: true do
+RSpec.feature 'Failing quadrants', js: true do
   has_a_working_api
 
   let(:user_uuid)      { 'user-uuid' }
@@ -20,7 +20,8 @@ RSpec.feature 'Failing wells', js: true do
     ]
   end
   let(:example_plate) do
-    create :v2_plate, uuid: plate_uuid, purpose_uuid: 'stock-plate-purpose-uuid', state: 'passed', wells: wells
+    create :v2_plate, uuid: plate_uuid, purpose_uuid: 'stock-plate-purpose-uuid',
+                      state: 'passed', wells: wells, size: 384
   end
 
   let!(:state_change_request) do
@@ -30,7 +31,7 @@ RSpec.feature 'Failing wells', js: true do
         'state_change' => {
           user: user_uuid,
           target: plate_uuid,
-          contents: %w[A2 A3],
+          contents: %w[A1 A3],
           target_state: 'failed',
           reason: 'Individual Well Failure',
           customer_accepts_responsibility: nil
@@ -61,12 +62,9 @@ RSpec.feature 'Failing wells', js: true do
   scenario 'failing wells' do
     fill_in_swipecard_and_barcode user_swipecard, plate_barcode
     click_on('Fail Wells')
-    within_fieldset('Select wells to fail') do
-      # The actual check-boxes are invisible so we use the labels
-      find_with_tooltip('A3').click
-      find_with_tooltip('A2').click
-      find_with_tooltip('B2').click
-    end
+
+    click_on('Select Quadrant 1')
+    click_on('Select Quadrant 4')
 
     click_on('Fail selected wells')
     expect(find('#flashes')).to have_content('Selected wells have been failed')

--- a/spec/helpers/labware_helper_spec.rb
+++ b/spec/helpers/labware_helper_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe LabwareHelper do
+  include LabwareHelper
+
+  # def failable?(container)
+  #   container.passed? && container.control_info != 'negative'
+  # end
+  describe '::failable?' do
+    subject { failable?(well) }
+
+    context 'when passed a failed well' do
+      let(:well) { instance_double(Sequencescape::Api::V2::Well, passed?: false, control_info: nil) }
+      it { is_expected.to be false }
+    end
+
+    context 'when passed a passed well' do
+      let(:well) { instance_double(Sequencescape::Api::V2::Well, passed?: true, control_info: nil) }
+      it { is_expected.to be true }
+    end
+
+    context 'when passed a positive control well' do
+      let(:well) { instance_double(Sequencescape::Api::V2::Well, passed?: true, control_info: 'positive') }
+      it { is_expected.to be true }
+    end
+
+    context 'when passed a negative control well' do
+      let(:well) { instance_double(Sequencescape::Api::V2::Well, passed?: true, control_info: 'negative') }
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/spec/helpers/labware_helper_spec.rb
+++ b/spec/helpers/labware_helper_spec.rb
@@ -5,9 +5,6 @@ require 'spec_helper'
 RSpec.describe LabwareHelper do
   include LabwareHelper
 
-  # def failable?(container)
-  #   container.passed? && container.control_info != 'negative'
-  # end
   describe '::failable?' do
     subject { failable?(well) }
 
@@ -24,6 +21,30 @@ RSpec.describe LabwareHelper do
     context 'when passed a positive control well' do
       let(:well) { instance_double(Sequencescape::Api::V2::Well, passed?: true, control_info: 'positive') }
       it { is_expected.to be true }
+    end
+
+    context 'when passed a negative control well' do
+      let(:well) { instance_double(Sequencescape::Api::V2::Well, passed?: true, control_info: 'negative') }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '::prevent_quadrant_fail?' do
+    subject { prevent_quadrant_fail?(well) }
+
+    context 'when passed a failed well' do
+      let(:well) { instance_double(Sequencescape::Api::V2::Well, passed?: false, control_info: nil) }
+      it { is_expected.to be true }
+    end
+
+    context 'when passed a passed well' do
+      let(:well) { instance_double(Sequencescape::Api::V2::Well, passed?: true, control_info: nil) }
+      it { is_expected.to be false }
+    end
+
+    context 'when passed a positive control well' do
+      let(:well) { instance_double(Sequencescape::Api::V2::Well, passed?: true, control_info: 'positive') }
+      it { is_expected.to be false }
     end
 
     context 'when passed a negative control well' do

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -117,4 +117,19 @@ module FeatureHelpers # rubocop:todo Metrics/ModuleLength
   def ean13(number, prefix = 'DN')
     SBCF::SangerBarcode.new(prefix: prefix, number: number).machine_barcode.to_s
   end
+
+  # Because wells can get quite small on 384 well plates, we use a tooltip
+  # to provide feedback about which well is being hovered over. This is provided
+  # by bootstrap: https://getbootstrap.com/docs/4.6/components/tooltips/
+  # This finder allows capybara to identify an element by its tooltip
+  #
+  # @param tooltip [String] The text of the tooltip
+  # @param type [String] A selector for the element eg. 'div', '.well'
+  #                      'div' by default
+  #
+  # @return [Capybara::Node::Element] The element found
+  #
+  def find_with_tooltip(tooltip, type: 'div')
+    find("#{type}[data-original-title='#{tooltip}']")
+  end
 end


### PR DESCRIPTION
Closes #649

Changes proposed in this pull request:

* Negative control wells can't be failed individually
* Adds 'Select quadrant' helper buttons that *can* fail negative controls
* Adjust font sizes to ensure tags display correctly on 96 and 384 well plates
* Fail wells interface displays control state, to make it easier to understand why a well is not failable
* Fail wells interface displays well name as tooltip, as not really enough space on the well itself on 384 well plates.
