### PR TITLE
Update yanked mimemagic version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
All prior versions of mimemagic have been yanked due to a GPL license
violation. https://github.com/minad/mimemagic/tree/0.3.6

This updates the mimemagic version, allowing limber to build.