### PR TITLE
Fix exception when tube not known to Limber

### DIFF
--- a/app/models/presenters/tube_presenter.rb
+++ b/app/models/presenters/tube_presenter.rb
@@ -72,7 +72,7 @@ module Presenters
     end
 
     def transfer_volumes?
-      !purpose_config.transfer_parameters.nil?
+      !purpose_config[:transfer_parameters].nil?
     end
   end
 end


### PR DESCRIPTION
This line was causing the following exception:
- undefined method 'transfer_parameters' for {}:Hash
- when loading a tube page where the tube type wasn't known to Limber i.e. wasn't in a pipeline

I ran the Heron integration suite tests (heron_lthr_pipeline_spec), which passed

I noticed the exception locally, but also in frequent emails from prod.