### PR TITLE
Y24-096 - Added 2D barcodes to LRC Blood Aliquot labels [2]

### DIFF
--- a/spec/models/labels/plate_label_human_barcode_spec.rb
+++ b/spec/models/labels/plate_label_human_barcode_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Labels::PlateLabelHumanBarcode, type: :model do
   it { expect(described_class).to be < Labels::Base }
 
-  context 'when creating the label of a plate' do
+  context 'when creating the label of a plate with a human readable barcode' do
     let(:labware) { create :v2_plate }
     let(:label) { Labels::PlateLabelHumanBarcode.new(labware) }
 

--- a/spec/models/labels/plate_label_human_barcode_spec.rb
+++ b/spec/models/labels/plate_label_human_barcode_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Labels::PlateLabelHumanBarcode, type: :model do
+  it { expect(described_class).to be < Labels::Base }
+
+  context 'when creating the label of a plate' do
+    let(:labware) { create :v2_plate }
+    let(:label) { Labels::PlateLabelHumanBarcode.new(labware) }
+
+    context '#attributes' do
+      it 'has the correct attributes' do
+        attributes = label.attributes
+        expect(attributes[:top_left]).to eq Time.zone.today.strftime('%e-%^b-%Y')
+        expect(attributes[:bottom_left]).to eq labware.barcode.human
+        expect(attributes[:top_right]).to eq labware.workline_identifier
+        expect(attributes[:bottom_right]).to eq [labware.role, labware.purpose.name].compact.join(' ')
+        expect(attributes[:barcode]).to eq labware.barcode.human
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes N/A

#### Changes proposed in this pull request

- Added a test for the human readable barcode label class (See [main change](https://github.com/sanger/limber/pull/1742))

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
