### PR TITLE
feat: add tooltips to labware state and priority

### DIFF
--- a/app/helpers/page_helper.rb
+++ b/app/helpers/page_helper.rb
@@ -53,7 +53,7 @@ module PageHelper # rubocop:todo Style/Documentation
   # eg. state_badge('pending')
   # <span class="state-badge-pending">Pending</span>
   def state_badge(state)
-    tag.span(state.titleize, class: "state-badge #{state}")
+    tag.span(state.titleize, class: "state-badge #{state}", title: 'Labware State', data: { toggle: 'tooltip' })
   end
 
   # eg. count_badge(0)

--- a/app/views/labware/_content_header.html.erb
+++ b/app/views/labware/_content_header.html.erb
@@ -2,7 +2,17 @@
   <h2 id="<%= type %>-title" class="card-title">
     <%= presenter.title %>
     <%= state_badge(presenter.state) %>
-    <%= image_tag("icon_#{presenter.priority}_flag.png", size: "32x32") if presenter.try(:priority)%>
+    <% if presenter.try(:priority) %>
+      <%
+        # Priorities are defined in Sequencescape:app/models/sample.rb
+        priorities = {0=>:no_priority, 1=>:backlog, 2=>:surveillance, 3=>:priority}
+      %>
+      <%= image_tag("icon_#{presenter.priority}_flag.png",
+            size: "32x32",
+            title: "Labware Priority: #{priorities[presenter.priority].to_s.titleize}",
+            data: { toggle: 'tooltip' }
+          ) %>
+    <% end %>
   </h2>
   <dl class="descriptive-list-inline">
     <dt>Barcode</dt> <dd><%= presenter.barcode %></dd>


### PR DESCRIPTION
Reduces confusion over states and icons in the Limber UI.

#### Changes proposed in this pull request

- Add tooltip indicating Labware State
- Add tooltip indicating Priority

<img width="480" alt="Screenshot 2023-11-30 at 15 50 03" src="https://github.com/sanger/limber/assets/135011085/1769152b-0ceb-4e20-9791-628aed91f2ae">

<img width="554" alt="Screenshot 2023-11-30 at 15 50 13" src="https://github.com/sanger/limber/assets/135011085/a7e33cd5-55dd-42c9-9bb8-117cf41b9395">

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
