### PR TITLE
Add Duplex-Seq to ISC library filters

### DIFF
--- a/config/pipelines/high_throughput_isc.yml
+++ b/config/pipelines/high_throughput_isc.yml
@@ -6,6 +6,7 @@ ISC:
     - limber_reisc # Typically reISC begins on LB Lib PCR-XP
     library_type: # Taken from the library types on the above request types
     - Agilent Pulldown
+    - Duplex-Seq
     - Twist Pulldown
   library_pass:
   - LB Cap Lib PCR-XP
@@ -29,4 +30,3 @@ ISC MX:
   relationships:
     LB Cap Lib PCR-XP: LB Cap Lib Pool
     LB Cap Lib Pool: Cap Lib Pool Norm
-


### PR DESCRIPTION
This is to complement https://github.com/sanger/sequencescape/pull/3380 for https://github.com/sanger/sequencescape/issues/3379