### PR TITLE
DPL-154 fix (multiple studies)

### DIFF
--- a/app/models/labware_creators/multi_stamp_tubes.rb
+++ b/app/models/labware_creators/multi_stamp_tubes.rb
@@ -47,6 +47,7 @@ module LabwareCreators
 
       transfer_material_from_parent!(child_v2)
 
+      child_v2 = Sequencescape::Api::V2.plate_with_custom_includes(PLATE_INCLUDES, uuid: @child.uuid) # reload to get the aliquots
       create_submission_from_child_plate(child_v2)
 
       yield(@child) if block_given?


### PR DESCRIPTION
Not sure if this was worth doing as DPL-074-1 (in progress) will be changing this bit of code, but UAT is currently broken so probably worth it to unblock that.

Need to reload the v2 plate to pull back the aliquots, as they are created during 'transfer_material_from_parent' - this means the submission will be created correctly - asset_groups was empty before
