### PR TITLE
Set label template options to avoid using defaults

### DIFF
--- a/app/models/labels/base.rb
+++ b/app/models/labels/base.rb
@@ -33,17 +33,28 @@ class Labels::Base # rubocop:todo Style/Documentation
 
   delegate :workline_identifier, to: :labware
 
+  # Returns printer type name for the label. It is configured for label
+  # definitions in label_templates.yml and corresponds to one of the values
+  # in name column of barcode_printer_types table in sequencescape database.
   def printer_type
-    config.fetch(:printer_type, default_printer_type)
+    # NB. We are using short-circuit-or to avoid unnecessary method evaluation
+    # instead of Hash.fetch with the default argument as a method call.
+    config[:printer_type] || default_printer_type
   end
 
   def label_template
-    config.fetch(:pmb_template, default_label_template)
+    # NB. We are using short-circuit-or to avoid unnecessary method evaluation
+    # instead of Hash.fetch with the default argument as a method call.
+    config[:pmb_template] || default_label_template
   end
 
   def label_templates_by_service
-    pmb_template = config.fetch(:pmb_template, default_label_template)
-    sprint_template = config.fetch(:sprint_template, default_sprint_label_template)
+    # NB. Make sure label_templates.yml contains settings for label definitions
+    # explicity, in order to avoid incorrect results. The lines below do not 
+    # work as intended because the config is filled with default values for 
+    # missing settings by PurposeConfig class.
+    pmb_template = config[:pmb_template] || default_label_template
+    sprint_template = config[:sprint_template] || default_sprint_label_template
     { 'PMB' => pmb_template, 'SPrint' => sprint_template }
   end
 
@@ -53,15 +64,21 @@ class Labels::Base # rubocop:todo Style/Documentation
     @config ||= Settings.purposes.fetch(labware.purpose&.uuid, {})
   end
 
-  def default_printer_type_for(printer_type)
-    Settings.default_printer_type_names[printer_type]
+  # NB. The argument in the following methods was renamed from "printer_type" 
+  # to "key" to avoid confusion. It can be one of the keys in 
+  # default_printer_type_names section of label_templates.yml config file.
+  # It is used for accessing an option for a printer type in default_* 
+  # sections. 
+
+  def default_printer_type_for(key)
+    Settings.default_printer_type_names[key]
   end
 
-  def default_label_template_for(printer_type)
-    Settings.default_pmb_templates[printer_type]
+  def default_label_template_for(key)
+    Settings.default_pmb_templates[key]
   end
 
-  def default_sprint_label_template_for(printer_type)
-    Settings.default_sprint_templates[printer_type]
+  def default_sprint_label_template_for(key)
+    Settings.default_sprint_templates[key]
   end
 end

--- a/app/models/labels/base.rb
+++ b/app/models/labels/base.rb
@@ -50,8 +50,8 @@ class Labels::Base # rubocop:todo Style/Documentation
 
   def label_templates_by_service
     # NB. Make sure label_templates.yml contains settings for label definitions
-    # explicity, in order to avoid incorrect results. The lines below do not 
-    # work as intended because the config is filled with default values for 
+    # explicity, in order to avoid incorrect results. The lines below do not
+    # work as intended because the config is filled with default values for
     # missing settings by PurposeConfig class.
     pmb_template = config[:pmb_template] || default_label_template
     sprint_template = config[:sprint_template] || default_sprint_label_template
@@ -64,11 +64,11 @@ class Labels::Base # rubocop:todo Style/Documentation
     @config ||= Settings.purposes.fetch(labware.purpose&.uuid, {})
   end
 
-  # NB. The argument in the following methods was renamed from "printer_type" 
-  # to "key" to avoid confusion. It can be one of the keys in 
+  # NB. The argument in the following methods was renamed from "printer_type"
+  # to "key" to avoid confusion. It can be one of the keys in
   # default_printer_type_names section of label_templates.yml config file.
-  # It is used for accessing an option for a printer type in default_* 
-  # sections. 
+  # It is used for accessing an option for a printer type in default_*
+  # sections.
 
   def default_printer_type_for(key)
     Settings.default_printer_type_names[key]

--- a/config/label_templates.yml
+++ b/config/label_templates.yml
@@ -17,13 +17,14 @@ default_printer_type_names:
   :tube_rack: 96 Well Plate
   :tube: 1D Tube
 
+# NB. plate_384.yml.erb is for printing double-sticker 384-well plate labels.
 plate_6mm_double:
   :label_class: Labels::PlateDoubleLabel
   :printer_type: 384 Well Plate Double
   :pmb_template: plate_6mm_double_code39
   :sprint_template: plate_384.yml.erb
 
-# The following label defintion is not used by the current Heron pipeline.
+# The following label definition is not used by the current Heron (LTHR-384) pipeline.
 plate_6mm_double_qc:
   :label_class: Labels::PlateDoubleLabelQc
   :printer_type: 384 Well Plate Double

--- a/config/label_templates.yml
+++ b/config/label_templates.yml
@@ -21,33 +21,46 @@ plate_6mm_double:
   :label_class: Labels::PlateDoubleLabel
   :printer_type: 384 Well Plate Double
   :pmb_template: plate_6mm_double_code39
+  :sprint_template: plate_384.yml.erb
 
+# The following label defintion is not used by the current Heron pipeline.
 plate_6mm_double_qc:
   :label_class: Labels::PlateDoubleLabelQc
   :printer_type: 384 Well Plate Double
   :pmb_template: plate_6mm_double_code39
+  :sprint_template: plate_384.yml.erb
 
 plate_xp:
   :label_class: Labels::PlateLabelXp
+  :printer_type: 96 Well Plate
   :pmb_template: sqsc_96plate_label_template_code39
+  :sprint_template: plate_96.yml.erb
 
 plate_split:
   :label_class: Labels::PlateSplit
+  :printer_type: 96 Well Plate
   :pmb_template: sqsc_96plate_label_template_code39
+  :sprint_template: plate_96.yml.erb
 
 plate_lds_al_lib:
   :label_class: Labels::PlateLabelLdsAlLib
+  :printer_type: 96 Well Plate
   :pmb_template: sqsc_96plate_label_template_code39
+  :sprint_template: plate_96.yml.erb
 
 plate_ltn_al_lib:
   :label_class: Labels::PlateLabelLtnAlLib
+  :printer_type: 96 Well Plate
   :pmb_template: sqsc_96plate_label_template_code39
+  :sprint_template: plate_96.yml.erb
 
 plate_cellaca_qc:
   :label_class: Labels::PlateLabelCellacaQc
+  :printer_type: 96 Well Plate
   :pmb_template: sqsc_96plate_label_template_code39
+  :sprint_template: plate_96.yml.erb
 
-# Only Squix printers are used through SPrint for tube_traction_compatible
+# Only Squix printers are used through SPrint for tube_traction_compatible.
 # pmb_template setting is for completeness; it is not used.
 tube_traction_compatible:
   :label_class: Labels::TubeLabelTractionCompatible
@@ -55,8 +68,11 @@ tube_traction_compatible:
   :pmb_template: tube_label_template_1d
   :sprint_template: tube_label_traction_compatible.yml.erb
 
-# Only Squix printers are used through SPrint for plate_384_single
-# pmb_template setting is for completeness; it is not used.
+# Only Squix printers are used through SPrint for plate_384_single.
+# pmb_template setting is for completeness; it is not used. Although 
+# it is for printing single-sticker labels, printer_type is set to 
+# "384 Well Plate Double" because barcode_printers table of sequencescape
+# database use "384 Well Plate Double" for all 384-well plate printers.
 plate_384_single:
   :label_class: Labels::Plate384SingleLabel
   :printer_type: 384 Well Plate Double

--- a/config/label_templates.yml
+++ b/config/label_templates.yml
@@ -70,8 +70,8 @@ tube_traction_compatible:
   :sprint_template: tube_label_traction_compatible.yml.erb
 
 # Only Squix printers are used through SPrint for plate_384_single.
-# pmb_template setting is for completeness; it is not used. Although 
-# it is for printing single-sticker labels, printer_type is set to 
+# pmb_template setting is for completeness; it is not used. Although
+# it is for printing single-sticker labels, printer_type is set to
 # "384 Well Plate Double" because barcode_printers table of sequencescape
 # database use "384 Well Plate Double" for all 384-well plate printers.
 plate_384_single:

--- a/lib/purpose_config.rb
+++ b/lib/purpose_config.rb
@@ -117,6 +117,9 @@ class PurposeConfig
     }
   end
 
+  # NB. Make sure label_templates.yml contains settings for label definitions
+  # explicity, in order to avoid incorrect results. The options below are used
+  # for assigning values for missing settings.
   def default_printer_options
     {
       printer_type: default_printer_type,


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

- Set label template options in label_templates.yml explicitly to fix heron 384-well plates label printing bug reported in RT 784533 .

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check version_  
