### PR TITLE
Switch WIP views to use updated_at instead of created_at

### DIFF
--- a/app/controllers/pipeline_work_in_progress_controller.rb
+++ b/app/controllers/pipeline_work_in_progress_controller.rb
@@ -50,13 +50,13 @@ class PipelineWorkInProgressController < ApplicationController
     labware_query =
       Sequencescape::Api::V2::Labware
         .select(
-          { plates: %w[uuid purpose labware_barcode state_changes created_at ancestors] },
-          { tubes: %w[uuid purpose labware_barcode state_changes created_at ancestors] },
+          { plates: %w[uuid purpose labware_barcode state_changes updated_at ancestors] },
+          { tubes: %w[uuid purpose labware_barcode state_changes updated_at ancestors] },
           { purposes: 'name' }
         )
         .includes(:state_changes, :purpose, 'ancestors.purpose')
-        .where(without_children: true, purpose_name: purposes, created_at_gt: from_date)
-        .order(:created_at)
+        .where(without_children: true, purpose_name: purposes, updated_at_gt: from_date)
+        .order(:updated_at)
         .per(page_size)
 
     Sequencescape::Api::V2.merge_page_results(labware_query)

--- a/app/views/pipeline_work_in_progress/show.html.erb
+++ b/app/views/pipeline_work_in_progress/show.html.erb
@@ -19,7 +19,7 @@
               <%= link_to "#{labware.labware_barcode&.human}", url_for(labware) %><br/>
               <%= labware.input_barcode %><br/>
               <%= labware_data[:state] %><br/>
-              <%= "created #{labware.created_at.strftime("%d/%m/%y")}" %>
+              <%= "updated #{labware.updated_at.strftime("%d/%m/%y")}" %>
             <% end %>
           <% end %>
         <% end %>


### PR DESCRIPTION
Closes #1220 

Changes proposed in this pull request:

* Change work in progress views to show updated at times for labware rather than created at.
