### PR TITLE
fix: add 'requireTubePassed' parameter to MultiStampTubes

### DIFF
--- a/app/javascript/multi-stamp-tubes/components/MultiStampTubes.vue
+++ b/app/javascript/multi-stamp-tubes/components/MultiStampTubes.vue
@@ -133,6 +133,10 @@ export default {
     // Should tube duplication validation be included or skipped
     // Also referenced as allow-tube-duplicates and allow_tube_duplicates
     allowTubeDuplicates: { type: String, required: true },
+
+    // Should tubes be required to be in passed state
+    // Also referenced as require-tube-passed and require_tube_passed
+    requireTubePassed: { type: String, required: true },
   },
   data() {
     return {
@@ -215,7 +219,9 @@ export default {
       return filterProps.tubeFields
     },
     scanValidation() {
-      const validators = [checkState(['unknown', 'passed'])]
+      const validators = []
+
+      if (this.requireTubePassed === 'true') validators.push(checkState(['passed']))
 
       if (this.allowTubeDuplicates === 'true') return validators
 

--- a/app/models/labware_creators/multi_stamp_tubes.rb
+++ b/app/models/labware_creators/multi_stamp_tubes.rb
@@ -27,6 +27,10 @@ module LabwareCreators
       params.fetch('allow_tube_duplicates', false)
     end
 
+    def require_tube_passed?
+      params.fetch('require_tube_passed', false)
+    end
+
     private
 
     def create_labware!

--- a/app/views/plate_creation/multi_stamp_tubes.html.erb
+++ b/app/views/plate_creation/multi_stamp_tubes.html.erb
@@ -10,6 +10,7 @@
      data-target-columns="<%= @labware_creator.target_columns %>"
      data-source-tubes="<%= @labware_creator.source_tubes %>"
      data-allow-tube-duplicates="<%= @labware_creator.allow_tube_duplicates? %>"
+     data-require-tube-passed="<%= @labware_creator.require_tube_passed? %>"
      >
   <div class="spinner-dark">Loading...</div>
 </div>

--- a/config/purposes/scrna_core_cell_extraction.wip.yml
+++ b/config/purposes/scrna_core_cell_extraction.wip.yml
@@ -37,6 +37,7 @@ LRC Blood Bank:
     name: LabwareCreators::MultiStampTubes
     params:
       allow_tube_duplicates: yes
+      require_tube_passed: yes
   :submission_options:
     scRNA core cell extraction:
       template_name: 'Limber - scRNA Core Cell Extraction'

--- a/docs/presenters.md
+++ b/docs/presenters.md
@@ -34,6 +34,26 @@ LBC 3pV3 GEX Dil
 {Presenters::ConcentrationBinnedPlatePresenter View class documentation}
 
 
+### Presenters::StockPlatePresenter
+
+{include:Presenters::StockPlatePresenter}
+
+Used directly in 16 purposes:
+GnT Stock, LB Cherrypick, LBB Cherrypick, LBC Stock, LBR Cherrypick, LCMB Cherrypick, LDS Cherrypick, LDS Stock, LHR RT, LHR-384 RT, LTHR RT, LTHR-384 RT, LTN Cherrypick, LTN Stock, PF Cherrypicked, and scRNA Stock
+
+{Presenters::StockPlatePresenter View class documentation}
+
+
+### Presenters::FailableStockPlatePresenter
+
+{include:Presenters::FailableStockPlatePresenter}
+
+Used directly in 2 purposes:
+LBSN-96 Lysate and LILYS-96 Stock
+
+{Presenters::FailableStockPlatePresenter View class documentation}
+
+
 ### Presenters::MinimalPlatePresenter
 
 {include:Presenters::MinimalPlatePresenter}
@@ -132,16 +152,6 @@ Used directly in 1 purposes:
 PF Lib Q-XP2
 
 {Presenters::SplitPresenter View class documentation}
-
-
-### Presenters::StockPlatePresenter
-
-{include:Presenters::StockPlatePresenter}
-
-Used directly in 18 purposes:
-GnT Stock, LB Cherrypick, LBB Cherrypick, LBC Stock, LBR Cherrypick, LBSN-96 Lysate, LCMB Cherrypick, LDS Cherrypick, LDS Stock, LHR RT, LHR-384 RT, LILYS-96 Stock, LTHR RT, LTHR-384 RT, LTN Cherrypick, LTN Stock, PF Cherrypicked, and scRNA Stock
-
-{Presenters::StockPlatePresenter View class documentation}
 
 
 ### Presenters::SubmissionPlatePresenter


### PR DESCRIPTION
Closes https://github.com/sanger/General-Backlog-Items/issues/353, linked to #1437 

#### Changes proposed in this pull request

- add `requireTubePassed` to MultiStampTubes
  - this allows state validation to be enabled on a per labware (and therefore pipeline) basis
  - sets `require_tube_passed: yes` for the scRNA extraction pipeline
  - implemented in the same manner as `allowTubeDuplicates`

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
