### PR TITLE
DPL-610: Add filter for the final column on work in progress views

### DIFF
--- a/.github/workflows/ruby_test.yml
+++ b/.github/workflows/ruby_test.yml
@@ -15,6 +15,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Export node version
+        id: node_version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/app/controllers/pipeline_work_in_progress_controller.rb
+++ b/app/controllers/pipeline_work_in_progress_controller.rb
@@ -11,7 +11,7 @@ class PipelineWorkInProgressController < ApplicationController
 
     @ordered_purpose_list = Settings.pipelines.combine_and_order_pipelines(pipelines_for_group)
 
-    labware_records = arrange_labware_records(@ordered_purpose_list)
+    labware_records = arrange_labware_records(@ordered_purpose_list, from_date(params))
 
     @grouped = mould_data_for_view(@ordered_purpose_list, labware_records)
   end
@@ -23,12 +23,12 @@ class PipelineWorkInProgressController < ApplicationController
   # Split out requests for the last purpose and the rest of the purposes so that
   # the labware for the last purpose can be filtered by those that have
   # ancestors including at least one purpose from the rest.
-  def arrange_labware_records(ordered_purposes)
+  def arrange_labware_records(ordered_purposes, from_date)
     page_size = 500
 
     specific_purposes = ordered_purposes.first(ordered_purposes.count - 1)
-    specific_labware_records = retrieve_labware(page_size, from_date(params), specific_purposes)
-    general_labware_records = retrieve_labware(page_size, from_date(params), ordered_purposes.last)
+    specific_labware_records = retrieve_labware(page_size, from_date, specific_purposes)
+    general_labware_records = retrieve_labware(page_size, from_date, ordered_purposes.last)
 
     specific_labware_records +
       filter_labware_records_by_ancestor_purpose_names(general_labware_records, specific_purposes)

--- a/spec/controllers/pipeline_work_in_progress_controller_spec.rb
+++ b/spec/controllers/pipeline_work_in_progress_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PipelineWorkInProgressController, type: :controller do
 
   describe 'GET show' do
     let(:purposes) { create_list :v2_purpose, 2 }
-    let(:purpose_names) { purposes.map &:name }
+    let(:purpose_names) { purposes.map(&:name) }
     let(:labware) { create_list :labware, 2, purpose: purposes[0] }
 
     before do
@@ -48,10 +48,11 @@ RSpec.describe PipelineWorkInProgressController, type: :controller do
 
   describe '#mould_data_for_view' do
     let(:purposes) { create_list :v2_purpose, 2 }
-    let(:purpose_names) { purposes.map &:name }
+    let(:purpose_names) { purposes.map(&:name) }
     let(:labware_record_no_state) { create :labware, purpose: purposes[0] }
     let(:labware_record_passed) { create :labware_with_state_changes, purpose: purposes[0], target_state: 'passed' }
-    let(:labware_record_cancelled) { create :labware_with_state_changes, purpose: purposes[0], target_state: 'cancelled' }
+    let(:labware_record_cancelled) do
+ create :labware_with_state_changes, purpose: purposes[0], target_state: 'cancelled' end
     let(:labware_records) { [labware_record_no_state, labware_record_passed, labware_record_cancelled] }
 
     it 'returns the correct format' do
@@ -72,7 +73,7 @@ RSpec.describe PipelineWorkInProgressController, type: :controller do
     let(:pipeline_purposes) { create_list :v2_purpose, 3 }
     let(:another_purpose) { create :v2_purpose }
 
-    let(:pipeline_purpose_names) { pipeline_purposes.map &:name }
+    let(:pipeline_purpose_names) { pipeline_purposes.map(&:name) }
 
     let(:pipeline_ancestor1) { create :labware, purpose: pipeline_purposes[0] }
     let(:pipeline_ancestor2) { create :labware, purpose: pipeline_purposes[1] }
@@ -83,9 +84,13 @@ RSpec.describe PipelineWorkInProgressController, type: :controller do
     let(:valid_labware3) { create :labware, purpose: pipeline_purposes[1], ancestors: [pipeline_ancestor1] }
     let(:valid_labware4) { create :labware, purpose: pipeline_purposes[2], ancestors: [pipeline_ancestor1] }
     let(:valid_labware5) { create :labware, purpose: pipeline_purposes[2], ancestors: [pipeline_ancestor2] }
-    let(:valid_labware6) { create :labware, purpose: pipeline_purposes[2], ancestors: [pipeline_ancestor1, pipeline_ancestor2] }
-    let(:valid_labware7) { create :labware, purpose: pipeline_purposes[2], ancestors: [pipeline_ancestor1, pipeline_ancestor2, another_ancestor] }
-    let(:valid_labware) { [valid_labware1, valid_labware2, valid_labware3, valid_labware4, valid_labware5, valid_labware6, valid_labware7] }
+    let(:valid_labware6) do
+ create :labware, purpose: pipeline_purposes[2], ancestors: [pipeline_ancestor1, pipeline_ancestor2] end
+    let(:valid_labware7) do
+ create :labware, purpose: pipeline_purposes[2], 
+ancestors: [pipeline_ancestor1, pipeline_ancestor2, another_ancestor] end
+    let(:valid_labware) do
+ [valid_labware1, valid_labware2, valid_labware3, valid_labware4, valid_labware5, valid_labware6, valid_labware7] end
 
     let(:invalid_labware1) { create :labware, purpose: pipeline_purposes[2] }
     let(:invalid_labware2) { create :labware, purpose: pipeline_purposes[2], ancestors: [another_ancestor]}

--- a/spec/controllers/pipeline_work_in_progress_controller_spec.rb
+++ b/spec/controllers/pipeline_work_in_progress_controller_spec.rb
@@ -52,14 +52,15 @@ RSpec.describe PipelineWorkInProgressController, type: :controller do
     let(:labware_record_no_state) { create :labware, purpose: purposes[0] }
     let(:labware_record_passed) { create :labware_with_state_changes, purpose: purposes[0], target_state: 'passed' }
     let(:labware_record_cancelled) do
- create :labware_with_state_changes, purpose: purposes[0], target_state: 'cancelled' end
+      create :labware_with_state_changes, purpose: purposes[0], target_state: 'cancelled'
+    end
     let(:labware_records) { [labware_record_no_state, labware_record_passed, labware_record_cancelled] }
 
     it 'returns the correct format' do
       expected_output = {
         purposes[0].name => [
           { record: labware_record_no_state, state: 'pending' },
-          { record: labware_record_passed, state: 'passed' },
+          { record: labware_record_passed, state: 'passed' }
           # cancelled one not present
         ],
         purposes[1].name => []
@@ -85,15 +86,19 @@ RSpec.describe PipelineWorkInProgressController, type: :controller do
     let(:valid_labware4) { create :labware, purpose: pipeline_purposes[2], ancestors: [pipeline_ancestor1] }
     let(:valid_labware5) { create :labware, purpose: pipeline_purposes[2], ancestors: [pipeline_ancestor2] }
     let(:valid_labware6) do
- create :labware, purpose: pipeline_purposes[2], ancestors: [pipeline_ancestor1, pipeline_ancestor2] end
+      create :labware, purpose: pipeline_purposes[2], ancestors: [pipeline_ancestor1, pipeline_ancestor2]
+    end
     let(:valid_labware7) do
- create :labware, purpose: pipeline_purposes[2], 
-ancestors: [pipeline_ancestor1, pipeline_ancestor2, another_ancestor] end
+      create :labware,
+             purpose: pipeline_purposes[2],
+             ancestors: [pipeline_ancestor1, pipeline_ancestor2, another_ancestor]
+    end
     let(:valid_labware) do
- [valid_labware1, valid_labware2, valid_labware3, valid_labware4, valid_labware5, valid_labware6, valid_labware7] end
+      [valid_labware1, valid_labware2, valid_labware3, valid_labware4, valid_labware5, valid_labware6, valid_labware7]
+    end
 
     let(:invalid_labware1) { create :labware, purpose: pipeline_purposes[2] }
-    let(:invalid_labware2) { create :labware, purpose: pipeline_purposes[2], ancestors: [another_ancestor]}
+    let(:invalid_labware2) { create :labware, purpose: pipeline_purposes[2], ancestors: [another_ancestor] }
     let(:invalid_labware) { [invalid_labware1, invalid_labware2] }
 
     let(:all_labware) { valid_labware + invalid_labware }

--- a/spec/controllers/pipeline_work_in_progress_controller_spec.rb
+++ b/spec/controllers/pipeline_work_in_progress_controller_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe PipelineWorkInProgressController, type: :controller do
   let(:controller) { described_class.new }
 
   describe 'GET show' do
-    let(:labware) { create_list :labware_with_purpose, 2 }
-    let(:purposes) { labware.map { |lw| lw.purpose.name } }
+    let(:purposes) { create_list :v2_purpose, 2 }
+    let(:purpose_names) { purposes.map &:name }
+    let(:labware) { create_list :labware, 2, purpose: purposes[0] }
 
     before do
-      labware.each { |lw| lw.ancestors = [] }
-      allow(Settings.pipelines).to receive(:combine_and_order_pipelines).and_return(purposes)
+      allow(Settings.pipelines).to receive(:combine_and_order_pipelines).and_return(purpose_names)
       allow(Sequencescape::Api::V2).to receive(:merge_page_results).and_return(labware)
     end
 
@@ -47,28 +47,63 @@ RSpec.describe PipelineWorkInProgressController, type: :controller do
   end
 
   describe '#mould_data_for_view' do
-    let(:labware_record_no_state) { create :labware_with_purpose }
-    let(:labware_record_passsed) { create :labware_with_state_changes, target_state: 'passed' }
-    let(:labware_record_cancelled) { create :labware_with_state_changes, target_state: 'cancelled' }
-    let(:labware_records) { [labware_record_no_state, labware_record_passsed, labware_record_cancelled] }
-    let(:purposes) { labware_records.map { |lw| lw.purpose.name } }
-
-    let(:expected_output) do
-      {
-        labware_record_no_state.purpose.name => [
-          { record: labware_record_no_state, state: 'pending' }
-        ],
-        labware_record_passsed.purpose.name => [
-          { record: labware_record_passsed, state: 'passed' }
-        ],
-        labware_record_cancelled.purpose.name => [
-          # cancelled one not present
-        ]
-      }
-    end
+    let(:purposes) { create_list :v2_purpose, 2 }
+    let(:purpose_names) { purposes.map &:name }
+    let(:labware_record_no_state) { create :labware, purpose: purposes[0] }
+    let(:labware_record_passed) { create :labware_with_state_changes, purpose: purposes[0], target_state: 'passed' }
+    let(:labware_record_cancelled) { create :labware_with_state_changes, purpose: purposes[0], target_state: 'cancelled' }
+    let(:labware_records) { [labware_record_no_state, labware_record_passed, labware_record_cancelled] }
 
     it 'returns the correct format' do
-      expect(controller.mould_data_for_view(purposes, labware_records)).to eq expected_output
+      expected_output = {
+        purposes[0].name => [
+          { record: labware_record_no_state, state: 'pending' },
+          { record: labware_record_passed, state: 'passed' },
+          # cancelled one not present
+        ],
+        purposes[1].name => []
+      }
+
+      expect(controller.mould_data_for_view(purpose_names, labware_records)).to eq expected_output
+    end
+  end
+
+  describe '#arrange_labware_records' do
+    let(:pipeline_purposes) { create_list :v2_purpose, 3 }
+    let(:another_purpose) { create :v2_purpose }
+
+    let(:pipeline_purpose_names) { pipeline_purposes.map &:name }
+
+    let(:pipeline_ancestor1) { create :labware, purpose: pipeline_purposes[0] }
+    let(:pipeline_ancestor2) { create :labware, purpose: pipeline_purposes[1] }
+    let(:another_ancestor) { create :labware, purpose: another_purpose }
+
+    let(:valid_labware1) { create :labware, purpose: pipeline_purposes[0] }
+    let(:valid_labware2) { create :labware, purpose: pipeline_purposes[1] }
+    let(:valid_labware3) { create :labware, purpose: pipeline_purposes[1], ancestors: [pipeline_ancestor1] }
+    let(:valid_labware4) { create :labware, purpose: pipeline_purposes[2], ancestors: [pipeline_ancestor1] }
+    let(:valid_labware5) { create :labware, purpose: pipeline_purposes[2], ancestors: [pipeline_ancestor2] }
+    let(:valid_labware6) { create :labware, purpose: pipeline_purposes[2], ancestors: [pipeline_ancestor1, pipeline_ancestor2] }
+    let(:valid_labware7) { create :labware, purpose: pipeline_purposes[2], ancestors: [pipeline_ancestor1, pipeline_ancestor2, another_ancestor] }
+    let(:valid_labware) { [valid_labware1, valid_labware2, valid_labware3, valid_labware4, valid_labware5, valid_labware6, valid_labware7] }
+
+    let(:invalid_labware1) { create :labware, purpose: pipeline_purposes[2] }
+    let(:invalid_labware2) { create :labware, purpose: pipeline_purposes[2], ancestors: [another_ancestor]}
+    let(:invalid_labware) { [invalid_labware1, invalid_labware2] }
+
+    let(:all_labware) { valid_labware + invalid_labware }
+    let(:specific_labware) { all_labware.select { |lw| pipeline_purposes.take(2).include? lw.purpose } }
+    let(:general_labware) { all_labware.select { |lw| lw.purpose == pipeline_purposes.last } }
+
+    before do
+      allow(Sequencescape::Api::V2).to receive(:merge_page_results).and_return(specific_labware, general_labware)
+    end
+
+    it 'filters the final purpose for labware with ancestors from previous purposes' do
+      actual = controller.arrange_labware_records(pipeline_purpose_names, '2020-08-25')
+      expected = valid_labware
+
+      expect(actual).to eq expected
     end
   end
 end

--- a/spec/factories/labware_factories.rb
+++ b/spec/factories/labware_factories.rb
@@ -13,24 +13,26 @@ FactoryBot.define do
     uuid
     type { 'labware' }
 
+    transient do
+      purpose { nil }
+      ancestors { [] }
+    end
+
     factory(:labware_plate) { type { 'plates' } }
     factory(:labware_tube) { type { 'tubes' } }
     factory(:labware_tube_rack) { type { 'tube_racks' } }
 
-    factory(:labware_with_purpose) do
-      purpose { create :v2_purpose }
+    after(:build) do |labware, evaluator|
+      # see plate_factories -> v2_plate factory -> after(:build) for an explanation of _cached_relationship
+      # basically, it allows you to call .purpose on the labware and get a Sequencescape::Api::V2::Purpose
+      labware._cached_relationship(:purpose) { evaluator.purpose } if evaluator.purpose
+      labware._cached_relationship(:ancestors) { evaluator.ancestors } if evaluator.ancestors
+    end
 
-      after(:build) do |labware, evaluator|
-        # see plate_factories -> v2_plate factory -> after(:build) for an explanation of _cached_relationship
-        # basically, it allows you to call .purpose on the labware and get a Sequencescape::Api::V2::Purpose
-        labware._cached_relationship(:purpose) { evaluator.purpose }
-      end
+    factory(:labware_with_state_changes) do
+      state_changes { create_list :v2_state_change, 2, target_state: target_state }
 
-      factory(:labware_with_state_changes) do
-        state_changes { create_list :v2_state_change, 2, target_state: target_state }
-
-        after(:build) { |labware, evaluator| labware._cached_relationship(:state_changes) { evaluator.state_changes } }
-      end
+      after(:build) { |labware, evaluator| labware._cached_relationship(:state_changes) { evaluator.state_changes } }
     end
   end
 end

--- a/spec/factories/plate_purpose_factories.rb
+++ b/spec/factories/plate_purpose_factories.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   # Basic v2 Plate Purpose
   factory :v2_purpose, class: Sequencescape::Api::V2::Purpose, traits: [:barcoded_v2] do
     skip_create
-    name { 'Limber Example Purpose' }
+    sequence(:name) { |n| "Limber Example Purpose #{n}" }
     uuid { 'example-purpose-uuid' }
   end
 


### PR DESCRIPTION
The final column needs to be pared down to only those labware where they have an ancestor with a purpose matching one of the earlier columns.

Closes #1221 