### PR TITLE
Int Suite test fix, take 2

### DIFF
--- a/app/views/labware/_content_header.html.erb
+++ b/app/views/labware/_content_header.html.erb
@@ -5,7 +5,7 @@
     <%= image_tag("icon_#{presenter.priority}_flag.png", size: "32x32") if presenter.try(:priority)%>
   </h2>
   <dl class="descriptive-list-inline">
-    <dt>Labware Barcode</dt> <dd><%= presenter.barcode %></dd>
+    <dt>Labware barcode</dt> <dd><%= presenter.barcode %></dd>
     <dt>Input</dt> <dd><%= presenter.input_barcode %></dd>
   </dl>
 </div>


### PR DESCRIPTION
Previous commit (https://github.com/sanger/limber/pull/1071/commits/cf3370c1b76f7e08f4d1bfd9dded89a54980b693) wasn't effective because:
- the test selects elements with text 'Barcode' and adding 'Labware' on front doesn't exclude the element
- however, if we change the 'B' to lower case (which is also consistent with how the other fields on the page are formatted), it should work
