### PR TITLE
Allow release of pipelines before they are ready

### DIFF
--- a/lib/config_loader/base.rb
+++ b/lib/config_loader/base.rb
@@ -9,6 +9,7 @@ module ConfigLoader
   class Base
     BASE_CONFIG_PATH = %w[config].freeze
     EXTENSION = '.yml'
+    WIP_EXTENSION = '.wip.yml'
 
     class_attribute :config_folder
 
@@ -21,7 +22,7 @@ module ConfigLoader
     #
     def initialize(files: nil, directory: default_path)
       path = directory.is_a?(Pathname) ? directory : Pathname.new(directory)
-      @files = path.children.select { |child| yaml?(child) && in_list?(files, child) }
+      @files = path.children.select { |child| yaml?(child) && in_list?(files, child) && !work_in_progress?(child) }
       load_config
     end
 
@@ -44,6 +45,10 @@ module ConfigLoader
 
     def in_list?(list, file)
       (list.nil? || list.include?(file.basename(EXTENSION).to_s))
+    end
+
+    def work_in_progress?(filename)
+      filename.to_s.end_with?(WIP_EXTENSION)
     end
 
     #


### PR DESCRIPTION
to allow release of pipelines before they are ready (feature flag ish)
- to get config loader to ignore config files that are not ready, change their extension to .wip.yml
- this will also prevent them from creating any data in the db

I tested this by doing the following:

- Reset SS db
- Switch to SS & Limber develop branches, run rake limber:setup and config:generate
- Switch back to cardinal develop branches
- Comment out SS Cardinal limber.rake stuff
- Change pipeline / purpose config file extensions to .wip.yml
- Run limber:setup and config:generate, see if it makes any of the cardinal data
- It didn't make any Cardinal data