### PR TITLE
docs: remove unused template doc folder

### DIFF
--- a/doc/README_FOR_APP
+++ b/doc/README_FOR_APP
@@ -1,2 +1,0 @@
-Use this README file to introduce your application and point to useful places in the API for learning more.
-Run "rake doc:app" to generate API documentation for your models, controllers, helpers, and libraries.


### PR DESCRIPTION
#### Changes proposed in this pull request

- Removes an unused template file, removing the `/doc` folder
  - The actual used `/docs` folder remains
  - Makes it slightly easier to find internal docs

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
