### PR TITLE
Fix Webpacker::Manifest::MissingEntryError

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,6 @@
 
     <%= javascript_include_tag 'application'  %>
     <%= javascript_pack_tag 'application' %>
-    <%= stylesheet_pack_tag 'application' %>
 
     <% if Rails.application.config.disable_animations %>
       <%= stylesheet_link_tag  'disable_animations' %>


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Removing node_modules and running yarn install again did not work. 
- Remove stylesheet_pack_tag call from application.html.erb to fix the error:

![screenshot_2024-03-01_at_14 43 22_720](https://github.com/sanger/limber/assets/91894/315f4122-2a97-4102-a17d-e790a239b51c)

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
