### PR TITLE
DPL-1042 Bed verification change (PBMC isolation)

### DIFF
--- a/config/robots.rb
+++ b/config/robots.rb
@@ -3052,10 +3052,10 @@ ROBOT_CONFIG =
           states: ['passed'],
           label: 'Bed 15'
         },
-        bed(3).barcode => {
+        bed(5).barcode => {
           purpose: 'LRC PBMC Bank',
           states: ['pending'],
-          label: 'Bed 3',
+          label: 'Bed 5',
           parent: bed(15).barcode,
           target_state: 'passed'
         }


### PR DESCRIPTION
Closes #1535 

#### Changes proposed in this pull request

Change bed number according to story
- bed 5 is at the front of the deck so is easier for the user to access for scanning


See also: https://gitlab.internal.sanger.ac.uk/psd/integration-suite/-/merge_requests/113/diffs 

Tested locally using integration suite.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
