### PR TITLE
Delete misleading comment

### DIFF
--- a/app/controllers/pipeline_work_in_progress_controller.rb
+++ b/app/controllers/pipeline_work_in_progress_controller.rb
@@ -6,8 +6,6 @@ class PipelineWorkInProgressController < ApplicationController
   def show
     @pipeline = params[:id].capitalize
 
-    # Doesn't currently include 'Tailed MX' pipelines -
-    # Could be added in future if needed although might cause an issue as there might be loads of tubes in the final purpose
     # TODO: Add 'pipeline_group' or similar to pipeline config ymls, to group related ones together
     # So that it can work for all pipelines
     heron_pipeline_name_to_configs = {


### PR DESCRIPTION
This comment is no longer correct, since the new request type does include the multiplexing step.