### PR TITLE
Bioscan barcode label changes

### DIFF
--- a/app/models/labels/tube_label_traction_compatible.rb
+++ b/app/models/labels/tube_label_traction_compatible.rb
@@ -38,10 +38,9 @@ class Labels::TubeLabelTractionCompatible < Labels::TubeLabel
   end
 
   def first_line
-    # Parent barcode for PCR 2 Pool tube.
-    # This is the asset name (plate barcode and well range)
-    barcode_and_wells_format = /^.+?\s[A-Z]\d{1,2}:[A-Z]\d{1,2}$/
-    return labware.name if labware.name&.match?(barcode_and_wells_format)
+    # Parent barcode followed by well range from labware.name for PCR2 Pool tube.
+    match = labware.name.match(/^.+?\s([A-Z]\d{1,2}:[A-Z]\d{1,2})$/)
+    return "#{labware.parents[0].barcode.human} #{match[1]}" if match
 
     # Parent barcode for Lib PCR Pool and Lib PCR XP tubes
     labware.parents[0].barcode.human

--- a/config/purposes/bioscan.yml
+++ b/config/purposes/bioscan.yml
@@ -49,16 +49,16 @@ LBSN-384 PCR 1:
   :presenter_class: Presenters::MinimalPcrPlatePresenter
   :label_template: plate_384_single
   :size: 384
-  # LILYS plate barcode is shown on barcode label top-right if possible; LYSATE otherwise.
-  :alternative_workline_identifier: LILYS-96 Stock
+  # LYSATE plate barcode is shown on barcode label top-right
+  :alternative_workline_identifier: LBSN-96 Lysate
 LBSN-384 PCR 2:
   :asset_type: plate
   :creator_class: LabwareCreators::TaggedPlate
   :presenter_class: Presenters::MinimalPcrPlatePresenter
   :label_template: plate_384_single
   :size: 384
-  # LILYS plate barcode is shown on barcode label top-right if possible; LYSATE otherwise.
-  :alternative_workline_identifier: LILYS-96 Stock
+  # LYSATE plate barcode is shown on barcode label top-right
+  :alternative_workline_identifier: LBSN-96 Lysate
   # NB. will need to update this list to include new versions of the templates
   # as we generate new sets after changes from the scripts in Sequencescape
   :tag_layout_templates:

--- a/spec/models/labels/tube_label_traction_compatible_spec.rb
+++ b/spec/models/labels/tube_label_traction_compatible_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe Labels::TubeLabelTractionCompatible, type: :model do
   end
 
   context 'when labware name contains plate and well range' do
-    let(:labware) { build :v2_tube, name: 'SQPT-12345-H A1:P24', parents: [build(:v2_tube)] }
+    let(:labware) { build :v2_tube, name: 'SQPT-12345-H A1:P24', parents: [build(:v2_plate)] }
 
     it 'has the correct attributes' do
       attributes = label.attributes
-      expect(attributes[:first_line]).to eq labware.name
+      expect(attributes[:first_line]).to eq "#{labware.parents[0].barcode.human} #{labware.name.split.last}"
       expect(attributes[:second_line]).to match(/, P/)
       expect(attributes[:third_line]).to eq labware.purpose.name
       expect(attributes[:fourth_line]).to eq Time.zone.today.strftime('%e-%^b-%Y')


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- For `LBSN-384 PCR 1` and `LBSN-384 PCR 2` plates, show an`LBSN-96 Lysate` barcode in the top-right corner
- For `LBSN-384 PCR 2 Pool` tube, the first line shows the immediate parent `LBSN-384 PCR 2` plate barcode followed by well range extracted from `labware.name`

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
