### PR TITLE
DPL-823 Import PBMC pool plates into Sequencescape

### DIFF
--- a/config/purposes/scrna_core_cdna_prep.wip.yml
+++ b/config/purposes/scrna_core_cdna_prep.wip.yml
@@ -26,7 +26,7 @@ LRC PBMC Pools:
 # This plate has come from faculty and is entering the SeqOps pipeline for the first time here.
 LRC PBMC Pools Input:
   :asset_type: plate
-  :stock_plate: false
+  :stock_plate: true
   :input_plate: false
 # 10X Chromium 16-well chip
 LRC HT 5p Chip:

--- a/config/purposes/scrna_core_cdna_prep.wip.yml
+++ b/config/purposes/scrna_core_cdna_prep.wip.yml
@@ -26,6 +26,7 @@ LRC PBMC Pools:
 # This plate has come from faculty and is entering the SeqOps pipeline for the first time here.
 LRC PBMC Pools Input:
   :asset_type: plate
+  # stock_plate has to be true so that it appears in the 'Purpose' list when generating a sample manifest in Sequencescape
   :stock_plate: true
   :input_plate: false
 # 10X Chromium 16-well chip


### PR DESCRIPTION
Main changes for this story are in Sequencescape - https://github.com/sanger/sequencescape/pull/4017

#### Changes proposed in this pull request

- LRC PBMC Pools Input must be a 'stock plate' so that it can be used in sample manifests in Sequencescape

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
