### PR TITLE
fix: replace deprecated btn-default with btn-primary

### DIFF
--- a/app/views/search/_plate_search_form.html.erb
+++ b/app/views/search/_plate_search_form.html.erb
@@ -9,5 +9,5 @@
     <%= f.check_box :include_used, class: 'custom-control-input' %>
     <%= f.label :include_used, 'Include used plates', class: 'custom-control-label' %>
   </div>
-  <%= f.submit 'Update', class: 'btn btn-default' %>
+  <%= f.submit 'Update', class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/search/_tube_search_form.html.erb
+++ b/app/views/search/_tube_search_form.html.erb
@@ -3,5 +3,5 @@
   <%= f.select :purposes, options_for_select(@purpose_options, tube_search_form.purposes), { include_hidden: false }, multiple: true, class: 'form-control' %>
   <%= f.label :include_used, 'Include used tubes' %>
   <%= f.check_box :include_used %>
-  <%= f.submit 'Update', class: 'btn btn-default' %>
+  <%= f.submit 'Update', class: 'btn btn-primary' %>
 <% end %>


### PR DESCRIPTION
Makes buttons look like buttons and not text

#### Changes proposed in this pull request

- replace deprecated class `btn-default` with Bootstrap's `btn-primary`

Before:
<img width="1215" alt="Screenshot 2024-03-14 at 14 17 11" src="https://github.com/sanger/limber/assets/135011085/a116d780-df2f-4e21-a7dc-206e82b4cdd9">

After:
<img width="1216" alt="Screenshot 2024-03-14 at 14 17 49" src="https://github.com/sanger/limber/assets/135011085/856ca5bf-a56e-4467-bb40-89f2390d8d48">




#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
