### PR TITLE
DPL-187: New submission interface when submission failed

### DIFF
--- a/app/models/concerns/presenters/statemachine/submission.rb
+++ b/app/models/concerns/presenters/statemachine/submission.rb
@@ -68,6 +68,10 @@ module Presenters::Statemachine
 
         state :failed do
           include StateDoesNotAllowChildCreation
+
+          def sidebar_partial
+            'submission'
+          end
         end
 
         state :unknown do

--- a/spec/models/presenters/submission_plate_presenter_spec.rb
+++ b/spec/models/presenters/submission_plate_presenter_spec.rb
@@ -192,11 +192,50 @@ RSpec.describe Presenters::SubmissionPlatePresenter do
                               barcode_number: 2, pool_sizes: [2],
                               direct_submissions: submissions, state: state
     end
-    let(:submissions) { create_list :v2_submission, 1, state: 'cancelled' }
+    let(:submissions) { create_list :v2_submission, 1, state: state }
     let(:barcode_string) { 'DN2T' }
     let(:purpose_name) { 'Test Plate' }
     let(:title) { purpose_name }
     let(:state) { 'cancelled' }
+    let(:sidebar_partial) { 'submission' }
+    let(:summary_tab) do
+      [
+        %w[Barcode DN2T],
+        ['Number of wells', '2/96'],
+        ['Plate type', purpose_name],
+        ['Current plate state', state],
+        ['Input plate barcode', barcode_string],
+        ['Created on', '2017-06-29']
+      ]
+    end
+
+    it 'renders the submission options' do
+      expect { |b| presenter.each_submission_option(&b) }.to yield_successive_args(*template_options)
+    end
+
+    it 'has no pending submissions' do
+      # We have submissions, but they are built. pending_submissions? controls aspects like the
+      # refresh, that would be a nightmare if you were trying to set up a submission
+      expect(presenter.pending_submissions?).to eq false
+    end
+  end
+
+  context 'with failed submissions' do
+    # If our requests have been failed, then we're back at square 1
+
+    it_behaves_like 'a labware presenter'
+    it_behaves_like 'a stock presenter'
+
+    let(:labware) do
+      create :v2_stock_plate, purpose_name: purpose_name,
+                              barcode_number: 2, pool_sizes: [2],
+                              direct_submissions: submissions, state: state
+    end
+    let(:submissions) { create_list :v2_submission, 1, state: state }
+    let(:barcode_string) { 'DN2T' }
+    let(:purpose_name) { 'Test Plate' }
+    let(:title) { purpose_name }
+    let(:state) { 'failed' }
     let(:sidebar_partial) { 'submission' }
     let(:summary_tab) do
       [


### PR DESCRIPTION
Closes #929 

**Fair warning!**  I haven't been able to test this on my local machine as I can't seem to get a plate in the correct state with all the submissions to match.  I have been able to confirm that it theoretically works with the unit tests, but we can check it on UAT with http://uat.limber.psd.sanger.ac.uk/limber_plates/1addaa80-573d-11ec-8a99-fa163e1e3ca9 once it's been deployed.

Changes proposed in this pull request:

* Add submission creation to the sidebar of a submission plate if the previous submission became failed.
