### PR TITLE
Exclude hashes and arrays from length cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,10 @@ Style/ClassAndModuleChildren:
   Enabled: false
 # Filter out all the DSLs
 Metrics/BlockLength:
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
   IgnoredMethods:
     - describe
     - context
@@ -44,7 +48,16 @@ Metrics/BlockLength:
     - it
   Exclude:
     - config/robots.rb
-
+Metrics/ClassLength:
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
+Metrics/MethodLength:
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
 # Ideally we want to get this down a bit more. 120 would be nice, 80 is overkill
 # Although the above line is exactly 80 characters. That wasn't intentional.
 Layout/LineLength:

--- a/app/controllers/creation_controller.rb
+++ b/app/controllers/creation_controller.rb
@@ -36,7 +36,6 @@ class CreationController < ApplicationController
                       ))
   end
 
-  # rubocop:todo Metrics/MethodLength
   def creation_failed(exception) # rubocop:todo Metrics/AbcSize
     Rails.logger.error("Cannot create child of #{@labware_creator.parent.uuid}")
     Rails.logger.error(exception.message)
@@ -51,11 +50,10 @@ class CreationController < ApplicationController
       end
     end
   end
-  # rubocop:enable Metrics/MethodLength
 
   private
 
-  def create_success # rubocop:todo Metrics/MethodLength
+  def create_success
     respond_to do |format|
       format.json do
         render json: {
@@ -70,7 +68,6 @@ class CreationController < ApplicationController
     end
   end
 
-  # rubocop:todo Metrics/MethodLength
   def create_failure # rubocop:todo Metrics/AbcSize
     Rails.logger.error(@labware_creator.errors.full_messages)
     respond_to do |format|
@@ -84,7 +81,6 @@ class CreationController < ApplicationController
       end
     end
   end
-  # rubocop:enable Metrics/MethodLength
 
   def permitted_attributes
     creator_class.attributes

--- a/app/controllers/pipelines_controller.rb
+++ b/app/controllers/pipelines_controller.rb
@@ -36,7 +36,7 @@ class PipelinesController < ApplicationController
     end
   end
 
-  def calculate_nodes # rubocop:todo Metrics/MethodLength
+  def calculate_nodes
     Settings.purposes.map do |_uuid, purpose|
       {
         group: 'nodes',

--- a/app/controllers/plates_controller.rb
+++ b/app/controllers/plates_controller.rb
@@ -7,7 +7,6 @@
 class PlatesController < LabwareController
   before_action :check_for_current_user!, only: %i[update fail_wells] # rubocop:todo Rails/LexicallyScopedActionFilter
 
-  # rubocop:todo Metrics/MethodLength
   def fail_wells # rubocop:todo Metrics/AbcSize
     if wells_to_fail.empty?
       redirect_to(limber_plate_path(params[:id]), notice: 'No wells were selected to fail')
@@ -23,7 +22,6 @@ class PlatesController < LabwareController
       redirect_to(limber_plate_path(params[:id]), notice: 'Selected wells have been failed')
     end
   end
-  # rubocop:enable Metrics/MethodLength
 
   def wells_to_fail
     params.fetch(:plate, {}).fetch(:wells, {}).select { |_, v| v == '1' }.keys

--- a/app/models/concerns/presenters/creation_behaviour.rb
+++ b/app/models/concerns/presenters/creation_behaviour.rb
@@ -24,7 +24,7 @@ module Presenters::CreationBehaviour
     end
   end
 
-  def construct_buttons(scope) # rubocop:todo Metrics/MethodLength
+  def construct_buttons(scope)
     scope.map do |purpose_uuid, purpose_settings|
       LabwareCreators.class_for(purpose_uuid).creator_button(
         creator: LabwareCreators.class_for(purpose_uuid),

--- a/app/models/concerns/presenters/extended_csv.rb
+++ b/app/models/concerns/presenters/extended_csv.rb
@@ -8,7 +8,6 @@ module Presenters::ExtendedCsv # rubocop:todo Style/Documentation
   end
 
   # Yields information for the show_extended.csv
-  # rubocop:todo Metrics/MethodLength
   def each_well_transfer(offset = 0) # rubocop:todo Metrics/AbcSize
     index = 0
     transfers_for_csv[offset * 4...(offset + 1) * 4].each_with_index do |transfers_list, bed_index|
@@ -25,7 +24,6 @@ module Presenters::ExtendedCsv # rubocop:todo Style/Documentation
       end
     end
   end
-  # rubocop:enable Metrics/MethodLength
 
   private
 

--- a/app/models/concerns/presenters/statemachine.rb
+++ b/app/models/concerns/presenters/statemachine.rb
@@ -3,7 +3,7 @@
 module Presenters::Statemachine
   # State transitions are common across all of the statemachines.
   module StateTransitions
-    def self.inject(base) # rubocop:todo Metrics/MethodLength
+    def self.inject(base)
       base.instance_eval do
         event :take_default_path, human_name: 'Manual Transfer' do
           transition pending: :passed

--- a/app/models/labels/plate_double_label_qc.rb
+++ b/app/models/labels/plate_double_label_qc.rb
@@ -7,7 +7,7 @@ class Labels::PlateDoubleLabelQc < Labels::PlateDoubleLabel
   end
 
   # Prints an additional QC plate label
-  def qc_attributes # rubocop:todo Metrics/MethodLength
+  def qc_attributes
     [
       {
         right_text: workline_identifier,

--- a/app/models/labels/plate_label_lds_al_lib.rb
+++ b/app/models/labels/plate_label_lds_al_lib.rb
@@ -10,7 +10,7 @@ class Labels::PlateLabelLdsAlLib < Labels::PlateLabelBase
   end
 
   # rubocop:disable Metrics/AbcSize
-  def intermediate_attributes # rubocop:todo Metrics/MethodLength
+  def intermediate_attributes
     [
       {
         top_left: date_today,
@@ -36,7 +36,7 @@ class Labels::PlateLabelLdsAlLib < Labels::PlateLabelBase
     ]
   end
 
-  def qc_attributes # rubocop:todo Metrics/MethodLength
+  def qc_attributes
     [
       {
         top_left: date_today,

--- a/app/models/labware_creators/custom_tagged_plate.rb
+++ b/app/models/labware_creators/custom_tagged_plate.rb
@@ -37,7 +37,6 @@ module LabwareCreators
       parent.populate_wells_with_pool
     end
 
-    # rubocop:todo Metrics/MethodLength
     def create_plate! # rubocop:todo Metrics/AbcSize
       @child = api.pooled_plate_creation.create!(
         child_purpose: purpose_uuid,
@@ -61,7 +60,6 @@ module LabwareCreators
 
       true
     end
-    # rubocop:enable Metrics/MethodLength
 
     def pool_index(_pool_index)
       nil

--- a/app/models/labware_creators/multi_plate_pool.rb
+++ b/app/models/labware_creators/multi_plate_pool.rb
@@ -16,7 +16,7 @@ module LabwareCreators
 
     private
 
-    def create_labware! # rubocop:todo Metrics/MethodLength
+    def create_labware!
       plate_creation = api.pooled_plate_creation.create!(
         parents: transfers.keys,
         child_purpose: purpose_uuid,

--- a/app/models/labware_creators/pooled_tubes_from_whole_plates.rb
+++ b/app/models/labware_creators/pooled_tubes_from_whole_plates.rb
@@ -13,7 +13,6 @@ module LabwareCreators
 
     validate :parents_suitable
 
-    # rubocop:todo Metrics/MethodLength
     def create_labware! # rubocop:todo Metrics/AbcSize
       # Create a single tube
       # TODO: This should link to multiple parents in production
@@ -33,7 +32,6 @@ module LabwareCreators
         )
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     def barcodes=(input)
       @barcodes = (input || []).map(&:strip).reject(&:blank?)

--- a/app/models/labware_creators/tube_from_tube.rb
+++ b/app/models/labware_creators/tube_from_tube.rb
@@ -9,7 +9,7 @@ module LabwareCreators
 
     attr_reader :tube_transfer
 
-    def create_labware! # rubocop:todo Metrics/MethodLength
+    def create_labware!
       @child_tube = api.tube_from_tube_creation.create!(
         parent: parent_uuid,
         child_purpose: purpose_uuid,

--- a/app/models/print_job.rb
+++ b/app/models/print_job.rb
@@ -23,7 +23,7 @@ class PrintJob # rubocop:todo Style/Documentation
     end
   end
 
-  def print_to_pmb # rubocop:todo Metrics/MethodLength
+  def print_to_pmb
     job = PMB::PrintJob.new(
       printer_name: printer_name,
       label_template_id: pmb_label_template_id,

--- a/app/models/sequencescape_submission.rb
+++ b/app/models/sequencescape_submission.rb
@@ -126,7 +126,6 @@ class SequencescapeSubmission
     end
   end
 
-  # rubocop:todo Metrics/MethodLength
   def generate_submissions # rubocop:todo Metrics/AbcSize
     orders = generate_orders
 
@@ -144,7 +143,6 @@ class SequencescapeSubmission
     errors.add(:submission, e.resource.errors.full_messages.join('; '))
     false
   end
-  # rubocop:enable Metrics/MethodLength
 
   def submission_template
     api.order_template.find(template_uuid)

--- a/app/models/utility/common_dilution_calculations.rb
+++ b/app/models/utility/common_dilution_calculations.rb
@@ -108,7 +108,7 @@ module Utility
     #
     # @return [array] An array of qc assay details for the child plate, ready to send via Api to sequencescape.
     #
-    def construct_dest_qc_assay_attributes(child_uuid, transfer_hash) # rubocop:todo Metrics/MethodLength
+    def construct_dest_qc_assay_attributes(child_uuid, transfer_hash)
       dest_concs = extract_destination_concentrations(transfer_hash)
       dest_concs.map do |dest_locn, dest_conc|
         {

--- a/app/models/utility/concentration_binning_calculator.rb
+++ b/app/models/utility/concentration_binning_calculator.rb
@@ -71,7 +71,6 @@ module Utility
 
     # Build the transfers hash, cycling through the bins and their wells and locating them onto the
     # child plate.
-    # rubocop:todo Metrics/MethodLength
     def build_transfers_hash(bins, number_of_rows, compression_reqd) # rubocop:todo Metrics/AbcSize
       binner = Binner.new(compression_reqd, number_of_rows)
       bins.values.each_with_object({}).with_index do |(bin, transfers_hash), bin_index_within_bins|
@@ -90,6 +89,5 @@ module Utility
         end
       end
     end
-    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/lib/purpose_config.rb
+++ b/lib/purpose_config.rb
@@ -32,7 +32,6 @@ class PurposeConfig # rubocop:todo Style/Documentation
     default_options[:pmb_template] = default_pmb_template_for(default_options[:printer])
   end
 
-  # rubocop:todo Metrics/MethodLength
   def config
     {
       name: name,
@@ -47,7 +46,6 @@ class PurposeConfig # rubocop:todo Style/Documentation
       pmb_template: print_option(:pmb_template)
     }.merge(@options)
   end
-  # rubocop:enable Metrics/MethodLength
 
   def uuid
     store.fetch(name).uuid

--- a/lib/robot_configuration.rb
+++ b/lib/robot_configuration.rb
@@ -101,7 +101,7 @@ module RobotConfiguration
       "#{type} #{source_purpose} to #{target_purpose}".parameterize
     end
 
-    def configuration # rubocop:todo Metrics/MethodLength
+    def configuration
       {
         name: name,
         verify_robot: verify_robot,

--- a/script/limber
+++ b/script/limber
@@ -18,7 +18,7 @@ end
 environment = ARGV[0]
 command = ARGV[1] || 's'
 
-def build_config # rubocop:todo Metrics/MethodLength
+def build_config
   $stdout.puts 'No configuration for environment'
   $stdout.print 'Sequencescape url: '
   url = $stdin.gets.chomp

--- a/spec/models/labware_creators/quadrant_split_plate_spec.rb
+++ b/spec/models/labware_creators/quadrant_split_plate_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe LabwareCreators::QuadrantSplitPlate do
 
   shared_examples 'a quad-split plate creator' do
     describe '#save!' do
-      setup do # rubocop:todo Metrics/BlockLength
+      setup do
         allow(SearchHelper).to receive(:merger_plate_names)
           .and_return(stock_purpose_name)
 

--- a/spec/support/api_url_helper.rb
+++ b/spec/support/api_url_helper.rb
@@ -53,7 +53,7 @@ module ApiUrlHelper
       stub_api_modify(*components, status: status, body: body, payload: payload)
     end
 
-    def stub_api_modify(*components, body:, payload:, action: :post, status: 201) # rubocop:todo Metrics/MethodLength
+    def stub_api_modify(*components, body:, payload:, action: :post, status: 201)
       Array(body).reduce(
         stub_request(action, api_url_for(*components))
         .with(
@@ -91,7 +91,6 @@ module ApiUrlHelper
     end
 
     # Builds the basic v2 plate finding query.
-    # rubocop:todo Metrics/MethodLength
     def stub_v2_plate(plate, stub_search: true, custom_query: nil, custom_includes: nil) # rubocop:todo Metrics/AbcSize
       # Stub to v1 api search here as well!
       if stub_search
@@ -109,7 +108,6 @@ module ApiUrlHelper
         allow(Sequencescape::Api::V2).to receive(:plate_for_presenter).with(*arguments).and_return(plate)
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     # Builds the basic v2 tube finding query.
     def stub_v2_tube(tube, stub_search: true, custom_includes: false)

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module FeatureHelpers # rubocop:todo Metrics/ModuleLength
-  def stub_search_and_single_result(search, query, result = nil) # rubocop:todo Metrics/MethodLength
+  def stub_search_and_single_result(search, query, result = nil)
     search_uuid = search.downcase.tr(' ', '-')
     Settings.searches[search] = search_uuid
     stub_api_get(search_uuid, body: json(:swipecard_search, uuid: search_uuid))
@@ -53,7 +53,7 @@ module FeatureHelpers # rubocop:todo Metrics/ModuleLength
                  body: json(:v1_custom_metadatum_collection, params))
   end
 
-  def stub_create_labware_metadata(barcode, labware_v1, labware_uuid, user_uuid, metadata) # rubocop:todo Metrics/MethodLength
+  def stub_create_labware_metadata(barcode, labware_v1, labware_uuid, user_uuid, metadata)
     stub_asset_search(barcode, labware_v1)
     stub_api_post('custom_metadatum_collections',
                   payload: {

--- a/spec/support/with_pmb_stubbed.rb
+++ b/spec/support/with_pmb_stubbed.rb
@@ -29,7 +29,7 @@ def print_job_response(printer_name, template_id) # rubocop:todo Metrics/MethodL
   })
 end
 
-def print_job_post(printer_name, template_id) # rubocop:todo Metrics/MethodLength
+def print_job_post(printer_name, template_id)
   {
     data: {
       type: 'print_jobs',
@@ -46,7 +46,7 @@ def print_job_post(printer_name, template_id) # rubocop:todo Metrics/MethodLengt
   }.to_json
 end
 
-def print_job_post_multiple_labels(printer_name, template_id) # rubocop:todo Metrics/MethodLength
+def print_job_post_multiple_labels(printer_name, template_id)
   {
     data: {
       type: 'print_jobs',


### PR DESCRIPTION
Adjust rubocop rules to treat hashes etc as single line.