### PR TITLE
Bioscan tube labels first line

### DIFF
--- a/config/sprint/label_templates/tube_label_traction_compatible.yml.erb
+++ b/config/sprint/label_templates/tube_label_traction_compatible.yml.erb
@@ -40,7 +40,7 @@
         "y": 16,
         "value": "<%= merge_fields[:first_line] %>",
         "font": 'proportional',
-        "fontSize": 2,
+        "fontSize": 1.7,
         "rotation": 'east'
       },
       {


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Reduce the font size of the first line in Bioscan tube labels to avoid overflow.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
