### PR TITLE
Fix thresholds for well failure to handle there being no results

### DIFF
--- a/app/models/presenters/qc_threshold_presenter.rb
+++ b/app/models/presenters/qc_threshold_presenter.rb
@@ -76,7 +76,7 @@ class Presenters::QcThresholdPresenter
     # @return [Boolean]
     #
     def enabled?
-      has_results? && has_compatible_units?
+      results? && compatible_units?
     end
 
     #
@@ -85,12 +85,11 @@ class Presenters::QcThresholdPresenter
     # @return [String]
     #
     def error
-      return "There are no QC results of this type to apply a threshold." unless has_results?
+      return 'There are no QC results of this type to apply a threshold.' unless results?
+      return if compatible_units?
 
-      unless has_compatible_units?
-        units = unique_units.map(&:units).join(', ')
-        return "Incompatible units #{units}. Automatic thresholds disabled."
-      end
+      units = unique_units.map(&:units).join(', ')
+      "Incompatible units #{units}. Automatic thresholds disabled."
     end
 
     def value_for(qc_result)
@@ -108,11 +107,11 @@ class Presenters::QcThresholdPresenter
 
     private
 
-    def has_results?
+    def results?
       results.any?
     end
 
-    def has_compatible_units?
+    def compatible_units?
       unique_units.all? { |unit| unit.compatible?(units) }
     end
 

--- a/app/views/plates/_fail_wells.html.erb
+++ b/app/views/plates/_fail_wells.html.erb
@@ -13,7 +13,7 @@
       <%= render presenter.quadrants_helper %>
       <%= render 'thresholds', presenter: presenter.qc_thresholds %>
 
-      <p>Once the "Fail Selected Wells" button has been pressed failures can't be undone but further failed wells can be added. The 'Still charge customer' option will only affect the wells selected for failure at the same time. Previously and subsequently failed wells will retain their original options.</p>
+      <p>Once the "Fail Selected Wells" button has been pressed, failures cannot be undone, but further failed wells can be added. The 'Still charge customer' option will only affect the wells selected for failure at the same time. Previously and subsequently failed wells will retain their original options.</p>
 
       <div class = 'custom-control custom-checkbox'>
         <%= check_box_tag :customer_accepts_responsibility, true, false, class: 'custom-control-input' %>

--- a/app/views/plates/_threshold.html.erb
+++ b/app/views/plates/_threshold.html.erb
@@ -1,6 +1,6 @@
 <% if threshold.enabled? %>
-  <div data-qc-key="qc<%= threshold.key.camelcase %>" class="form-group">
-    <label for="qc-<%= threshold.key %>"><%= threshold.name.titlecase %></label>
+  <div data-qc-key="qc<%= threshold.key.camelcase %>" class="form-group alert alert-success">
+    <h4 class="alert-heading"><label for="qc-<%= threshold.key %>"><%= threshold.name.titlecase %></label></h4>
     <input type="range" id="qc-<%= threshold.key %>-range" name="<%= threshold.key %>"
           min="<%= threshold.min %>" max="<%= threshold.max %>" value="<%= threshold.default %>" step="0.01" list="<%= threshold.key %>-data"
           class="form-control-range mb-3">
@@ -18,7 +18,7 @@
   </div>
 <% else %>
   <div class="alert alert-warning">
-    <h4 class="alert-heading"><%= threshold.name %></h4>
+    <h4 class="alert-heading"><%= threshold.name.titlecase %></h4>
     <%= threshold.error %>
   </div>
 <% end %>

--- a/spec/models/presenters/qc_threshold_presenter_spec.rb
+++ b/spec/models/presenters/qc_threshold_presenter_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe Presenters::QcThresholdPresenter do
           [create(:qc_result, key: 'concentration', value: '50', units: 'nM')]
         ]
       end
-      let(:configuration) { {
-        molarity: { name: 'molarity', default_threshold: 20, max: 50, min: 5, units: 'nM' },
-      } }
+      let(:configuration) do
+        { molarity: { name: 'molarity', default_threshold: 20, max: 50, min: 5, units: 'nM' } }
+      end
 
       it 'is disabled' do
         expect(presenter.thresholds.first).to_not be_enabled

--- a/spec/models/presenters/qc_threshold_presenter_spec.rb
+++ b/spec/models/presenters/qc_threshold_presenter_spec.rb
@@ -68,6 +68,26 @@ RSpec.describe Presenters::QcThresholdPresenter do
       end
     end
 
+    context 'with no QC results for a configured key' do
+      let(:qc_results) do
+        [
+          [create(:qc_result, key: 'concentration', value: '10', units: 'ng/ul')],
+          [create(:qc_result, key: 'concentration', value: '50', units: 'nM')]
+        ]
+      end
+      let(:configuration) { {
+        molarity: { name: 'molarity', default_threshold: 20, max: 50, min: 5, units: 'nM' },
+      } }
+
+      it 'is disabled' do
+        expect(presenter.thresholds.first).to_not be_enabled
+      end
+
+      it 'explains the problem' do
+        expect(presenter.thresholds.first.error).to eq 'There are no QC results of this type to apply a threshold.'
+      end
+    end
+
     context 'with incompatible units' do
       let(:qc_results) do
         [


### PR DESCRIPTION
I also updated the appearance of the non-errored thresholds to be in green alerts to match the yellow ones used for when there are problems.  This makes it look much nicer.

![Screenshot 2021-09-21 at 14 52 57](https://user-images.githubusercontent.com/1999241/134187776-fed945e4-c8cd-40c9-a22f-c57541140263.png)


