### PR TITLE
fix: repair broken build by adding missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "vue-loader": "^15.11.1",
     "vue-style-loader": "^4.1.3",
     "vue-template-compiler": "^2.6.11",
+    "web-worker": "^1.3.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2358,7 +2358,7 @@
     consola "^2.15.0"
     node-fetch "^2.6.1"
 
-"@popperjs/core@^2.0.0", "@popperjs/core@^2.9.0":
+"@popperjs/core@^2.0.0":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
@@ -10889,6 +10889,11 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   integrity sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
   dependencies:
     minimalistic-assert "^1.0.0"
+
+web-worker@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/web-worker/-/web-worker-1.3.0.tgz#e5f2df5c7fe356755a5fb8f8410d4312627e6776"
+  integrity sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
The previous PR #1543 introduced a missing dependency that broke the compile-build step.

This PR should fix it.

#### Changes
- adds missing web-worker

#### References

- https://github.com/cytoscape/cytoscape.js-elk/issues/36
- https://github.com/kieler/elkjs/issues/141

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
