### PR TITLE
DPL-1024-2 PBMC donor pooling - ancestor plates

### DIFF
--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -60,7 +60,8 @@ class ExportsController < ApplicationController
   def locate_ancestor_plate_list
     return [] if export.ancestor_purpose.blank?
 
-    # Collect plate ids from Asset resource results to fetch Plates later.
+    # Collect plate ids from the polymorphic Sequencescape::Api::V2::Asset
+    # resource results to fetch Plates later.
     ids = @plate.ancestors.where(purpose_name: export.ancestor_purpose).map(&:id)
     return [] if ids.empty?
     Sequencescape::Api::V2::Plate.includes(include_parameters).find({ id: ids })

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -61,7 +61,7 @@ class ExportsController < ApplicationController
     return [] if export.ancestor_purpose.blank?
 
     # Collect plate ids from the polymorphic Sequencescape::Api::V2::Asset
-    # resource results to fetch Plates later.
+    # polymorphic results to fetch the plates.
     ids = @plate.ancestors.where(purpose_name: export.ancestor_purpose).map(&:id)
     return [] if ids.empty?
     Sequencescape::Api::V2::Plate.includes(include_parameters).find({ id: ids })

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -58,7 +58,7 @@ class ExportsController < ApplicationController
   # @return [Array, Sequencescape::Api::V2::Plate] An array of Plate records if
   #   any are found, otherwise an empty array.
   def locate_ancestor_plate_list
-    return nil if export.ancestor_purpose.blank?
+    return [] if export.ancestor_purpose.blank?
 
     # Collect plate ids from Asset resource results to fetch Plates later.
     ids = @plate.ancestors.where(purpose_name: export.ancestor_purpose).map(&:id)

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -58,6 +58,8 @@ class ExportsController < ApplicationController
   # @return [Array, Sequencescape::Api::V2::Plate] An array of Plate records if
   #   any are found, otherwise an empty array.
   def locate_ancestor_plate_list
+    return nil if export.ancestor_purpose.blank?
+
     # Collect plate ids from Asset resource results to fetch Plates later.
     ids = @plate.ancestors.where(purpose_name: export.ancestor_purpose).map(&:id)
     return [] if ids.empty?

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -43,11 +43,7 @@ class ExportsController < ApplicationController
   def locate_ancestor_plate
     return nil if export.ancestor_purpose.blank?
 
-    # Store the result of the query in order to support multiple ancestor plates
-    # for the specified ancestor purpose.
-    @ancestor_plate_list = @plate.ancestors.where(purpose_name: export.ancestor_purpose)
-
-    ancestor_result = @ancestor_plate_list.first
+    ancestor_result = @plate.ancestors.where(purpose_name: export.ancestor_purpose).first
     return nil if ancestor_result.blank?
 
     Sequencescape::Api::V2.plate_with_custom_includes(include_parameters, id: ancestor_result.id)

--- a/config/exports/exports.yml
+++ b/config/exports/exports.yml
@@ -187,4 +187,4 @@ hamilton_lrc_pbmc_defrost_pbs_to_lrc_pbmc_pools:
   plate_includes:
     - wells.qc_results
     - wells.transfer_requests_as_target.source_asset
-  ancestor_purpose: LRC PBMC Defrost
+  ancestor_purpose: LRC PBMC Defrost PBS

--- a/spec/controllers/exports_controller_spec.rb
+++ b/spec/controllers/exports_controller_spec.rb
@@ -375,14 +375,14 @@ RSpec.describe ExportsController, type: :controller do
     context 'when ancestor plate is not configured' do
       let(:csv_id) { 'multiple_ancestor_plates_not_configured' }
 
-      it 'does not assign @ancestor_plate_list' do
+      it 'assigns @ancestor_plate_list to an empty array' do
         # The export controller's show action should assing @ancestor_plate_list
         # to an empty array if the ancestor plate is not configured.
         get :show, params: { id: csv_id, limber_plate_id: plate_barcode }, as: :csv
         expect(assigns(:ancestor_plate_list)).to eq([])
       end
 
-      it 'renders the view without @ancestor_plate_list' do
+      it 'renders the view with an empty @ancestor_plate_list' do
         # The export controller's show action should render the view without
         # @ancestor_plate_list if the ancestor plate is not configured.
 

--- a/spec/controllers/exports_controller_spec.rb
+++ b/spec/controllers/exports_controller_spec.rb
@@ -285,4 +285,115 @@ RSpec.describe ExportsController, type: :controller do
       )
     end
   end
+
+  context 'with multiple ancestor plates' do
+    # Set up three ancestor plates for this test.
+    # example_ancestor_purpose is the purpose of the ancestor plates.
+    # The purpose name is used for ancestor_purpose in the exports configuration fixture.
+    #
+    # Fixtures:
+    # spec/fixtures/config/multiple_ancestor_plates.yml is the exports configuration file.
+    # spec/fixtures/app/views/exports/multiple_ancestor_plates.csv.erb is the view that generates the exports.
+    #
+    # multiple_ancestor_plates_configured is the id of an export in exports.yml
+    # multiple_ancestor_plates_not_configured is the id of an export in exports.yml
+    # multiple_ancestor_plates is the view name for both exports set in exports.yml
+
+    let(:ancestor_purpose_name) { 'example_ancestor_purpose' }
+    let(:ancestor_purpose) { create(:v2_purpose, name: ancestor_purpose_name) }
+    let(:ancestor_plates) { create_list(:v2_plate, 3, purpose: ancestor_purpose) }
+
+    let(:exports_path) { 'spec/fixtures/config/exports/multiple_ancestor_plates.yml' }
+    let(:config) { YAML.load_file(exports_path) }
+    let(:export) { Export.new(config.fetch(csv_id)) } # csv_id specified by the individual test
+
+    let(:view_path) { 'spec/fixtures/app/views/' } # for exports/multiple_ancestor_plates.csv.erb
+
+    before do
+      # Make the controller to receive the plate.
+      # NB. Uses plate_includes if specified in the export configuration.
+      allow(Sequencescape::Api::V2).to receive(:plate_with_custom_includes)
+        .with(export.plate_includes, barcode: plate_barcode)
+        .and_return(plate)
+
+      # Make the controller to use the export loaded from fixture config.
+      allow(subject).to receive(:export).and_return(export)
+
+      # Make the controller to find the fixture template for rendering.
+      subject.prepend_view_path('spec/fixtures/app/views')
+
+      # Stub the ancestors query to return ancestor plates.
+      # NB. The result is an array of Sequencescape::Api::V2::Asset objects
+      # with the ancestor plate ids.
+      asset_ancestors =
+        ancestor_plates.map { |ancestor_plate| double('Sequencescape::Api::V2::Asset', id: ancestor_plate.id) }
+
+      allow(plate).to receive_message_chain(:ancestors, :where)
+        .with(purpose_name: export.ancestor_purpose)
+        .and_return(asset_ancestors)
+
+      # Stub the plate_with_custom_includes query to return the first ancestor plate.
+      # NB. This stub is not used in this test directly, but it is required to make
+      # the other methods in the show controller action not to fail when they try to
+      # receive the first ancestor.
+      allow(Sequencescape::Api::V2).to receive(:plate_with_custom_includes)
+        .with(export.plate_includes, id: asset_ancestors.first.id)
+        .and_return(ancestor_plates.first)
+
+      # Stub the plate query to return ancestor plates.
+      builder = double('JsonApiClient::Query::Builder')
+      allow(Sequencescape::Api::V2::Plate).to receive(:includes).with(export.plate_includes).and_return(builder)
+      allow(builder).to receive(:find).with({ id: asset_ancestors.map(&:id) }).and_return(ancestor_plates)
+    end
+
+    context 'when ancestor plate is configured' do
+      let(:csv_id) { 'multiple_ancestor_plates_configured' }
+
+      it 'assigns @ancestor_plate_list to the list of ancestor plates' do
+        # The export controller's show action should assign @ancestor_plate_list
+        # to an array of ancestor plates.
+        get :show, params: { id: csv_id, limber_plate_id: plate_barcode }, as: :csv
+        expect(assigns(:ancestor_plate_list)).to eq(ancestor_plates)
+      end
+
+      it 'renders the view with @ancestor_plate_list' do
+        # The export controller's show action should render the view with
+        # @ancestor_plate_list.
+        get :show, params: { id: csv_id, limber_plate_id: plate_barcode }, as: :csv
+
+        expect(response).to render_template('exports/multiple_ancestor_plates')
+
+        output = [['Plate Barcode', plate.barcode.human], ['Ancestor Barcode', 'Ancestor Purpose']]
+        ancestor_plates.each { |ancestor_plate| output << [ancestor_plate.barcode.human, ancestor_purpose_name] }
+
+        output = "#{output.map { |line| line.join(',') }.join("\n")}\n"
+
+        expect(response.body).to eq(output)
+      end
+    end
+
+    context 'when ancestor plate is not configured' do
+      let(:csv_id) { 'multiple_ancestor_plates_not_configured' }
+
+      it 'does not assign @ancestor_plate_list' do
+        # The export controller's show action should assing @ancestor_plate_list
+        # to an empty array if the ancestor plate is not configured.
+        get :show, params: { id: csv_id, limber_plate_id: plate_barcode }, as: :csv
+        expect(assigns(:ancestor_plate_list)).to eq([])
+      end
+
+      it 'renders the view without @ancestor_plate_list' do
+        # The export controller's show action should render the view without
+        # @ancestor_plate_list if the ancestor plate is not configured.
+
+        get :show, params: { id: csv_id, limber_plate_id: plate_barcode }, as: :csv
+        expect(response).to render_template('exports/multiple_ancestor_plates')
+
+        output = [['Plate Barcode', plate.barcode.human], ['Ancestor Barcode', 'Ancestor Purpose']]
+        output = "#{output.map { |line| line.join(',') }.join("\n")}\n"
+
+        expect(response.body).to eq(output) # empty ancestor plate table
+      end
+    end
+  end
 end

--- a/spec/controllers/exports_controller_spec.rb
+++ b/spec/controllers/exports_controller_spec.rb
@@ -333,9 +333,8 @@ RSpec.describe ExportsController, type: :controller do
         .and_return(asset_ancestors)
 
       # Stub the plate_with_custom_includes query to return the first ancestor plate.
-      # NB. This stub is not used in this test directly, but it is required to make
-      # the other methods in the show controller action not to fail when they try to
-      # receive the first ancestor.
+      # NB. This stub is required to make the other methods in the show controller
+      # action not to fail when they try to receive the first ancestor plate.
       allow(Sequencescape::Api::V2).to receive(:plate_with_custom_includes)
         .with(export.plate_includes, id: asset_ancestors.first.id)
         .and_return(ancestor_plates.first)
@@ -376,14 +375,14 @@ RSpec.describe ExportsController, type: :controller do
       let(:csv_id) { 'multiple_ancestor_plates_not_configured' }
 
       it 'assigns @ancestor_plate_list to an empty array' do
-        # The export controller's show action should assing @ancestor_plate_list
+        # The export controller's show action should assign @ancestor_plate_list
         # to an empty array if the ancestor plate is not configured.
         get :show, params: { id: csv_id, limber_plate_id: plate_barcode }, as: :csv
         expect(assigns(:ancestor_plate_list)).to eq([])
       end
 
       it 'renders the view with an empty @ancestor_plate_list' do
-        # The export controller's show action should render the view without
+        # The export controller's show action should render the view with an empty
         # @ancestor_plate_list if the ancestor plate is not configured.
 
         get :show, params: { id: csv_id, limber_plate_id: plate_barcode }, as: :csv

--- a/spec/fixtures/app/views/exports/multiple_ancestor_plates.csv.erb
+++ b/spec/fixtures/app/views/exports/multiple_ancestor_plates.csv.erb
@@ -1,0 +1,5 @@
+<%= CSV.generate_line ['Plate Barcode', @plate.labware_barcode.human], row_sep: "" %>
+<%= CSV.generate_line ['Ancestor Barcode', 'Ancestor Purpose'], row_sep: "" %>
+<% @ancestor_plate_list.each do |ancestor_plate| %>
+<%= CSV.generate_line [ancestor_plate.labware_barcode.human, ancestor_plate.purpose.name], row_sep: "" %>
+<% end %>

--- a/spec/fixtures/config/exports/multiple_ancestor_plates.yml
+++ b/spec/fixtures/config/exports/multiple_ancestor_plates.yml
@@ -1,0 +1,9 @@
+---
+# Fixture for testing exporting multiple ancestor plates
+multiple_ancestor_plates_configured:
+  csv: multiple_ancestor_plates
+  plate_includes: wells.qc_results
+  ancestor_purpose: example_ancestor_purpose
+multiple_ancestor_plates_not_configured:
+  csv: multiple_ancestor_plates
+  plate_includes: wells.qc_results

--- a/spec/fixtures/config/exports/multiple_ancestor_plates.yml
+++ b/spec/fixtures/config/exports/multiple_ancestor_plates.yml
@@ -1,5 +1,5 @@
 ---
-# Fixture for testing exporting multiple ancestor plates
+# Fixture for testing multiple ancestor plates support in exports
 multiple_ancestor_plates_configured:
   csv: multiple_ancestor_plates
   plate_includes: wells.qc_results

--- a/spec/lib/config_loader/exports_loader_spec.rb
+++ b/spec/lib/config_loader/exports_loader_spec.rb
@@ -7,12 +7,28 @@ RSpec.describe ConfigLoader::ExportsLoader, type: :model, loader: true do
   subject(:loader) { described_class.new(directory: test_directory, files: selected_files) }
 
   let(:test_directory) { Rails.root.join('spec/fixtures/config/exports') }
+  let(:expected_count) do
+    # Compute the expected number of exports.
+    files_to_load =
+      if selected_files
+        [File.join(test_directory, "#{selected_files}.yml")] # specific files
+      else
+        Dir.glob("#{test_directory}/*.yml") # all files
+      end
+
+    # The total number of exports for selected_files.
+    files_to_load.sum do |file|
+      YAML.load_file(file).keys.count
+    rescue StandardError
+      0
+    end
+  end
 
   context 'with no files specified' do
     let(:selected_files) { nil }
 
-    it 'loads purposes from all files' do
-      expect(loader.config.length).to eq 26
+    it 'loads exports from all files' do
+      expect(loader.config.length).to eq expected_count
       expect(loader.config).to be_a(Hash)
     end
   end
@@ -20,8 +36,8 @@ RSpec.describe ConfigLoader::ExportsLoader, type: :model, loader: true do
   context 'with a specific file specified' do
     let(:selected_files) { 'exports' }
 
-    it 'loads purposes from specified files' do
-      expect(loader.config.length).to eq 26
+    it 'loads exports from specified files' do
+      expect(loader.config.length).to eq expected_count
       expect(loader.config).to be_a(Hash)
     end
   end


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

Updates for using multiple ancestor plates in driver file download

Summary:

The ancestor_purpose setting of an export configuration will make an additional controller instance variable`@ancestor_plate_list` populated with all ancestor plates of that purpose and available in the view template.

Background:

The existing export controller allows making an ancestor plate available to the export view template by specifying the ancestor plate purpose in the export configuration. This is useful in several cases, for example, access to parent plate barcode and relating source wells specified in transfer templates in driver file exports. However, only one ancestor plate is made available to the view, the first, which assumes a single parent for the current plate being viewed and download requested.

In cases where a plate has (or may have) multiple ancestors of a specific purpose, such as pooling from multiple source plates, as in scRNA donor pooling, we need access to more than one parent in the view to interpret the transfer request and generate a column with parent barcode. This PR enables that.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
