### PR TITLE
Fix rare error handling bug

### DIFF
--- a/app/models/robots/bed/base.rb
+++ b/app/models/robots/bed/base.rb
@@ -24,6 +24,10 @@ module Robots::Bed
       true
     end
 
+    def error_messages
+      errors.full_messages.join(' ')
+    end
+
     def parent=(parent_bed)
       @parents = [parent_bed]
     end


### PR DESCRIPTION
We perform a last ditch validation on a bed before starting it.
Generally this should already have been gated by the previous step,
but if people use multiple tabs, manage to hit 'start robot' twice,
or something unexpected happens, we can hit here.

The previous error handling wasn't updated when the bed was migrated to
use the rails validation three years ago.

Closes #

Changes proposed in this pull request:

*
*
* ...
