### PR TITLE
DPL-1043 Change label type for 'LRC Blood Aliquot' to plate

### DIFF
--- a/config/label_templates.yml
+++ b/config/label_templates.yml
@@ -17,6 +17,12 @@ default_printer_type_names:
   :tube_rack: 96 Well Plate
   :tube: 1D Tube
 
+plate_a:
+  :label_class: Labels::PlateLabel
+  :printer_type: 96 Well Plate
+  :pmb_template: sqsc_96plate_label_template_code39
+  :sprint_template: plate_96.yml.erb
+
 # NB. plate_384.yml.erb is for printing double-sticker 384-well plate labels.
 plate_6mm_double:
   :label_class: Labels::PlateDoubleLabel

--- a/config/purposes/scrna_core_cell_extraction.yml
+++ b/config/purposes/scrna_core_cell_extraction.yml
@@ -23,7 +23,7 @@ LRC Blood Aliquot:
   :type: Tube::Purpose
   :presenter_class: Presenters::SimpleTubePresenter
   :creator_class: LabwareCreators::TubeFromTube
-  :default_printer_type: :tube
+  :label_template: plate_a
 ###
 # scRNA Core Cell Extraction Blood Pipeline
 ###

--- a/lib/purpose_config.rb
+++ b/lib/purpose_config.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# This is used as part of a take task, and will be run within a console.
+# This is used as part of a rake task, and will be run within a console.
 # rubocop:disable Rails/Output
 # rubocop:disable Metrics/ParameterLists
 


### PR DESCRIPTION
Closes #1536 

#### Changes proposed in this pull request

Create a 'plate_a' label template and use it in the purpose config for LRC Blood Aliquot

- this solution seems to work (printers drop down changes in the UI), but I'm not sure it's a good solution - may refactor

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
