### PR TITLE
fix: create more robust locale independent implementation of format-date

### DIFF
--- a/app/javascript/asset-comments/components/AssetComments.vue
+++ b/app/javascript/asset-comments/components/AssetComments.vue
@@ -20,22 +20,33 @@
 </template>
 
 <script>
-const dateOptions = {
-  year: 'numeric',
-  month: 'long',
-  day: 'numeric',
-  hour: 'numeric',
-  minute: '2-digit',
-}
-const formatDate = function (date) {
-  const dateObject = new Date(date)
-  return dateObject.toLocaleString('en-GB', dateOptions)
-}
-
 export default {
   name: 'AssetComments',
   filters: {
-    formatDate: formatDate,
+    formatDate(value) {
+      // return date like 30 September 2017, 12:18
+      const months = [
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December',
+      ]
+      const date = new Date(value)
+      const day = date.getDate()
+      const month = months[date.getMonth()]
+      const year = date.getFullYear()
+      const hour = date.getHours().toString().padStart(2, '0')
+      const minute = date.getMinutes().toString().padStart(2, '0')
+      return `${day} ${month} ${year}, ${hour}:${minute}`
+    },
   },
   computed: {
     noComments() {


### PR DESCRIPTION
Whenever I run `yarn test` on my Mac I get this machine-locale based test failing:

```sh
Summary of all failing tests
 FAIL  asset-comments/components/AssetComments.spec.js
  ● AssetComments › renders a list of comments

    expect(received).toContain(expected) // indexOf

    Expected substring: "30 September 2017, 12:18"
    Received string:    "This is also a comment
         Jane Smythe (js2) 30 September 2017 at 12:18"

      52 |     expect(wrapper.find('.comments-list').findAll('li').wrappers[0].text()).toContain('This is also a comment')
      53 |     expect(wrapper.find('.comments-list').findAll('li').wrappers[0].text()).toContain('Jane Smythe (js2)')
    > 54 |     expect(wrapper.find('.comments-list').findAll('li').wrappers[0].text()).toContain('30 September 2017, 12:18')
         |                                                                             ^
      55 |     expect(wrapper.find('.comments-list').findAll('li').wrappers[1].text()).toContain('This is a comment')
      56 |     expect(wrapper.find('.comments-list').findAll('li').wrappers[1].text()).toContain('John Smith (js1)')
      57 |     expect(wrapper.find('.comments-list').findAll('li').wrappers[1].text()).toContain('31 August 2017, 11:18')

      at Object.<anonymous> (asset-comments/components/AssetComments.spec.js:54:77)
```

This PR concretises the code to not be machine independent, based on the original test expectations.

#### Changes proposed in this pull request

- create more robust locale independent implementation of format-date

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
