### PR TITLE
DPL-916-4 PBMC donor pooling - validate cell count

### DIFF
--- a/app/models/concerns/labware_creators/donor_pooling_validator.rb
+++ b/app/models/concerns/labware_creators/donor_pooling_validator.rb
@@ -121,11 +121,7 @@ module LabwareCreators::DonorPoolingValidator
   def locations_with_missing_donor_id
     # source_wells_for_pooling contains filtered wells from source plates
     invalid_wells = source_wells_for_pooling.select { |well| missing_donor_id?(well) }
-    invalid_wells.each_with_object({}) do |well, hash|
-      plate_barcode = source_wells_to_plates[well].human_barcode # find the plate barcode
-      hash[plate_barcode] ||= []
-      hash[plate_barcode] << well.location
-    end
+    invalid_wells_hash(invalid_wells)
   end
 
   # Checks if a well is missing a donor_id. If there is an aliquot, it checks
@@ -143,15 +139,18 @@ module LabwareCreators::DonorPoolingValidator
 
   def locations_with_missing_cell_count
     invalid_wells = source_wells_for_pooling.select { |well| missing_cell_count?(well) }
-    invalid_wells.each_with_object({}) do |well, hash|
-      plate_barcode = source_wells_to_plates[well].human_barcode # find the plate barcode
-      hash[plate_barcode] ||= []
-      hash[plate_barcode] << well.location
-    end
+    invalid_wells_hash(invalid_wells)
   end
 
   def missing_cell_count?(well)
     well.lastest_live_cell_count.blank?
   end
 
+  def invalid_wells_hash(invalid_wells)
+    invalid_wells.each_with_object({}) do |well, hash|
+      plate_barcode = source_wells_to_plates[well].human_barcode # find the plate barcode
+      hash[plate_barcode] ||= []
+      hash[plate_barcode] << well.location
+    end
+  end
 end

--- a/app/models/concerns/labware_creators/donor_pooling_validator.rb
+++ b/app/models/concerns/labware_creators/donor_pooling_validator.rb
@@ -76,8 +76,7 @@ module LabwareCreators::DonorPoolingValidator
   # @return [void]
   def number_of_pools_must_not_exceed_configured
     # Don't add this error if there are already errors about invalid wells
-    invalid_wells_hash = locations_with_missing_donor_id || locations_with_missing_cell_count
-    return if invalid_wells_hash.any?
+    return if locations_with_missing_donor_id.any? || locations_with_missing_cell_count.any?
 
     return if pools.size <= number_of_pools
 

--- a/app/models/concerns/labware_creators/donor_pooling_validator.rb
+++ b/app/models/concerns/labware_creators/donor_pooling_validator.rb
@@ -99,7 +99,7 @@ module LabwareCreators::DonorPoolingValidator
     errors.add(:source_plates, format(WELLS_WITH_ALIQUOTS_MUST_HAVE_DONOR_ID, formatted_string))
   end
 
-  # Validates that wells with aliquots have a lastest_live_cell_count. It uses
+  # Validates that wells with aliquots have a latest_live_cell_count. It uses
   # the locations_with_missing_cell_count method to find any wells that are
   # missing a cell count. If any such wells are found, it adds an error message
   # to the source_plates attribute, formatted with the barcodes of the plates
@@ -166,7 +166,7 @@ module LabwareCreators::DonorPoolingValidator
   # @param well [Well] The well to check.
   # @return [Boolean] True if the well is missing a cell count, false otherwise.
   def missing_cell_count?(well)
-    well.lastest_live_cell_count.blank?
+    well.latest_live_cell_count.blank?
   end
 
   # Generates a hash mapping plate barcodes to invalid well locations. For each

--- a/app/models/concerns/labware_creators/donor_pooling_validator.rb
+++ b/app/models/concerns/labware_creators/donor_pooling_validator.rb
@@ -95,7 +95,7 @@ module LabwareCreators::DonorPoolingValidator
     invalid_wells_hash = locations_with_missing_donor_id
     return if invalid_wells_hash.empty?
 
-    formatted_string = invalid_wells_hash.map { |barcode, locations| "#{barcode}: #{locations.join(', ')}" }.join(' ')
+    formatted_string = formatted_invalid_wells_hash(invalid_wells_hash)
     errors.add(:source_plates, format(WELLS_WITH_ALIQUOTS_MUST_HAVE_DONOR_ID, formatted_string))
   end
 
@@ -103,7 +103,7 @@ module LabwareCreators::DonorPoolingValidator
     invalid_wells_hash = locations_with_missing_cell_count
     return if invalid_wells_hash.empty?
 
-    formatted_string = invalid_wells_hash.map { |barcode, locations| "#{barcode}: #{locations.join(', ')}" }.join(' ')
+    formatted_string = formatted_invalid_wells_hash(invalid_wells_hash)
     errors.add(:source_plates, format(WELLS_WITH_ALIQUOTS_MUST_HAVE_CELL_COUNT, formatted_string))
   end
 
@@ -152,5 +152,9 @@ module LabwareCreators::DonorPoolingValidator
       hash[plate_barcode] ||= []
       hash[plate_barcode] << well.location
     end
+  end
+
+  def formatted_invalid_wells_hash(invalid_wells_hash)
+    invalid_wells_hash.map { |barcode, locations| "#{barcode}: #{locations.join(', ')}" }.join(' ')
   end
 end

--- a/app/models/concerns/labware_creators/donor_pooling_validator.rb
+++ b/app/models/concerns/labware_creators/donor_pooling_validator.rb
@@ -33,7 +33,7 @@ module LabwareCreators::DonorPoolingValidator
       'Wells missing donor_id (on sample metadata): %s'
 
   WELLS_WITH_ALIQUOTS_MUST_HAVE_CELL_COUNT =
-    'All wells must have cell count data unless they are failed.' \
+    'All wells must have cell count data unless they are failed. ' \
       'Wells missing cell count data: %s'
 
   # Validates that at least one source barcode has been entered. If no barcodes

--- a/app/models/concerns/labware_creators/donor_pooling_validator.rb
+++ b/app/models/concerns/labware_creators/donor_pooling_validator.rb
@@ -32,9 +32,9 @@ module LabwareCreators::DonorPoolingValidator
     'All samples must have the donor_id specified. ' \
       'Wells missing donor_id (on sample metadata): %s'
 
-  WELLS_WITH_ALIQUOTS_MUST_HAVE_CELL_COUNT = \
+  WELLS_WITH_ALIQUOTS_MUST_HAVE_CELL_COUNT =
     'All wells must have cell count data unless they are failed.' \
-    'Wells missing cell count data: %s'
+      'Wells missing cell count data: %s'
 
   # Validates that at least one source barcode has been entered. If no barcodes
   # are entered, an error is added to the :source_barcodes attribute.
@@ -99,6 +99,15 @@ module LabwareCreators::DonorPoolingValidator
     errors.add(:source_plates, format(WELLS_WITH_ALIQUOTS_MUST_HAVE_DONOR_ID, formatted_string))
   end
 
+  # Validates that wells with aliquots have a lastest_live_cell_count. It uses
+  # the locations_with_missing_cell_count method to find any wells that are
+  # missing a cell count. If any such wells are found, it adds an error message
+  # to the source_plates attribute, formatted with the barcodes of the plates
+  # and the wells that are missing a cell count. Note that the well filter
+  # already excludes failed wells. This validation ensures that all wells with
+  # aliquots have a cell count unless they are failed.
+  #
+  # @return [void]
   def wells_with_aliquots_must_have_cell_count
     invalid_wells_hash = locations_with_missing_cell_count
     return if invalid_wells_hash.empty?
@@ -137,15 +146,35 @@ module LabwareCreators::DonorPoolingValidator
     (aliquot.sample.sample_metadata.donor_id || '').to_s.strip.blank?
   end
 
+  # Checks each source well for pooling for missing cell count. Returns a hash
+  # with keys as the barcodes of source plates and values as arrays of well
+  # locations with missing cell count. If a plate has no wells with missing
+  # cell count, it is not included in the returned hash. This method is used by
+  # the wells_with_aliquots_must_have_cell_count method to generate an error
+  # message.
+  #
+  # @return [Hash] A hash mapping source plate barcodes to arrays of invalid
+  #   well locations.
   def locations_with_missing_cell_count
     invalid_wells = source_wells_for_pooling.select { |well| missing_cell_count?(well) }
     invalid_wells_hash(invalid_wells)
   end
 
+  # Checks if a well is missing a latest live cell count. If the cell count is
+  # missing, it returns true. Otherwise, it returns false.
+  #
+  # @param well [Well] The well to check.
+  # @return [Boolean] True if the well is missing a cell count, false otherwise.
   def missing_cell_count?(well)
     well.lastest_live_cell_count.blank?
   end
 
+  # Generates a hash mapping plate barcodes to invalid well locations. For each
+  # invalid well, it finds the corresponding plate barcode and adds the well's
+  # location to the list of invalid locations for that plate.
+  #
+  # @param invalid_wells [Array] the wells to be processed
+  # @return [Hash] a hash mapping plate barcodes to arrays of invalid well locations
   def invalid_wells_hash(invalid_wells)
     invalid_wells.each_with_object({}) do |well, hash|
       plate_barcode = source_wells_to_plates[well].human_barcode # find the plate barcode
@@ -154,6 +183,13 @@ module LabwareCreators::DonorPoolingValidator
     end
   end
 
+  # Formats a hash of invalid wells for display. For each plate barcode, it
+  # concatenates the invalid well locations into a string, separated by commas.
+  # It then joins these strings into a single string, separated by spaces.
+  #
+  # @param invalid_wells_hash [Hash] a hash mapping plate barcodes to arrays of
+  #   invalid well locations
+  # @return [String] a string representation of the invalid wells
   def formatted_invalid_wells_hash(invalid_wells_hash)
     invalid_wells_hash.map { |barcode, locations| "#{barcode}: #{locations.join(', ')}" }.join(' ')
   end

--- a/app/models/concerns/labware_creators/donor_pooling_validator.rb
+++ b/app/models/concerns/labware_creators/donor_pooling_validator.rb
@@ -75,8 +75,8 @@ module LabwareCreators::DonorPoolingValidator
   #
   # @return [void]
   def number_of_pools_must_not_exceed_configured
-    # Don't add this error if there are already errors about missing donor_ids.
-    invalid_wells_hash = locations_with_missing_donor_id
+    # Don't add this error if there are already errors about invalid wells
+    invalid_wells_hash = locations_with_missing_donor_id || locations_with_missing_cell_count
     return if invalid_wells_hash.any?
 
     return if pools.size <= number_of_pools

--- a/app/models/labware_creators/donor_pooling_plate.rb
+++ b/app/models/labware_creators/donor_pooling_plate.rb
@@ -9,6 +9,8 @@ module LabwareCreators
   # The creator imposes restrictions:
   # - It doesn't allow combining samples from different studies or projects.
   # - It doesn't allow samples with the same donor_id in the same pool.
+  # - All wells must have cell count data unless they are failed.
+  # - The number of pools must not exceed the number configured for the samples.
   #
   # The number of pools is determined by a lookup table based on sample count.
   # Tag depth index is added to aliquot attributes to avoid tag clashes.

--- a/app/models/labware_creators/donor_pooling_plate.rb
+++ b/app/models/labware_creators/donor_pooling_plate.rb
@@ -49,6 +49,7 @@ module LabwareCreators
       wells.aliquots.request
       wells.aliquots.sample.sample_metadata
       wells.requests_as_source
+      wells.qc_results
     ].freeze
 
     # The default number of pools to be created if the count is not found in

--- a/app/views/plate_creation/donor_pooling_plate.html.erb
+++ b/app/views/plate_creation/donor_pooling_plate.html.erb
@@ -9,6 +9,7 @@
           <li>All source wells with aliquots must have donor IDs.</li>
           <li>Combining samples from different studies or projects in the same pool is not allowed.</li>
           <li>Including samples with the same donor ID in the same pool is not allowed.</li>
+          <li>All wells must have cell count data unless they are failed.</li>
           <li>The number of pools must not exceed the number configured for the samples.</li>
         </ul>
         <p>Scan the source plate barcodes into the panel on the right of the screen (the order doesn't matter) and click <i>Create Plate</i>.</p>

--- a/config/pipelines/high_throughput_scrna_core_cdna_prep.wip.yml
+++ b/config/pipelines/high_throughput_scrna_core_cdna_prep.wip.yml
@@ -13,7 +13,7 @@ scRNA Core Donor Pooling:
 scRNA Core cDNA Prep:
   pipeline_group: scRNA Core cDNA Prep
   filters:
-    request_type_key: limber_scrna_core_cDNA_prep
+    request_type_key: limber_scrna_core_cdna_prep
     library_type: Chromium single cell 5 prime HT v2
   relationships:
     LRC PBMC Pools: LRC HT 5p Chip

--- a/spec/lib/config_loader/poolings_loader_spec.rb
+++ b/spec/lib/config_loader/poolings_loader_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe ConfigLoader::PoolingsLoader, type: :model, loader: true do
       expect(loader.config).to be_a(Hash)
       expect(loader.config.keys).to include('donor_pooling', 'second_pooling_config')
       expect(loader.config.dig('donor_pooling', 'number_of_pools')&.size).to eq(96)
-      p loader.config.dig('second_pooling_config', 'number_of_pools')&.size
       expect(loader.config.dig('second_pooling_config', 'number_of_pools')&.size).to eq(4)
     end
   end

--- a/spec/models/labware_creators/donor_pooling_spec.rb
+++ b/spec/models/labware_creators/donor_pooling_spec.rb
@@ -607,6 +607,7 @@ RSpec.describe LabwareCreators::DonorPoolingPlate do
           well.aliquots.first.study = study_1
           well.aliquots.first.project = project_1
           well.aliquots.first.sample.sample_metadata.donor_id = 1
+          well.qc_results << create(:qc_result, key: 'live_cell_count', value: '1_000_000', units: 'cells/ml')
           [well]
         end
         before do

--- a/spec/models/labware_creators/donor_pooling_spec.rb
+++ b/spec/models/labware_creators/donor_pooling_spec.rb
@@ -607,6 +607,7 @@ RSpec.describe LabwareCreators::DonorPoolingPlate do
           well.aliquots.first.study = study_1
           well.aliquots.first.project = project_1
           well.aliquots.first.sample.sample_metadata.donor_id = 1
+          [well]
         end
         before do
           allow(Sequencescape::Api::V2::Plate).to receive(:find_all)

--- a/spec/models/labware_creators/donor_pooling_spec.rb
+++ b/spec/models/labware_creators/donor_pooling_spec.rb
@@ -607,6 +607,7 @@ RSpec.describe LabwareCreators::DonorPoolingPlate do
           well.aliquots.first.study = study_1
           well.aliquots.first.project = project_1
           well.aliquots.first.sample.sample_metadata.donor_id = 1
+          well.qc_results << create(:qc_result, key: 'live_cell_count', units: 'cells/ml', value: 1_000_000)
           [well]
         end
         before do
@@ -616,8 +617,7 @@ RSpec.describe LabwareCreators::DonorPoolingPlate do
         end
         let(:barcodes) { [parent_1_plate.human_barcode] }
         it 'allows plate creation' do
-          # TODO: Add tests for latest_live_cell_count.
-          # TODO: Use qc_results to fix existing tests.
+          expect(wells.first.latest_live_cell_count&.value).to eq(1_000_000) # sanity check
           expect(subject).to be_valid
         end
       end

--- a/spec/models/labware_creators/donor_pooling_spec.rb
+++ b/spec/models/labware_creators/donor_pooling_spec.rb
@@ -607,7 +607,6 @@ RSpec.describe LabwareCreators::DonorPoolingPlate do
           well.aliquots.first.study = study_1
           well.aliquots.first.project = project_1
           well.aliquots.first.sample.sample_metadata.donor_id = 1
-          well.qc_results << create(:qc_result, key: 'live_cell_count', value: '1_000_000', units: 'cells/ml')
           [well]
         end
         before do
@@ -616,7 +615,11 @@ RSpec.describe LabwareCreators::DonorPoolingPlate do
             .and_return([parent_1_plate])
         end
         let(:barcodes) { [parent_1_plate.human_barcode] }
-        it { is_expected.to be_valid }
+        it 'allows plate creation' do
+          # TODO: Add tests for latest_live_cell_count.
+          # TODO: Use qc_results to fix existing tests.
+          expect(subject).to be_valid
+        end
       end
     end
 

--- a/spec/models/labware_creators/donor_pooling_spec.rb
+++ b/spec/models/labware_creators/donor_pooling_spec.rb
@@ -640,9 +640,13 @@ RSpec.describe LabwareCreators::DonorPoolingPlate do
 
     describe '#number_of_pools_must_not_exceed_configured' do
       let!(:wells) do
+        # The number of pools validation is applied when all other conditions
+        # for building the pools are met, i.e. study, project, donor_id and cell_count.
+        #
         # Up to 20 wells, the number of pools is configured as 1. If multiple
         # studies, projects or the same donors are present, the number of pools
-        # calculated will be more than 1.
+        # calculated will be more than 1 to generate a validation error in this test.
+
         wells = [parent_1_plate.wells[0], parent_1_plate.wells[1], parent_2_plate.wells[0]]
         studies = [study_1, study_2, study_3]
         wells.each_with_index do |well, index|
@@ -650,6 +654,7 @@ RSpec.describe LabwareCreators::DonorPoolingPlate do
           well.aliquots.first.study = studies[index] # different studies
           well.aliquots.first.project = project_1 # same project
           well.aliquots.first.sample.sample_metadata.donor_id = 1 # same donor
+          well.qc_results << create(:qc_result, key: 'live_cell_count', units: 'cells/ml', value: 1_000_000) # QC
         end
       end
       it 'reports the error' do


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Add a validation into LCR PBMC Pools plate creation to enforce cell count data presence on the LRC PBMC Defrost PBS wells going into pooling. All wells must have cell count data unless they are failed. This will ensure consistency between the created pools plate and the driver download.

- Use lowercase letters for  `request_type_key` for `limber_scrna_core_cdna_prep` in pipeline config to make the _Add and empty LRC HT 5p Chip plate_ button available.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
