### PR TITLE
DPL-919-3 UAT Updates

### DIFF
--- a/app/models/concerns/labware_creators/stamped_plate_reordering_validator.rb
+++ b/app/models/concerns/labware_creators/stamped_plate_reordering_validator.rb
@@ -21,6 +21,6 @@ module LabwareCreators::StampedPlateReorderingValidator
     wells_with_aliquots = labware_wells.reject(&:empty?)
     return if wells_with_aliquots.size <= child_plate_size
 
-    errors.add(:source_plate, format(SOURCE_WELLS_MUST_FIT_CHILD_PLATE, labware_wells.size, child_plate_size))
+    errors.add(:source_plate, format(SOURCE_WELLS_MUST_FIT_CHILD_PLATE, wells_with_aliquots.size, child_plate_size))
   end
 end


### PR DESCRIPTION


Closes #

#### Changes proposed in this pull request

- Fix error message when the number of parent wells exceeds the child plate size. Use the wells with aliquots; not the parent plate size for the message.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
