### PR TITLE
fix: update cache_format_version for rails 7.1.2

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,7 @@ Bundler.require(*Rails.groups)
 
 module Limber
   class Application < Rails::Application # rubocop:todo Style/Documentation
-    config.load_defaults 6.1
+    config.load_defaults 6.0
     config.active_support.cache_format_version = 7.0
 
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
Solves the following deployment error by following the guide below.
```
STDERR:

DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.

Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
for more information on how to upgrade.
```

Closes #1509

EDIT: Turns out the deployment issue was unrelated to this error. However, this update is recommended for Rails going forward.

#### Changes proposed in this pull request

- update `cache_format_version` for rails 7.1.2

#### Instructions for Reviewers

**PS:** Does anyone know how to test this locally?

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
