### PR TITLE
Revert "Bioscan barcode label changes"

### DIFF
--- a/app/models/labels/tube_label_traction_compatible.rb
+++ b/app/models/labels/tube_label_traction_compatible.rb
@@ -38,9 +38,10 @@ class Labels::TubeLabelTractionCompatible < Labels::TubeLabel
   end
 
   def first_line
-    # Parent barcode followed by well range from labware.name for PCR2 Pool tube.
-    match = labware.name.match(/^.+?\s([A-Z]\d{1,2}:[A-Z]\d{1,2})$/)
-    return "#{labware.parents[0].barcode.human} #{match[1]}" if match
+    # Parent barcode for PCR 2 Pool tube.
+    # This is the asset name (plate barcode and well range)
+    barcode_and_wells_format = /^.+?\s[A-Z]\d{1,2}:[A-Z]\d{1,2}$/
+    return labware.name if labware.name&.match?(barcode_and_wells_format)
 
     # Parent barcode for Lib PCR Pool and Lib PCR XP tubes
     labware.parents[0].barcode.human

--- a/config/purposes/bioscan.yml
+++ b/config/purposes/bioscan.yml
@@ -49,16 +49,16 @@ LBSN-384 PCR 1:
   :presenter_class: Presenters::MinimalPcrPlatePresenter
   :label_template: plate_384_single
   :size: 384
-  # LYSATE plate barcode is shown on barcode label top-right
-  :alternative_workline_identifier: LBSN-96 Lysate
+  # LILYS plate barcode is shown on barcode label top-right if possible; LYSATE otherwise.
+  :alternative_workline_identifier: LILYS-96 Stock
 LBSN-384 PCR 2:
   :asset_type: plate
   :creator_class: LabwareCreators::TaggedPlate
   :presenter_class: Presenters::MinimalPcrPlatePresenter
   :label_template: plate_384_single
   :size: 384
-  # LYSATE plate barcode is shown on barcode label top-right
-  :alternative_workline_identifier: LBSN-96 Lysate
+  # LILYS plate barcode is shown on barcode label top-right if possible; LYSATE otherwise.
+  :alternative_workline_identifier: LILYS-96 Stock
   # NB. will need to update this list to include new versions of the templates
   # as we generate new sets after changes from the scripts in Sequencescape
   :tag_layout_templates:

--- a/spec/models/labels/tube_label_traction_compatible_spec.rb
+++ b/spec/models/labels/tube_label_traction_compatible_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe Labels::TubeLabelTractionCompatible, type: :model do
   end
 
   context 'when labware name contains plate and well range' do
-    let(:labware) { build :v2_tube, name: 'SQPT-12345-H A1:P24', parents: [build(:v2_plate)] }
+    let(:labware) { build :v2_tube, name: 'SQPT-12345-H A1:P24', parents: [build(:v2_tube)] }
 
     it 'has the correct attributes' do
       attributes = label.attributes
-      expect(attributes[:first_line]).to eq "#{labware.parents[0].barcode.human} #{labware.name.split.last}"
+      expect(attributes[:first_line]).to eq labware.name
       expect(attributes[:second_line]).to match(/, P/)
       expect(attributes[:third_line]).to eq labware.purpose.name
       expect(attributes[:fourth_line]).to eq Time.zone.today.strftime('%e-%^b-%Y')


### PR DESCRIPTION
Reverts sanger/limber#1493

This PR is for reverting the changes to bioscan label printing changes for PCR 1 and PCR 2 plates (showing LYSATE ancestor top-left) and PCR2 Pool tube (immediate parent in first line). The reason for the revert is that UAT is not finished yet and we have to deploy Limber to production before the end of year future freeze. 