### PR TITLE
DPL-213 show low molarity transfer

### DIFF
--- a/app/javascript/shared/tubeTransferVolumes.js
+++ b/app/javascript/shared/tubeTransferVolumes.js
@@ -31,17 +31,19 @@ const tubeMostRecentMolarity = function(tube) {
 // minimum_pick [Float] The minimum pick volume possible for both the sample and the buffer.
 //        Units should match the target_volume.
 //
-// [Object] An Object containing keys sampleVolume and bufferVolume for the transfer.
+// [Object] An Object containing keys sampleVolume, bufferVolume and belowTarget for the transfer.
 //          Volumes in the return Object use the same units as the target_volume parameter.
+//          The boolean returned in belowTarget indicates whether the target_molarity was achieved or
+//          if the actual molarity is below the target due to a weak concentration of source sample.
 const calculateTransferVolumes = function(target_molarity, target_volume, source_molarity, minimum_pick) {
   const calc_sample_volume = (target_molarity / source_molarity) * target_volume
   const sample_volume = Math.max(calc_sample_volume, minimum_pick)
   const buffer_volume = target_volume - sample_volume
 
   if (buffer_volume < minimum_pick) {
-    return { sampleVolume: target_volume, bufferVolume: 0 }
+    return { sampleVolume: target_volume, bufferVolume: 0, belowTarget: buffer_volume < 0 }
   } else {
-    return { sampleVolume: sample_volume, bufferVolume: buffer_volume }
+    return { sampleVolume: sample_volume, bufferVolume: buffer_volume, belowTarget: false }
   }
 }
 

--- a/app/javascript/shared/tubeTransferVolumes.spec.js
+++ b/app/javascript/shared/tubeTransferVolumes.spec.js
@@ -152,19 +152,20 @@ describe('calculateTransferVolumes', () => {
     })
 
     it('returns an object with the correct keys', () => {
-      expect(Object.keys(volumes)).toEqual(['sampleVolume', 'bufferVolume'])
+      expect(Object.keys(volumes)).toEqual(['sampleVolume', 'bufferVolume', 'belowTarget'])
     })
 
-    test.each(Object.keys(volumes))(
-      'returns an object with value for key %p as a Number',
-      (key) => {
-        expect(volumes[key]).toEqual(expect.any(Number))
+    test.each([['sampleVolume', Number], ['bufferVolume', Number], ['belowTarget', Boolean]])(
+      'returns an object with value for key %p as a %p',
+      (key, type) => {
+        expect(volumes[key]).toEqual(expect.any(type))
       }
     )
 
     it('returns the correctly calculated values', () => {
       expect(volumes.sampleVolume).toBeCloseTo(66.667, 3)
       expect(volumes.bufferVolume).toBeCloseTo(133.333, 3)
+      expect(volumes.belowTarget).toBe(false)
     })
   })
 
@@ -174,6 +175,7 @@ describe('calculateTransferVolumes', () => {
     it('returns the correctly calculated values', () => {
       expect(volumes.sampleVolume).toBe(200)
       expect(volumes.bufferVolume).toBe(0)
+      expect(volumes.belowTarget).toBe(true)
     })
   })
 
@@ -183,6 +185,7 @@ describe('calculateTransferVolumes', () => {
     it('returns the correctly calculated values', () => {
       expect(volumes.sampleVolume).toBe(200)
       expect(volumes.bufferVolume).toBe(0)
+      expect(volumes.belowTarget).toBe(false)
     })
   })
 
@@ -192,6 +195,7 @@ describe('calculateTransferVolumes', () => {
     it('returns the correctly calculated values', () => {
       expect(volumes.sampleVolume).toBe(2)
       expect(volumes.bufferVolume).toBe(198)
+      expect(volumes.belowTarget).toBe(false)
     })
   })
 })

--- a/app/javascript/validate-paired-tubes/components/TransferVolumes.spec.js
+++ b/app/javascript/validate-paired-tubes/components/TransferVolumes.spec.js
@@ -89,6 +89,25 @@ describe('TransferVolumes', () => {
     })
   })
 
+  describe('sourceMolarity', () => {
+    var wrapper
+    const sourceMolarity = 6
+
+    beforeEach(() => {
+      tubeMostRecentMolarity.mockReturnValue(sourceMolarity)
+      wrapper = wrapperFactory()
+    })
+
+    it('calls purposeTargetVolumeParameter with expected arguments', () => {
+      expect(tubeMostRecentMolarity.mock.calls.length).toBe(1)
+      expect(tubeMostRecentMolarity.mock.calls[0][0]).toBe(mockTube)
+    })
+
+    it('returns the expected target volume', () => {
+      expect(wrapper.vm.sourceMolarity).toBe(sourceMolarity)
+    })
+  })
+
   describe('transferVolumes', () => {
     var wrapper
     const targetMolarity = 4
@@ -130,7 +149,7 @@ describe('TransferVolumes', () => {
     })
   })
 
-  describe('sampleVolume', () => {
+  describe('sampleVolumeForDisplay', () => {
     var wrapper
     const transferVolumes = {
       sampleVolume: 150.12345,
@@ -143,11 +162,11 @@ describe('TransferVolumes', () => {
     })
 
     it('returns the expected sample volume', () => {
-      expect(wrapper.vm.sampleVolume).toBe('150.12')
+      expect(wrapper.vm.sampleVolumeForDisplay).toBe('150.12')
     })
   })
 
-  describe('bufferVolume', () => {
+  describe('bufferVolumeForDisplay', () => {
     var wrapper
     const transferVolumes = {
       sampleVolume: 150.12345,
@@ -160,7 +179,7 @@ describe('TransferVolumes', () => {
     })
 
     it('returns the expected buffer volume', () => {
-      expect(wrapper.vm.bufferVolume).toBe('49.88')
+      expect(wrapper.vm.bufferVolumeForDisplay).toBe('49.88')
     })
   })
 
@@ -214,13 +233,13 @@ describe('TransferVolumes', () => {
     })
 
     it('displays the target molarity', () => {
-      expect(wrapper.text()).toMatch(/4 nM/)
+      expect(wrapper.text()).toMatch(/4.00 nM/)
     })
 
     // Have to use \u03BC in place of µ symbol because JavaScript regex doesn't like it
 
     it('displays the target volume', () => {
-      expect(wrapper.text()).toMatch(/192 \u03BCl/)
+      expect(wrapper.text()).toMatch(/192.00 \u03BCl/)
     })
 
     it('displays the sample volume', () => {

--- a/app/javascript/validate-paired-tubes/components/TransferVolumes.spec.js
+++ b/app/javascript/validate-paired-tubes/components/TransferVolumes.spec.js
@@ -49,6 +49,25 @@ describe('TransferVolumes', () => {
     })
   })
 
+  describe('sourceMolarity', () => {
+    var wrapper
+    const sourceMolarity = 6
+
+    beforeEach(() => {
+      tubeMostRecentMolarity.mockReturnValue(sourceMolarity)
+      wrapper = wrapperFactory()
+    })
+
+    it('calls purposeTargetVolumeParameter with expected arguments', () => {
+      expect(tubeMostRecentMolarity.mock.calls.length).toBe(1)
+      expect(tubeMostRecentMolarity.mock.calls[0][0]).toBe(mockTube)
+    })
+
+    it('returns the expected target volume', () => {
+      expect(wrapper.vm.sourceMolarity).toBe(sourceMolarity)
+    })
+  })
+
   describe('targetMolarity', () => {
     var wrapper
     const molarity = 250
@@ -86,25 +105,6 @@ describe('TransferVolumes', () => {
 
     it('returns the expected target volume', () => {
       expect(wrapper.vm.targetVolume).toBe(volume)
-    })
-  })
-
-  describe('sourceMolarity', () => {
-    var wrapper
-    const sourceMolarity = 6
-
-    beforeEach(() => {
-      tubeMostRecentMolarity.mockReturnValue(sourceMolarity)
-      wrapper = wrapperFactory()
-    })
-
-    it('calls purposeTargetVolumeParameter with expected arguments', () => {
-      expect(tubeMostRecentMolarity.mock.calls.length).toBe(1)
-      expect(tubeMostRecentMolarity.mock.calls[0][0]).toBe(mockTube)
-    })
-
-    it('returns the expected target volume', () => {
-      expect(wrapper.vm.sourceMolarity).toBe(sourceMolarity)
     })
   })
 
@@ -161,7 +161,7 @@ describe('TransferVolumes', () => {
       wrapper = wrapperFactory()
     })
 
-    it('returns the expected sample volume', () => {
+    it('returns the expected sample volume string', () => {
       expect(wrapper.vm.sampleVolumeForDisplay).toBe('150.12')
     })
   })
@@ -178,8 +178,88 @@ describe('TransferVolumes', () => {
       wrapper = wrapperFactory()
     })
 
-    it('returns the expected buffer volume', () => {
+    it('returns the expected buffer volume string', () => {
       expect(wrapper.vm.bufferVolumeForDisplay).toBe('49.88')
+    })
+  })
+
+  describe('sourceMolarityForDisplay', () => {
+    var wrapper
+    const sourceMolarity = 3.4567
+
+    beforeEach(() => {
+      tubeMostRecentMolarity.mockReturnValue(sourceMolarity)
+      wrapper = wrapperFactory()
+    })
+
+    it('returns the expected source molarity string', () => {
+      expect(wrapper.vm.sourceMolarityForDisplay).toBe('3.46')
+    })
+
+  })
+
+  describe('targetMolarityForDisplay', () => {
+    var wrapper
+    const molarity = 5.6789
+
+    beforeEach(() => {
+      purposeConfigForTube.mockReturnValue(mockPurposeConfig)
+      purposeTargetMolarityParameter.mockReturnValue(molarity)
+      wrapper = wrapperFactory()
+    })
+
+    it('returns the expected target molarity string', () => {
+      expect(wrapper.vm.targetMolarityForDisplay).toBe('5.68')
+    })
+
+  })
+
+  describe('targetVolumeForDisplay', () => {
+    var wrapper
+    const volume = 25.6789
+
+    beforeEach(() => {
+      purposeConfigForTube.mockReturnValue(mockPurposeConfig)
+      purposeTargetVolumeParameter.mockReturnValue(volume)
+      wrapper = wrapperFactory()
+    })
+
+    it('returns the expected target volume string', () => {
+      expect(wrapper.vm.targetVolumeForDisplay).toBe('25.68')
+    })
+  })
+
+  describe('belowTargetMolarity', () => {
+    describe('is below target molarity', () => {
+      var wrapper
+      const transferVolumes = {
+        belowTarget: true
+      }
+
+      beforeEach(() => {
+        calculateTransferVolumes.mockReturnValue(transferVolumes)
+        wrapper = wrapperFactory()
+      })
+
+      it('returns the expected below target molarity value', () => {
+        expect(wrapper.vm.belowTargetMolarity).toBe(true)
+      })
+    })
+
+    describe('is not below target molarity', () => {
+      var wrapper
+      const transferVolumes = {
+        belowTarget: false
+      }
+
+      beforeEach(() => {
+        calculateTransferVolumes.mockReturnValue(transferVolumes)
+        wrapper = wrapperFactory()
+      })
+
+      it('returns the expected below target molarity value', () => {
+        expect(wrapper.vm.belowTargetMolarity).toBe(false)
+      })
     })
   })
 

--- a/app/javascript/validate-paired-tubes/components/TransferVolumes.vue
+++ b/app/javascript/validate-paired-tubes/components/TransferVolumes.vue
@@ -8,14 +8,21 @@
     </p>
     <div v-show="readyToDisplayResult">
       <p>
-        The transfer volumes shown are to make a {{ targetVolume }} μl / {{ targetMolarity }} nM solution.
+        The transfer volumes shown are to make a {{ targetVolumeForDisplay }} μl / {{ targetMolarityForDisplay }} nM solution.
       </p>
       <dl class="row metadata">
         <dt>Sample Volume</dt>
-        <dd>{{ sampleVolume }} μl</dd>
+        <dd>{{ sampleVolumeForDisplay }} μl</dd>
         <dt>Buffer Volume</dt>
-        <dd>{{ bufferVolume }} μl</dd>
+        <dd>{{ bufferVolumeForDisplay }} μl</dd>
       </dl>
+      <div v-show="belowTargetMolarity" class="alert alert-warning">
+        <h5>Insufficient Source Molarity</h5>
+        <p>
+          The source sample has a molarity of {{ sourceMolarityForDisplay }} nM which is below the target of {{ targetMolarityForDisplay }} nM.
+          The transfer as shown will not achieve the target molarity.
+        </p>
+      </div>
     </div>
   </b-card>
 </template>
@@ -46,6 +53,9 @@ export default {
     purposeConfig() {
       return purposeConfigForTube(this.tube, this.purposeConfigs)
     },
+    sourceMolarity() {
+      return tubeMostRecentMolarity(this.tube)
+    },
     targetMolarity() {
       return purposeTargetMolarityParameter(this.purposeConfig)
     },
@@ -53,15 +63,26 @@ export default {
       return purposeTargetVolumeParameter(this.purposeConfig)
     },
     transferVolumes() {
-      const sourceMolarity = tubeMostRecentMolarity(this.tube)
       const minimumPick = purposeMinimumPickParameter(this.purposeConfig)
-      return calculateTransferVolumes(this.targetMolarity, this.targetVolume, sourceMolarity, minimumPick)
+      return calculateTransferVolumes(this.targetMolarity, this.targetVolume, this.sourceMolarity, minimumPick)
     },
-    sampleVolume() {
+    sampleVolumeForDisplay() {
       return this.transferVolumes?.sampleVolume?.toFixed(2)
     },
-    bufferVolume() {
+    bufferVolumeForDisplay() {
       return this.transferVolumes?.bufferVolume?.toFixed(2)
+    },
+    sourceMolarityForDisplay() {
+      return this.sourceMolarity?.toFixed(2)
+    },
+    targetMolarityForDisplay() {
+      return this.targetMolarity?.toFixed(2)
+    },
+    targetVolumeForDisplay() {
+      return this.targetVolume?.toFixed(2)
+    },
+    belowTargetMolarity() {
+      return this.transferVolumes?.belowTarget
     },
     readyToDisplayResult() {
       return this.purposeConfig && this.confirmedPair


### PR DESCRIPTION
Closes #961 

Changes proposed in this pull request:

* Add a warning when the source concentration is lower than the target molarity.

I feel like I might have made a mistake getting this done in the calculated volume functions rather than just getting the Vue component to identify that the source molarity is lower than the target molarity, but actually I'm in two minds because it feels like logic the UI layer shouldn't need to deal with and this might be needed elsewhere as well without repeating the logic for when it applies.

![DPL-213](https://user-images.githubusercontent.com/1999241/149927941-d650cf80-34d4-4dec-9100-bd81b7029f03.png)

