### PR TITLE
revert some of the features added to the download file in DPL-071

### DIFF
--- a/app/views/exports/cardinal_tagging_csv_for_custom_pooling.csv.erb
+++ b/app/views/exports/cardinal_tagging_csv_for_custom_pooling.csv.erb
@@ -1,5 +1,5 @@
 <%
-  csv_array = [['Source Well', 'Volume to add to pool', 'Dest. pool', 'Number of samples', 'Tag index', 'Tag 2 index']]
+  csv_array = [['Source Well', 'Volume to add to pool', 'Dest. well', 'Number of samples', 'Tag index', 'Tag 2 index']]
   @plate.wells_in_columns.each do |well|
     # We want to skip wells that are empty or have multiple aliquots with different tag indices
     tag_1_indices = well.aliquots.map(&:tag_index).uniq
@@ -7,7 +7,7 @@
     next if well.empty? || tag_1_indices.size > 1 || tag_2_indices.size > 1
 
     csv_array << [
-      "#{@plate.human_barcode}:#{well.location}",
+      well.location,
       nil,
       nil,
       rand(12) + 1, # TODO: DPL-067 Determine actual number of samples per well

--- a/spec/views/exports/cardinal_tagging_csv_for_custom_pooling.csv.erb_spec.rb
+++ b/spec/views/exports/cardinal_tagging_csv_for_custom_pooling.csv.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'exports/cardinal_tagging_csv_for_custom_pooling.csv.erb' do
   end
 
   let(:expected_headers) do
-    ['Source Well', 'Volume to add to pool', 'Dest. pool', 'Number of samples', 'Tag index', 'Tag 2 index']
+    ['Source Well', 'Volume to add to pool', 'Dest. well', 'Number of samples', 'Tag index', 'Tag 2 index']
   end
 
   def get_column(csv, index)
@@ -27,8 +27,7 @@ RSpec.describe 'exports/cardinal_tagging_csv_for_custom_pooling.csv.erb' do
     expect(parsed_csv[0]).to eq expected_headers
 
     # Check one column at a time
-    barcode = labware.labware_barcode.human
-    expect(get_column(parsed_csv, 0)).to eq(["#{barcode}:A1", "#{barcode}:B1"])
+    expect(get_column(parsed_csv, 0)).to eq(['A1', 'B1'])
     expect(get_column(parsed_csv, 1)).to eq([nil, nil])
     expect(get_column(parsed_csv, 2)).to eq([nil, nil])
 
@@ -49,8 +48,7 @@ RSpec.describe 'exports/cardinal_tagging_csv_for_custom_pooling.csv.erb' do
       expect(parsed_csv.size).to eq 3
       expect(parsed_csv[0]).to eq expected_headers
 
-      barcode = labware.labware_barcode.human
-      expect(get_column(parsed_csv, 0)).to eq(["#{barcode}:A1", "#{barcode}:B1"])
+      expect(get_column(parsed_csv, 0)).to eq(['A1', 'B1'])
       expect(get_column(parsed_csv, 1)).to eq([nil, nil])
       expect(get_column(parsed_csv, 2)).to eq([nil, nil])
       expect(get_column(parsed_csv, 3)).to all(satisfy { |val| val.match(/^\d+$/) })
@@ -67,7 +65,7 @@ RSpec.describe 'exports/cardinal_tagging_csv_for_custom_pooling.csv.erb' do
       expect(parsed_csv.size).to eq 2
       expect(parsed_csv[0]).to eq expected_headers
 
-      expect(get_column(parsed_csv, 0)).to eq(["#{labware.labware_barcode.human}:B1"])
+      expect(get_column(parsed_csv, 0)).to eq(['B1'])
       expect(get_column(parsed_csv, 1)).to eq([nil])
       expect(get_column(parsed_csv, 2)).to eq([nil])
       expect(get_column(parsed_csv, 3)).to all(satisfy { |val| val.match(/^\d+$/) })
@@ -84,8 +82,7 @@ RSpec.describe 'exports/cardinal_tagging_csv_for_custom_pooling.csv.erb' do
       expect(parsed_csv.size).to eq 3
       expect(parsed_csv[0]).to eq expected_headers
 
-      barcode = labware.labware_barcode.human
-      expect(get_column(parsed_csv, 0)).to eq(["#{barcode}:A1", "#{barcode}:B1"])
+      expect(get_column(parsed_csv, 0)).to eq(['A1', 'B1'])
       expect(get_column(parsed_csv, 1)).to eq([nil, nil])
       expect(get_column(parsed_csv, 2)).to eq([nil, nil])
       expect(get_column(parsed_csv, 3)).to all(satisfy { |val| val.match(/^\d+$/) })
@@ -104,7 +101,7 @@ RSpec.describe 'exports/cardinal_tagging_csv_for_custom_pooling.csv.erb' do
       expect(parsed_csv.size).to eq 2
       expect(parsed_csv[0]).to eq expected_headers
 
-      expect(get_column(parsed_csv, 0)).to eq(["#{labware.labware_barcode.human}:B1"])
+      expect(get_column(parsed_csv, 0)).to eq(['B1'])
       expect(get_column(parsed_csv, 1)).to eq([nil])
       expect(get_column(parsed_csv, 2)).to eq([nil])
       expect(get_column(parsed_csv, 3)).to all(satisfy { |val| val.match(/^\d+$/) })
@@ -123,7 +120,7 @@ RSpec.describe 'exports/cardinal_tagging_csv_for_custom_pooling.csv.erb' do
       expect(parsed_csv.size).to eq 2
       expect(parsed_csv[0]).to eq expected_headers
 
-      expect(get_column(parsed_csv, 0)).to eq(["#{labware.labware_barcode.human}:B1"])
+      expect(get_column(parsed_csv, 0)).to eq(['B1'])
       expect(get_column(parsed_csv, 1)).to eq([nil])
       expect(get_column(parsed_csv, 2)).to eq([nil])
       expect(get_column(parsed_csv, 3)).to all(satisfy { |val| val.match(/^\d+$/) })

--- a/spec/views/exports/cardinal_tagging_csv_for_custom_pooling.csv.erb_spec.rb
+++ b/spec/views/exports/cardinal_tagging_csv_for_custom_pooling.csv.erb_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'exports/cardinal_tagging_csv_for_custom_pooling.csv.erb' do
     expect(parsed_csv[0]).to eq expected_headers
 
     # Check one column at a time
-    expect(get_column(parsed_csv, 0)).to eq(['A1', 'B1'])
+    expect(get_column(parsed_csv, 0)).to eq(%w[A1 B1])
     expect(get_column(parsed_csv, 1)).to eq([nil, nil])
     expect(get_column(parsed_csv, 2)).to eq([nil, nil])
 
@@ -48,7 +48,7 @@ RSpec.describe 'exports/cardinal_tagging_csv_for_custom_pooling.csv.erb' do
       expect(parsed_csv.size).to eq 3
       expect(parsed_csv[0]).to eq expected_headers
 
-      expect(get_column(parsed_csv, 0)).to eq(['A1', 'B1'])
+      expect(get_column(parsed_csv, 0)).to eq(%w[A1 B1])
       expect(get_column(parsed_csv, 1)).to eq([nil, nil])
       expect(get_column(parsed_csv, 2)).to eq([nil, nil])
       expect(get_column(parsed_csv, 3)).to all(satisfy { |val| val.match(/^\d+$/) })
@@ -82,7 +82,7 @@ RSpec.describe 'exports/cardinal_tagging_csv_for_custom_pooling.csv.erb' do
       expect(parsed_csv.size).to eq 3
       expect(parsed_csv[0]).to eq expected_headers
 
-      expect(get_column(parsed_csv, 0)).to eq(['A1', 'B1'])
+      expect(get_column(parsed_csv, 0)).to eq(%w[A1 B1])
       expect(get_column(parsed_csv, 1)).to eq([nil, nil])
       expect(get_column(parsed_csv, 2)).to eq([nil, nil])
       expect(get_column(parsed_csv, 3)).to all(satisfy { |val| val.match(/^\d+$/) })


### PR DESCRIPTION
Closes #770 

The page works as is, if you upload a csv in the format described on the page.

The changes here are to alter the csv download on the previous plate page, to be in a format that matches the upload. See commit message for details.