### PR TITLE
Fix creator lookup when not configured

### DIFF
--- a/app/models/labware_creators.rb
+++ b/app/models/labware_creators.rb
@@ -13,7 +13,10 @@ module LabwareCreators # rubocop:todo Style/Documentation
   end
 
   def self.class_for(purpose_uuid)
-    refer = Settings.purposes.fetch(purpose_uuid).fetch(:creator_class)
+    # While most creators have a creator_class assigned by default, this wasn't the case with tube racks
+    # when first added. Here we fall back to 'LabwareCreators::Uncreatable' in cases where the purpose is
+    # not fully configured
+    refer = Settings.purposes.fetch(purpose_uuid, {}).fetch(:creator_class, 'LabwareCreators::Uncreatable')
     if refer.is_a?(String)
       refer.constantize
     else
@@ -22,7 +25,7 @@ module LabwareCreators # rubocop:todo Style/Documentation
   end
 
   def self.params_for(purpose_uuid)
-    refer = Settings.purposes.fetch(purpose_uuid).fetch(:creator_class)
+    refer = Settings.purposes.fetch(purpose_uuid, {}).fetch(:creator_class, 'LabwareCreators::Uncreatable')
     return { params: {} } if refer.is_a?(String)
 
     { params: refer[:params] }

--- a/spec/models/labware_creators_spec.rb
+++ b/spec/models/labware_creators_spec.rb
@@ -7,10 +7,13 @@ require 'labware_creators'
 RSpec.describe LabwareCreators do
   let(:basic_purpose)  { 'test-purpose' }
   let(:tagged_purpose) { 'dummy-purpose' }
+  let(:partial_purpose) { 'partial-purpose' }
 
   before do
     create :purpose_config, creator_class: 'LabwareCreators::StampedPlate', uuid: basic_purpose
     create :purpose_config, creator_class: 'LabwareCreators::TaggedPlate', uuid: tagged_purpose
+    create :purpose_config, uuid: partial_purpose
+    Settings.purposes[partial_purpose].delete(:creator_class)
   end
 
   it 'can lookup form for a given purpose' do
@@ -19,5 +22,9 @@ RSpec.describe LabwareCreators do
 
   it 'can lookup form for another purpose' do
     expect(LabwareCreators.class_for(tagged_purpose)).to eq(LabwareCreators::TaggedPlate)
+  end
+
+  it 'can handle partially configured purposes' do
+    expect(LabwareCreators.class_for(partial_purpose)).to eq(LabwareCreators::Uncreatable)
   end
 end


### PR DESCRIPTION
Tube racks currently don't have a default creator.
This change ensures we fall-back to an uncreatable creator in this
scenario.

Closes #

Changes proposed in this pull request:

*
*
* ...
