### PR TITLE
Dpl 908 purpose config

### DIFF
--- a/app/models/labware_creators/pooled_wells_by_sample_in_groups.rb
+++ b/app/models/labware_creators/pooled_wells_by_sample_in_groups.rb
@@ -12,12 +12,9 @@ module LabwareCreators
   class PooledWellsBySampleInGroups < Base
     include SupportParent::PlateOnly
 
-    # By default, source wells with the sample are pooled in pairs.
-    DEFAULT_NUMBER_OF_SOURCE_WELLS = 2
-
     # Number of source wells with the same sample to be pooled.
     def number_of_source_wells
-      purpose_config[:number_of_source_wells] || DEFAULT_NUMBER_OF_SOURCE_WELLS
+      @number_of_source_wells ||= purpose_config.dig(:creator_class, :args, :number_of_source_wells)
     end
 
     # Well filter with this object as the creator

--- a/config/purposes/scrna_core_cell_extraction.wip.yml
+++ b/config/purposes/scrna_core_cell_extraction.wip.yml
@@ -53,11 +53,13 @@ LRC Blood Bank:
 LRC PBMC Bank:
   :asset_type: plate
   # Labware creator for pooling isolations by sample before cell counting
-  :creator_class: LabwareCreators::PooledWellsBySampleInGroups
+  :creator_class:
+    name: LabwareCreators::PooledWellsBySampleInGroups
+    args:
+      # number of source wells to pool into a single destination well by sample from LRC Bank to LRC PBMC Bank
+      # e.g. 6 copies of sample in 6 wells, '2' in the config, pool to make 3 child wells
+      number_of_source_wells: 2
   :label_template: plate_cellaca_qc # creates QC1 up to QC4 barcodes
-  # number of source wells to pool into a single destination well by sample from LRC Bank to LRC PBMC Bank
-  # e.g. 6 copies of sample in 6 wells, '2' in the config, pool to make 3 child wells
-  :number_of_source_wells: 2
   :file_links:
     - name: 'Download Cellaca Input QC1'
       id: cellaca_input_file

--- a/docs/creators.md
+++ b/docs/creators.md
@@ -252,7 +252,8 @@ Labware creators are responsible for creating new labware from a parent labware.
 
 {include:LabwareCreators::MultiStampLibrarySplitter}
 
-  **This labware creator is unused**
+  Used directly in 2 purposes:
+  CLCM Lysate DNA and CLCM Lysate RNA
 
 {LabwareCreators::MultiStampLibrarySplitter View class documentation}
 
@@ -300,8 +301,8 @@ Labware creators are responsible for creating new labware from a parent labware.
 
 {include:LabwareCreators::MultiStampTubes}
 
-  Used directly in 1 purposes:
-  LCA Blood Array
+  Used directly in 3 purposes:
+  LRC Blood Bank, LCA Blood Array, and LCA Blood Bank
 
 {LabwareCreators::MultiStampTubes View class documentation}
 
@@ -310,7 +311,8 @@ Labware creators are responsible for creating new labware from a parent labware.
 
 {include:LabwareCreators::PlateSplitToTubeRacks}
 
-  **This labware creator is unused**
+  Used directly in 2 purposes:
+  LRC Bank Seq and LRC Bank Spare
 
 {LabwareCreators::PlateSplitToTubeRacks View class documentation}
 

--- a/lib/tasks/docs_update.rake
+++ b/lib/tasks/docs_update.rake
@@ -9,7 +9,12 @@ namespace :docs do
 
     Settings.purposes.each_value do |purpose|
       used_presenter[purpose['presenter_class']] << purpose['name']
-      used_creator[purpose['creator_class']] << purpose['name']
+
+      # If creator_class is a hash, then we get the name from the hash instead.
+      cls = purpose['creator_class']
+      key = cls.is_a?(Hash) ? cls['name'] : cls
+      used_creator[key] << purpose['name']
+
       used_state_changer[purpose['state_changer_class']] << purpose['name']
     end
 

--- a/spec/factories/purpose_config_factories.rb
+++ b/spec/factories/purpose_config_factories.rb
@@ -239,6 +239,19 @@ FactoryBot.define do
       ancestor_stock_tube_purpose_name { 'Ancestor Tube Purpose' }
     end
 
+    # Configuration to set number_of_source_wells argument
+    factory :pooled_wells_by_sample_in_groups_purpose_config do
+      transient { number_of_source_wells { 2 } }
+      creator_class do
+        {
+          name: 'LabwareCreators::PooledWellsBySampleInGroups',
+          args: {
+            number_of_source_wells: number_of_source_wells
+          }
+        }
+      end
+    end
+
     # Basic tube purpose configuration
     factory :tube_config do
       asset_type { 'tube' }

--- a/spec/models/labware_creators/pooled_wells_by_sample_in_groups_spec.rb
+++ b/spec/models/labware_creators/pooled_wells_by_sample_in_groups_spec.rb
@@ -35,19 +35,11 @@ RSpec.describe LabwareCreators::PooledWellsBySampleInGroups do
   end
 
   describe '#number_of_source_wells' do
-    context 'when purpose_config includes number_of_source_wells' do
-      before { create(:purpose_config, uuid: child_purpose_uuid, number_of_source_wells: 3) }
-
-      it 'returns the number of source wells from the purpose_config' do
-        expect(subject.number_of_source_wells).to eq(3)
-      end
+    before do
+      create(:pooled_wells_by_sample_in_groups_purpose_config, uuid: child_purpose_uuid, number_of_source_wells: 3)
     end
-
-    context 'when purpose_config does not include number_of_source_wells' do
-      before { create(:purpose_config, uuid: child_purpose_uuid) }
-      it 'returns the default number of source wells' do
-        expect(subject.number_of_source_wells).to eq(2)
-      end
+    it 'returns the number of source wells from the purpose_config' do
+      expect(subject.number_of_source_wells).to eq(3)
     end
   end
 

--- a/spec/models/labware_creators/pooled_wells_by_sample_in_groups_spec.rb
+++ b/spec/models/labware_creators/pooled_wells_by_sample_in_groups_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe LabwareCreators::PooledWellsBySampleInGroups do
   let(:child_plate) { create(:v2_plate, uuid: child_plate_uuid) }
   subject { described_class.new(api, form_attributes) }
   before do
+    # Create a purpose config for the plate (number_of_source_wells is 2)
+    create(:pooled_wells_by_sample_in_groups_purpose_config, uuid: child_purpose_uuid)
     allow(subject).to receive(:parent).and_return(parent_plate)
     stub_v2_plate(parent_plate, stub_search: false)
     stub_v2_plate(child_plate, stub_search: false)
@@ -36,6 +38,7 @@ RSpec.describe LabwareCreators::PooledWellsBySampleInGroups do
 
   describe '#number_of_source_wells' do
     before do
+      # Use a different purpose config for this test (number_of_source_wells is 3)
       create(:pooled_wells_by_sample_in_groups_purpose_config, uuid: child_purpose_uuid, number_of_source_wells: 3)
     end
     it 'returns the number of source wells from the purpose_config' do


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- number_of_source_wells setting is specific to the PooledWellsBySampleInGroups labware creator. Therefore, it is moved to the args section under creator_class of LRC PBMC Bank purpose.

- docs/creators.md was incorrectly reporting that the labware creator is not used for any purpose. The issue has been fixed by checking if creator_class is a hash and getting the name instead. This fixes the incorrect documentation for labware creators of other purposes as well.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
