### PR TITLE
Change primer panel name to nCoV-2019/V4 for Heron plates

### DIFF
--- a/config/purposes/heron_lthr_entry.yml
+++ b/config/purposes/heron_lthr_entry.yml
@@ -17,7 +17,7 @@ LTHR Cherrypick:
         read_length: 150
         fragment_size_required_from: '50'
         fragment_size_required_to: '800'
-        primer_panel_name: nCoV-2019/V3/B
+        primer_panel_name: nCoV-2019/V4
       allowed_extra_barcodes: false
     LTHR 384 - NovaSeq:
       template_name: 'Limber - Heron LTHR - Automated'
@@ -26,6 +26,6 @@ LTHR Cherrypick:
         read_length: 150
         fragment_size_required_from: '50'
         fragment_size_required_to: '800'
-        primer_panel_name: nCoV-2019/V3/B
+        primer_panel_name: nCoV-2019/V4
       allowed_extra_barcodes: true
       num_extra_barcodes: 3

--- a/docs/purposes_yaml_files.md
+++ b/docs/purposes_yaml_files.md
@@ -594,7 +594,7 @@ This mirrors the same structure used by work completions.
       read_length: 150
       fragment_size_required_from: '50'
       fragment_size_required_to: '800'
-      primer_panel_name: nCoV-2019/V3/B
+      primer_panel_name: nCoV-2019/V4
   LTHR 384 - NovaSeq:
     template_name: 'Limber - Heron LTHR - Automated'
     request_options:
@@ -602,5 +602,5 @@ This mirrors the same structure used by work completions.
       read_length: 150
       fragment_size_required_from: '50'
       fragment_size_required_to: '800'
-      primer_panel_name: nCoV-2019/V3/B
+      primer_panel_name: nCoV-2019/V4
 ```

--- a/spec/controllers/sequencescape_submissions_controller_spec.rb
+++ b/spec/controllers/sequencescape_submissions_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SequencescapeSubmissionsController, type: :controller do
         'read_length' => '150',
         'fragment_size_required_from' => '50',
         'fragment_size_required_to' => '800',
-        'primer_panel_name' => 'nCoV-2019/V3/B'
+        'primer_panel_name' => 'nCoV-2019/V4'
       }
     end
     let(:template_uuid) { SecureRandom.uuid }


### PR DESCRIPTION
Closes #774 

Changes proposed in this pull request:

* Update the reference to the primer panel for the V4 set.
