### PR TITLE
fix: reorder Cellaca buttons

### DIFF
--- a/config/purposes/scrna_core_cell_extraction.yml
+++ b/config/purposes/scrna_core_cell_extraction.yml
@@ -63,6 +63,12 @@ LRC PBMC Bank:
       number_of_source_wells: 2
   :label_template: plate_cellaca_qc # creates QC1 up to QC4 barcodes
   :file_links:
+    - name: 'Download Hamilton LRC Blood Bank plate to LRC PBMC Bank plate CSV'
+      id: hamilton_lrc_blood_bank_to_lrc_pbmc_bank
+    - name: 'Download Hamilton LRC PBMC Bank plate to LRC Bank Seq and Spare tubes CSV'
+      id: hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare
+    - name: 'Download PBMC Bank Tubes Content Report'
+      id: pbmc_bank_tubes_content_report
     - name: 'Download Cellaca Input QC1'
       id: cellaca_input_file
       params:
@@ -79,12 +85,6 @@ LRC PBMC Bank:
       id: cellaca_input_file
       params:
         page: 3
-    - name: 'Download Hamilton LRC Blood Bank plate to LRC PBMC Bank plate CSV'
-      id: hamilton_lrc_blood_bank_to_lrc_pbmc_bank
-    - name: 'Download Hamilton LRC PBMC Bank plate to LRC Bank Seq and Spare tubes CSV'
-      id: hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare
-    - name: 'Download PBMC Bank Tubes Content Report'
-      id: pbmc_bank_tubes_content_report
   :qc_thresholds:
     viability:
       units: '%'


### PR DESCRIPTION
Closes https://sanger-global.slack.com/archives/C05F21NKATD/p1702387845191799

#### Changes proposed in this pull request

- Moves the order of the Celleca buttons to the bottom of the list
  <img width="756" alt="Screenshot 2023-12-12 at 15 10 02" src="https://github.com/sanger/limber/assets/135011085/9ddd575a-92a3-4ec2-9178-4e83d2563af5">


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
