### PR TITLE
Bioscan uat updates from testing 24th May

### DIFF
--- a/app/models/labware_creators/pooled_tubes_from_whole_plates.rb
+++ b/app/models/labware_creators/pooled_tubes_from_whole_plates.rb
@@ -63,5 +63,10 @@ module LabwareCreators
     def plate_search
       api.search.find(Settings.searches['Find plates'])
     end
+
+    def number_of_parent_labwares
+      # default to 4 if value not found in config
+      purpose_config.fetch(:number_of_parent_labwares, 4)
+    end
   end
 end

--- a/app/models/labware_creators/pooled_tubes_from_whole_tubes.rb
+++ b/app/models/labware_creators/pooled_tubes_from_whole_tubes.rb
@@ -56,9 +56,9 @@ module LabwareCreators
       errors.add(:barcodes, "could not be found: #{missing_barcodes}")
     end
 
-    def number_of_parent_tubes
+    def number_of_parent_labwares
       # default to 4 if value not found in config
-      purpose_config.fetch(:number_of_parent_tubes, 4)
+      purpose_config.fetch(:number_of_parent_labwares, 4)
     end
 
     private

--- a/app/models/labware_creators/stamped_plate_adding_randomised_controls.rb
+++ b/app/models/labware_creators/stamped_plate_adding_randomised_controls.rb
@@ -41,11 +41,11 @@ module LabwareCreators
     # generate randomised well locations for each control
     # rubocop:todo Metrics/MethodLength
     def generate_control_well_locations
-      control_locations = []
       max_retries = 5
       retries_count = 0
 
       until retries_count >= max_retries
+        control_locations = []
         list_of_controls.count.times do |_control_index|
           # sample a random parent well and fetch its location (child not created yet)
           location = parent.wells.sample.position['name']

--- a/app/views/tube_creation/pooled_tubes_from_whole_plates.html.erb
+++ b/app/views/tube_creation/pooled_tubes_from_whole_plates.html.erb
@@ -7,7 +7,7 @@
       <div id="validation_report"></div>
       <div id="add-plates-instructions-block" class="card-body" >
         <div class="instructions">
-          <p>Scan in up to 4 plates.</p>
+          <p>Scan in up to <%= @labware_creator.number_of_parent_labwares.to_s %> plate(s).</p>
         </div>
       </div>
       <div class="card-body">
@@ -19,7 +19,7 @@
 
         <%= form.hidden_field :parent_uuid %>
         <%= form.hidden_field :purpose_uuid %>
-        <% 4.times do |i| %>
+        <% @labware_creator.number_of_parent_labwares.times do |i| %>
           <div class="plate-container scan-plate form-group row">
             <label for="tube[barocdes][<%= i %>]" class="plate-label col-2" >Plate <%= i+1 %></label>
             <input id="tube[barocdes][<%= i %>]" name="tube[barcodes][]" class="form-control plate-box col-8" tabindex="1" data-position=<%= i %> data-labware-type="plate"/>

--- a/app/views/tube_creation/pooled_tubes_from_whole_tubes.html.erb
+++ b/app/views/tube_creation/pooled_tubes_from_whole_tubes.html.erb
@@ -7,7 +7,7 @@
       <div id="validation_report"></div>
       <div id="add-tubes-instructions-block" class="card-body" >
         <div class="instructions">
-          <p>Scan in up to <%= @labware_creator.number_of_parent_tubes.to_s %> tubes.</p>
+          <p>Scan in up to <%= @labware_creator.number_of_parent_labwares.to_s %> tube(s).</p>
         </div>
       </div>
       <div class="card-body">
@@ -19,7 +19,7 @@
 
         <%= form.hidden_field :parent_uuid %>
         <%= form.hidden_field :purpose_uuid %>
-        <% @labware_creator.number_of_parent_tubes.times do |i| %>
+        <% @labware_creator.number_of_parent_labwares.times do |i| %>
           <div class="plate-container scan-plate form-group row">
             <label for="tube[barcodes][<%= i %>]" class="plate-label col-2" >Tube <%= i+1 %></label>
             <input id="tube[barcodes][<%= i %>]" name="tube[barcodes][]" class="form-control plate-box col-8" tabindex="1" data-position=<%= i %> data-labware-type="tube"/>

--- a/config/purposes/bioscan.yml
+++ b/config/purposes/bioscan.yml
@@ -41,8 +41,7 @@ LBSN-384 PCR 1:
   :asset_type: plate
   :creator_class: LabwareCreators::QuadrantStamp
   :merger_plate: true
-  # TODO: what presenter should this plate have?
-  # :presenter_class: Presenters::?
+  :presenter_class: Presenters::MinimalPcrPlatePresenter
   :label_template: plate_6mm_double
   :size: 384
 LBSN-384 PCR 2:

--- a/config/purposes/bioscan.yml
+++ b/config/purposes/bioscan.yml
@@ -84,12 +84,13 @@ LBSN-384 PCR 2 Pool:
   :creator_class: LabwareCreators::PooledTubesFromWholePlates
   :transfer_template: '384 plate to tube'
   :presenter_class: Presenters::SimpleTubePresenter
+  :number_of_parent_labwares: 1
 LBSN-9216 Lib PCR Pool:
   :asset_type: tube
   :target: StockMultiplexedLibraryTube
   :type: IlluminaHtp::StockTubePurpose
   :creator_class: LabwareCreators::PooledTubesFromWholeTubes
-  :number_of_parent_tubes: 24
+  :number_of_parent_labwares: 24
   :presenter_class: Presenters::SimpleTubePresenter
 LBSN-9216 Lib PCR Pool XP:
   :asset_type: tube

--- a/config/purposes/bioscan.yml
+++ b/config/purposes/bioscan.yml
@@ -37,7 +37,7 @@ LBSN-96 Lysate:
       value:
         - H1
         - G1
-    - type: well_restrictions
+    - type: well_exclusions
       value:
         - H12
 LBSN-384 PCR 1:

--- a/config/robots.rb
+++ b/config/robots.rb
@@ -2800,8 +2800,8 @@ ROBOT_CONFIG =
       }
     )
 
-    # Bioscan robots
-
+    # Bioscan Beckman bed verification
+    # LILYS-96 Stock ethanol removal step
     custom_robot(
       'beckman-lilys-96-stock-preparation',
       name: 'Beckman LILYS-96 Stock Preparation',
@@ -2816,6 +2816,9 @@ ROBOT_CONFIG =
       }
     )
 
+    # Bioscan Beckman bed verification
+    # LILYS-96 Stock to LBSN-96 Lysate
+    # one to one stamp with added randomised controls
     custom_robot(
       'beckman-lilys-96-stock-to-lbsn-96-lysate',
       name: 'Beckman LILYS-96 Stock => LBSN-96 Lysate',
@@ -2837,6 +2840,9 @@ ROBOT_CONFIG =
       }
     )
 
+    # Bioscan Mosquito bed verification
+    # LBSN-96 Lysate plates to LBSN-384 PCR 1
+    # transfers up to 4 plates into the 384 destination
     custom_robot(
       'mosquito-lbsn-96-lysate-to-lbsn-384-pcr-1',
       name: 'Mosquito LBSN-96 Lysate => LBSN-384 PCR 1',
@@ -2876,6 +2882,43 @@ ROBOT_CONFIG =
       },
       destination_bed: bed(5).barcode,
       class: 'Robots::QuadrantRobot'
+    )
+
+    # Bioscan Mosquito bed verification
+    # LBSN-384 PCR 1 to LBSN-384 PCR 2
+    # transfers up to 2 pairs of plates at a time
+    custom_robot(
+      'mosquito-lbsn-384-pcr-1-to-lbsn-384-pcr-2',
+      name: 'Mosquito LBSN-384 PCR 1 => LBSN-384 PCR 2',
+      require_robot: true,
+      beds: {
+        bed(2).barcode => {
+          purpose: 'LBSN-384 PCR 1',
+          states: ['passed'],
+          child: bed(3).barcode,
+          label: 'Bed 2'
+        },
+        bed(3).barcode => {
+          purpose: 'LBSN-384 PCR 2',
+          states: ['pending'],
+          label: 'Bed 3',
+          parent: bed(2).barcode,
+          target_state: 'passed'
+        },
+        bed(4).barcode => {
+          purpose: 'LBSN-384 PCR 1',
+          states: ['passed'],
+          child: bed(5).barcode,
+          label: 'Bed 4'
+        },
+        bed(5).barcode => {
+          purpose: 'LBSN-384 PCR 2',
+          states: ['pending'],
+          label: 'Bed 5',
+          parent: bed(4).barcode,
+          target_state: 'passed'
+        }
+      }
     )
 
     # hamilton robot for stamping deep well stock plates to shallow well stock plates

--- a/docs/presenters.md
+++ b/docs/presenters.md
@@ -48,8 +48,8 @@ scRNA-384 cDNA-XP and scRNA-384 End Prep
 
 {include:Presenters::MinimalPcrPlatePresenter}
 
-Used directly in 10 purposes:
-pWGS-384 Lib PCR, LTHR-384 Lib PCR 1, LTHR-384 Lib PCR 2, LBSN-384 PCR 2, LHR-384 Lib PCR, GBS PCR1, GBS PCR2, LTHR Lib PCR 1, LTHR Lib PCR 2, and scRNA-384 Lib PCR
+Used directly in 11 purposes:
+pWGS-384 Lib PCR, LTHR-384 Lib PCR 1, LTHR-384 Lib PCR 2, LBSN-384 PCR 1, LBSN-384 PCR 2, LHR-384 Lib PCR, GBS PCR1, GBS PCR2, LTHR Lib PCR 1, LTHR Lib PCR 2, and scRNA-384 Lib PCR
 
 {Presenters::MinimalPcrPlatePresenter View class documentation}
 
@@ -88,8 +88,8 @@ LTN AL Lib Dil and LDS AL Lib Dil
 
 {include:Presenters::StandardPresenter}
 
-Used directly in 89 purposes:
-LBC 5p GEX Frag 2XP, LB Lib PrePool, LB Hyb, LB Cap Lib, LB Cap Lib PCR, LB Cap Lib PCR-XP, LB Cap Lib Pool, CLCM Stock, CLCM Lysate DNA, CLCM DNA End Prep, CLCM DNA Lib PCR XP, CLCM Lysate RNA, CLCM RT PreAmp, CLCM RNA End Prep, CLCM RNA Lib PCR XP, pWGS-384 Post Shear XP, pWGS-384 AL Lib, PF Shear, PF Post Shear, PF Post Shear XP, PF-384 Post Shear XP, PF End Prep, PF-384 End Prep, PF Lib XP, PF-384 Lib XP2, PF Lib XP2, LTHR-384 RT-Q, LTHR-384 PCR 1, LTHR-384 PCR 2, LTHR-384 Lib PCR pool, LBSN-384 PCR 1, LBR Globin, LBR Frag cDNA, LTN Shear, LTN Post Shear, LTN Stock XP, LTN AL Lib, LTN Lib PCR XP, LBC BCR Dil 1, LBC BCR Enrich1 2XSPRI, LBC BCR Enrich2 2XSPRI, LBC BCR Dil 2, LBC BCR Post PCR, GnT scDNA, GnT Pico-XP, GnT Pico End Prep, LB Shear, LB Post Shear, LB End Prep, LB Lib PCR-XP, LDS Stock XP, LDS AL Lib, LDS Lib PCR XP, LHR-384 PCR 1, LHR-384 PCR 2, LHR-384 cDNA, LHR-384 XP, LHR-384 AL Lib, LBC Aggregate, LBC Cherrypick, LCA Blood Array, LCA PBMC, LCA PBMC Pools, LCA 10X cDNA, LCA Blood Bank, LCA PBMC Bank, LBC TCR Dil 1, LBC TCR Enrich1 2XSPRI, LBC TCR Enrich2 2XSPRI, LBC TCR Dil 2, LBC TCR Post PCR, LTHR RT-S, LTHR PCR 1, LTHR PCR 2, LTHR Lib PCR pool, LSW-96 Stock, LBB Ligation, LBB Lib-XP, LBB Enriched BCR, LBB Enriched BCR HT, LBB Enriched TCR, LBB Enriched TCR HT, LBC 3pV3 GEX Frag 2XP, scRNA cDNA-XP, scRNA End Prep, LHR PCR 1, LHR PCR 2, LHR XP, and LHR End Prep
+Used directly in 88 purposes:
+LBC 5p GEX Frag 2XP, LB Lib PrePool, LB Hyb, LB Cap Lib, LB Cap Lib PCR, LB Cap Lib PCR-XP, LB Cap Lib Pool, CLCM Stock, CLCM Lysate DNA, CLCM DNA End Prep, CLCM DNA Lib PCR XP, CLCM Lysate RNA, CLCM RT PreAmp, CLCM RNA End Prep, CLCM RNA Lib PCR XP, pWGS-384 Post Shear XP, pWGS-384 AL Lib, PF Shear, PF Post Shear, PF Post Shear XP, PF-384 Post Shear XP, PF End Prep, PF-384 End Prep, PF Lib XP, PF-384 Lib XP2, PF Lib XP2, LTHR-384 RT-Q, LTHR-384 PCR 1, LTHR-384 PCR 2, LTHR-384 Lib PCR pool, LBR Globin, LBR Frag cDNA, LTN Shear, LTN Post Shear, LTN Stock XP, LTN AL Lib, LTN Lib PCR XP, LBC BCR Dil 1, LBC BCR Enrich1 2XSPRI, LBC BCR Enrich2 2XSPRI, LBC BCR Dil 2, LBC BCR Post PCR, GnT scDNA, GnT Pico-XP, GnT Pico End Prep, LB Shear, LB Post Shear, LB End Prep, LB Lib PCR-XP, LDS Stock XP, LDS AL Lib, LDS Lib PCR XP, LHR-384 PCR 1, LHR-384 PCR 2, LHR-384 cDNA, LHR-384 XP, LHR-384 AL Lib, LBC Aggregate, LBC Cherrypick, LCA Blood Array, LCA PBMC, LCA PBMC Pools, LCA 10X cDNA, LCA Blood Bank, LCA PBMC Bank, LBC TCR Dil 1, LBC TCR Enrich1 2XSPRI, LBC TCR Enrich2 2XSPRI, LBC TCR Dil 2, LBC TCR Post PCR, LTHR RT-S, LTHR PCR 1, LTHR PCR 2, LTHR Lib PCR pool, LSW-96 Stock, LBB Ligation, LBB Lib-XP, LBB Enriched BCR, LBB Enriched BCR HT, LBB Enriched TCR, LBB Enriched TCR HT, LBC 3pV3 GEX Frag 2XP, scRNA cDNA-XP, scRNA End Prep, LHR PCR 1, LHR PCR 2, LHR XP, and LHR End Prep
 
 {Presenters::StandardPresenter View class documentation}
 

--- a/spec/models/labware_creators/pooled_tubes_from_whole_plates_spec.rb
+++ b/spec/models/labware_creators/pooled_tubes_from_whole_plates_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe LabwareCreators::PooledTubesFromWholePlates, with: :uploader do
   include FeatureHelpers
   it_behaves_like 'it only allows creation from tagged plates'
 
-  # let(:custom_page) { 'pooled_tubes_from_whole_plates' }
-
   subject { described_class.new(api, form_attributes) }
 
   it 'should have page' do

--- a/spec/models/labware_creators/stamped_plate_adding_randomised_controls_spec.rb
+++ b/spec/models/labware_creators/stamped_plate_adding_randomised_controls_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe LabwareCreators::StampedPlateAddingRandomisedControls do
       before { allow(subject).to receive(:validate_control_rules).and_return(true) }
 
       it 'returns the expected number of locations' do
-        expect(subject.generate_control_well_locations.length).to eq 2
+        expect(subject.generate_control_well_locations.length).to eq subject.list_of_controls.length
       end
     end
 


### PR DESCRIPTION
- added Mosquito bed verification for PCR 2 step (it does move the yellow 'perform pcr' down so less visible)
- limited plate scan boxes to 1 on pooling into 384 tube
- changed PCR 1 step to also use the Limber PCR presenter so visibly you see the same screen for both PCR 1 and 2 steps