### PR TITLE
fix: address 'compound selectors may no longer be extended' warning

### DIFF
--- a/app/assets/stylesheets/limber/pipeline-graph.scss
+++ b/app/assets/stylesheets/limber/pipeline-graph.scss
@@ -35,7 +35,7 @@
     height: calculate-graph-height();
     display: block;
     @extend .bg-dark;
-    @extend .text-white;
+    @extend .text-light;
   }
 
   #key {
@@ -43,7 +43,7 @@
     top: 10px;
     right: 10px;
     @extend .bg-dark;
-    @extend .text-white;
+    @extend .text-light;
     @extend .small;
 
     header {
@@ -62,7 +62,7 @@
       }
       #show-pipeline-groups:hover {
         @extend .icon-pipeline_single-light;
-        @extend .text-light:hover;
+        @extend .text-light, :hover;
       }
 
       #show-pipelines {
@@ -71,7 +71,7 @@
       }
       #show-pipelines:hover {
         @extend .icon-pipeline_stack-light;
-        @extend .text-light:hover;
+        @extend .text-light, :hover;
       }
 
       #pipelines-back {
@@ -83,7 +83,7 @@
         vertical-align: text-bottom;
       }
       #pipelines-back:hover {
-        @extend .text-light:hover;
+        @extend .text-light, :hover;
       }
     }
     ul {
@@ -97,7 +97,7 @@
         @extend .bg-dark;
       }
       li:hover {
-        @extend .text-light:hover;
+        @extend .text-light, :hover;
       }
     }
   }


### PR DESCRIPTION
Closes an annoying warning:

```
WARNING on line 74, column 17 of /Users/sh51/Sanger/PSD/short-reads/limber/app/assets/stylesheets/limber/pipeline-graph.scss:
Compound selectors may no longer be extended.
Consider `@extend .text-light, :hover` instead.
See http://bit.ly/ExtendCompound for details.
```

#### Changes proposed in this pull request

- Used the suggested fix and confirmed it's working as intended
- Changed `.text-white` to `.text-light` for better consistency across the styling

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
