### PR TITLE
Config change after UAT.

### DIFF
--- a/config/pipelines/high_throughput_targeted_nanoseq.yml
+++ b/config/pipelines/high_throughput_targeted_nanoseq.yml
@@ -3,8 +3,7 @@ Targeted NanoSeq:
   filters: &targeted_nanoseq_filters
     request_type_key: limber_targeted_nanoseq
     library_type:
-    - Targeted NanoSeq Pulldown Twist
-    - Targeted NanoSeq Pulldown Agilent
+    - Targeted NanoSeq
   library_pass: LTN Lib PCR XP
   relationships:
     LTN Stock: LTN Stock XP


### PR DESCRIPTION
Targeted Nanoseq library type will be used for the first half of the pipeline, then Twist and Agilent types for ReISC.

