### PR TITLE
DPL-1031 - File name improvements

### DIFF
--- a/app/controllers/concerns/exports_filename_behaviour.rb
+++ b/app/controllers/concerns/exports_filename_behaviour.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Helper methods for the Exports controllers
+module ExportsFilenameBehaviour    
+    # Builds and returns the filename and file extension for the export
+    def set_filename(labware, page)
+      # The filename falls back to the csv template attribute if no filename is provided.
+      filename = export.filename&.fetch('name') || export.csv
+      filename = build_filename(filename, labware, page)
+      file_extension = export.file_extension || 'csv'
+      response.headers['Content-Disposition'] = "attachment; filename=\"#{filename}.#{file_extension}\""
+    end
+
+    private
+
+    def build_filename(filename, labware, page)
+        # Append or prepend the given barcodes to the filename if specified in the export configuration.
+        filename = handle_filename_barcode(filename, labware, export.filename&.fetch('labware_barcode', nil))
+        filename = handle_filename_barcode(filename, labware.parents&.first, 
+                                           export.filename&.fetch('parent_labware_barcode', nil))
+
+        # Append the page number to the filename if specified in the export configuration.
+        filename += "_#{page + 1}" if export.filename&.fetch('include_page', false)
+        filename
+    end
+
+    def handle_filename_barcode(filename, labware, options)
+        return filename if options.blank? || labware.blank?
+
+        barcode = labware.barcode.human
+        filename = "#{barcode}_#{filename}" if options['prepend']
+        filename = "#{filename}_#{barcode}" if options['append']
+        filename
+    end
+end

--- a/app/controllers/concerns/exports_filename_behaviour.rb
+++ b/app/controllers/concerns/exports_filename_behaviour.rb
@@ -1,35 +1,35 @@
 # frozen_string_literal: true
 
 # Helper methods for the Exports controllers
-module ExportsFilenameBehaviour    
-    # Builds and returns the filename and file extension for the export
-    def set_filename(labware, page)
-      # The filename falls back to the csv template attribute if no filename is provided.
-      filename = export.filename&.fetch('name') || export.csv
-      filename = build_filename(filename, labware, page)
-      file_extension = export.file_extension || 'csv'
-      response.headers['Content-Disposition'] = "attachment; filename=\"#{filename}.#{file_extension}\""
-    end
+module ExportsFilenameBehaviour
+  # Builds and returns the filename and file extension for the export
+  def set_filename(labware, page)
+    # The filename falls back to the csv template attribute if no filename is provided.
+    filename = export.filename&.fetch('name', nil) || export.csv
+    filename = build_filename(filename, labware, page)
+    file_extension = export.file_extension || 'csv'
+    response.headers['Content-Disposition'] = "attachment; filename=\"#{filename}.#{file_extension}\""
+  end
 
-    private
+  private
 
-    def build_filename(filename, labware, page)
-        # Append or prepend the given barcodes to the filename if specified in the export configuration.
-        filename = handle_filename_barcode(filename, labware, export.filename&.fetch('labware_barcode', nil))
-        filename = handle_filename_barcode(filename, labware.parents&.first, 
-                                           export.filename&.fetch('parent_labware_barcode', nil))
+  def build_filename(filename, labware, page)
+    # Append or prepend the given barcodes to the filename if specified in the export configuration.
+    filename = handle_filename_barcode(filename, labware, export.filename&.fetch('labware_barcode', nil))
+    filename =
+      handle_filename_barcode(filename, labware.parents&.first, export.filename&.fetch('parent_labware_barcode', nil))
 
-        # Append the page number to the filename if specified in the export configuration.
-        filename += "_#{page + 1}" if export.filename&.fetch('include_page', false)
-        filename
-    end
+    # Append the page number to the filename if specified in the export configuration.
+    filename += "_#{page + 1}" if export.filename&.fetch('include_page', false)
+    filename
+  end
 
-    def handle_filename_barcode(filename, labware, options)
-        return filename if options.blank? || labware.blank?
+  def handle_filename_barcode(filename, labware, options)
+    return filename if options.blank? || labware.blank?
 
-        barcode = labware.barcode.human
-        filename = "#{barcode}_#{filename}" if options['prepend']
-        filename = "#{filename}_#{barcode}" if options['append']
-        filename
-    end
+    barcode = labware.barcode.human
+    filename = "#{barcode}_#{filename}" if options['prepend']
+    filename = "#{filename}_#{barcode}" if options['append']
+    filename
+  end
 end

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -72,11 +72,31 @@ class ExportsController < ApplicationController
   end
 
   def set_filename
-    filename = export.csv
-    filename += "_#{@labware.human_barcode}" if export.filename['include_barcode']
-    filename += "_#{@page + 1}" if export.filename['include_page']
-    response.headers['Content-Disposition'] = "attachment; filename=\"#{filename}.csv\""
+    # The filename falls back to the csv template attribute if no filename is provided.
+    filename = export.filename['name'] || export.csv
+    filename = build_filename(filename)
+    file_extension = export.file_extension || 'csv'
+    response.headers['Content-Disposition'] = "attachment; filename=\"#{filename}.#{file_extension}\""
   end
+
+  def build_filename(filename)
+    # Append or prepend the give barcodes to the filename if specified in the export configuration.
+    filename = handle_filename_barcode(filename, @labware, export.filename['labware_barcode'])
+    filename = handle_filename_barcode(filename, @labware.parents.first, export.filename['parent_labware_barcode'])
+    # Append the page number to the filename if specified in the export configuration.
+    filename += "_#{@page + 1}" if export.filename['include_page']
+    filename
+  end
+
+  def handle_filename_barcode(filename, labware, options)
+    return filename if options.blank? || labware.blank?
+
+    barcode = labware.human_barcode
+    filename = "#{barcode}_#{filename}" if options['prepend']
+    filename = "#{filename}_#{barcode}"if options['append']
+    filename
+  end
+
 
   def ancestor_tube_details(ancestor_results)
     ancestor_results.each_with_object({}) do |ancestor_result, tube_list|

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -80,7 +80,7 @@ class ExportsController < ApplicationController
   end
 
   def build_filename(filename)
-    # Append or prepend the give barcodes to the filename if specified in the export configuration.
+    # Append or prepend the given barcodes to the filename if specified in the export configuration.
     filename = handle_filename_barcode(filename, @labware, export.filename['labware_barcode'])
     filename = handle_filename_barcode(filename, @labware.parents&.first, export.filename['parent_labware_barcode'])
 

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -83,6 +83,7 @@ class ExportsController < ApplicationController
     # Append or prepend the give barcodes to the filename if specified in the export configuration.
     filename = handle_filename_barcode(filename, @labware, export.filename['labware_barcode'])
     filename = handle_filename_barcode(filename, @labware.parents.first, export.filename['parent_labware_barcode'])
+
     # Append the page number to the filename if specified in the export configuration.
     filename += "_#{@page + 1}" if export.filename['include_page']
     filename
@@ -93,10 +94,9 @@ class ExportsController < ApplicationController
 
     barcode = labware.human_barcode
     filename = "#{barcode}_#{filename}" if options['prepend']
-    filename = "#{filename}_#{barcode}"if options['append']
+    filename = "#{filename}_#{barcode}" if options['append']
     filename
   end
-
 
   def ancestor_tube_details(ancestor_results)
     ancestor_results.each_with_object({}) do |ancestor_result, tube_list|

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -17,6 +17,7 @@ class ExportsController < ApplicationController
     @ancestor_tubes = locate_ancestor_tubes
     @ancestor_plate_list = locate_ancestor_plate_list
 
+    # Set the filename for the export via the ExportsFilenameBehaviour concern
     set_filename(@labware, @page) if export.filename
 
     render export.csv, locals: { test: 'this' }

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -82,7 +82,7 @@ class ExportsController < ApplicationController
   def build_filename(filename)
     # Append or prepend the give barcodes to the filename if specified in the export configuration.
     filename = handle_filename_barcode(filename, @labware, export.filename['labware_barcode'])
-    filename = handle_filename_barcode(filename, @labware.parents.first, export.filename['parent_labware_barcode'])
+    filename = handle_filename_barcode(filename, @labware.parents&.first, export.filename['parent_labware_barcode'])
 
     # Append the page number to the filename if specified in the export configuration.
     filename += "_#{@page + 1}" if export.filename['include_page']
@@ -92,7 +92,7 @@ class ExportsController < ApplicationController
   def handle_filename_barcode(filename, labware, options)
     return filename if options.blank? || labware.blank?
 
-    barcode = labware.human_barcode
+    barcode = labware.barcode.human
     filename = "#{barcode}_#{filename}" if options['prepend']
     filename = "#{filename}_#{barcode}" if options['append']
     filename

--- a/app/controllers/tubes/tubes_exports_controller.rb
+++ b/app/controllers/tubes/tubes_exports_controller.rb
@@ -66,6 +66,7 @@ class Tubes::TubesExportsController < ApplicationController
     # Append or prepend the give barcodes to the filename if specified in the export configuration.
     filename = handle_filename_barcode(filename, @labware, export.filename['labware_barcode'])
     filename = handle_filename_barcode(filename, @labware.parents.first, export.filename['parent_labware_barcode'])
+
     # Append the page number to the filename if specified in the export configuration.
     filename += "_#{@page + 1}" if export.filename['include_page']
     filename
@@ -76,7 +77,7 @@ class Tubes::TubesExportsController < ApplicationController
 
     barcode = labware.human_barcode
     filename = "#{barcode}_#{filename}" if options['prepend']
-    filename = "#{filename}_#{barcode}"if options['append']
+    filename = "#{filename}_#{barcode}" if options['append']
     filename
   end
 end

--- a/app/controllers/tubes/tubes_exports_controller.rb
+++ b/app/controllers/tubes/tubes_exports_controller.rb
@@ -63,7 +63,7 @@ class Tubes::TubesExportsController < ApplicationController
   end
 
   def build_filename(filename)
-    # Append or prepend the give barcodes to the filename if specified in the export configuration.
+    # Append or prepend the given barcodes to the filename if specified in the export configuration.
     filename = handle_filename_barcode(filename, @labware, export.filename['labware_barcode'])
     filename = handle_filename_barcode(filename, @labware.parents&.first, export.filename['parent_labware_barcode'])
 

--- a/app/controllers/tubes/tubes_exports_controller.rb
+++ b/app/controllers/tubes/tubes_exports_controller.rb
@@ -5,6 +5,7 @@ require 'csv'
 # The exports controller handles the generation of exported files for tubes,
 # such as CSV files for mbrave files.
 class Tubes::TubesExportsController < ApplicationController
+  include ExportsFilenameBehaviour
   helper ExportsHelper
   before_action :locate_labware, only: :show
   rescue_from Export::NotFound, with: :not_found
@@ -13,7 +14,7 @@ class Tubes::TubesExportsController < ApplicationController
     @page = params.fetch(:page, 0).to_i
     @workflow = export.workflow
 
-    set_filename if export.filename
+    set_filename(@labware, @page) if export.filename
 
     render export.csv
   end
@@ -52,32 +53,5 @@ class Tubes::TubesExportsController < ApplicationController
   # https://jsonapi.org/format/#fetching-sparse-fieldsets
   def select_parameters
     export.tube_selects || nil
-  end
-
-  def set_filename
-    # The filename falls back to the csv template attribute if no filename is provided.
-    filename = export.filename['name'] || export.csv
-    filename = build_filename(filename)
-    file_extension = export.file_extension || 'csv'
-    response.headers['Content-Disposition'] = "attachment; filename=\"#{filename}.#{file_extension}\""
-  end
-
-  def build_filename(filename)
-    # Append or prepend the given barcodes to the filename if specified in the export configuration.
-    filename = handle_filename_barcode(filename, @labware, export.filename['labware_barcode'])
-    filename = handle_filename_barcode(filename, @labware.parents&.first, export.filename['parent_labware_barcode'])
-
-    # Append the page number to the filename if specified in the export configuration.
-    filename += "_#{@page + 1}" if export.filename['include_page']
-    filename
-  end
-
-  def handle_filename_barcode(filename, labware, options)
-    return filename if options.blank? || labware.blank?
-
-    barcode = labware.barcode.human
-    filename = "#{barcode}_#{filename}" if options['prepend']
-    filename = "#{filename}_#{barcode}" if options['append']
-    filename
   end
 end

--- a/app/controllers/tubes/tubes_exports_controller.rb
+++ b/app/controllers/tubes/tubes_exports_controller.rb
@@ -65,7 +65,7 @@ class Tubes::TubesExportsController < ApplicationController
   def build_filename(filename)
     # Append or prepend the give barcodes to the filename if specified in the export configuration.
     filename = handle_filename_barcode(filename, @labware, export.filename['labware_barcode'])
-    filename = handle_filename_barcode(filename, @labware.parents.first, export.filename['parent_labware_barcode'])
+    filename = handle_filename_barcode(filename, @labware.parents&.first, export.filename['parent_labware_barcode'])
 
     # Append the page number to the filename if specified in the export configuration.
     filename += "_#{@page + 1}" if export.filename['include_page']
@@ -75,7 +75,7 @@ class Tubes::TubesExportsController < ApplicationController
   def handle_filename_barcode(filename, labware, options)
     return filename if options.blank? || labware.blank?
 
-    barcode = labware.human_barcode
+    barcode = labware.barcode.human
     filename = "#{barcode}_#{filename}" if options['prepend']
     filename = "#{filename}_#{barcode}" if options['append']
     filename

--- a/app/controllers/tubes/tubes_exports_controller.rb
+++ b/app/controllers/tubes/tubes_exports_controller.rb
@@ -14,6 +14,7 @@ class Tubes::TubesExportsController < ApplicationController
     @page = params.fetch(:page, 0).to_i
     @workflow = export.workflow
 
+    # Set the filename for the export via the ExportsFilenameBehaviour concern
     set_filename(@labware, @page) if export.filename
 
     render export.csv

--- a/config/exports/exports.yml
+++ b/config/exports/exports.yml
@@ -157,6 +157,7 @@ hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare:
     - wells.aliquots.sample.sample_metadata
   ancestor_tube_purpose: LRC Blood Vac
   filename:
+    name: hamilton_pbmc_bank
     labware_barcode:
       prepend: true
 hamilton_lrc_blood_bank_to_lrc_pbmc_bank:
@@ -170,6 +171,7 @@ hamilton_lrc_blood_bank_to_lrc_pbmc_bank:
   ancestor_tube_purpose: LRC Blood Vac
   ancestor_purpose: LRC Blood Bank
   filename:
+    name: hamilton_pbmc_isolation
     labware_barcode:
       prepend: true
 pbmc_bank_tubes_content_report:

--- a/config/exports/exports.yml
+++ b/config/exports/exports.yml
@@ -98,7 +98,8 @@ hamilton_ltn_al_lib_to_ltn_al_lib_dil:
 cellaca_input_file:
   csv: cellaca_input_file
   filename:
-    include_barcode: true
+    labware_barcode:
+      append: true
     include_page: true
 hamilton_pooling_plate_pbmc:
   csv: hamilton_pooling_plate_pbmc
@@ -136,7 +137,8 @@ bioscan_mbrave:
       - sample_description
   file_extension: 'tsv'
   filename:
-    include_barcode: true
+    labware_barcode:
+      append: true
 lcmb_pcr_xp_concentrations_for_custom_pooling:
   csv: lcmb_pcr_xp_concentrations_for_custom_pooling
   plate_includes: wells.qc_results,wells.aliquots,wells.aliquots.sample
@@ -155,7 +157,8 @@ hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare:
     - wells.aliquots.sample.sample_metadata
   ancestor_tube_purpose: LRC Blood Vac
   filename:
-    include_barcode: true
+    labware_barcode:
+      prepend: true
 hamilton_lrc_blood_bank_to_lrc_pbmc_bank:
   csv: hamilton_lrc_blood_bank_to_lrc_pbmc_bank
   workflow: scRNA Core PBMC isolation
@@ -167,7 +170,8 @@ hamilton_lrc_blood_bank_to_lrc_pbmc_bank:
   ancestor_tube_purpose: LRC Blood Vac
   ancestor_purpose: LRC Blood Bank
   filename:
-    include_barcode: true
+    labware_barcode:
+      prepend: true
 pbmc_bank_tubes_content_report:
   csv: pbmc_bank_tubes_content_report
   workflow: scRNA Core PBMC Bank

--- a/docs/exports_yaml_files.md
+++ b/docs/exports_yaml_files.md
@@ -132,15 +132,17 @@ filename:
   name: 'example-name'
   # Includes the page number at the end of the filename
   include_page: true
-  # Includes the labware's human barcode in the file
+  # Includes the labware's human barcode in the file, there is no default, either append or prepend is needed to show the barcode
   labware_barcode:
-    # Includes the name of the labware in the file
+    # (Optional) Includes the name of the labware in the file
     append: true
-    # Add the name to the end of the file
+    # (Optional) Add the name to the end of the file
     prepend: false
-  # Includes the parent labware's human barcode
+  # Includes the parent labware's human barcode, either append or prepend is needed to show the barcode
   parent_labware_barcode:
+    # (Optional) Includes the name of the labware in the file
     append: true
+    # (Optional) Add the name to the end of the file
     prepend: true
 ```
 

--- a/docs/exports_yaml_files.md
+++ b/docs/exports_yaml_files.md
@@ -76,6 +76,7 @@ The other keys are detailed below.
 
 Determines the template in `app/views/exports` that will be used to render the
 export. If possible, try and use the same value for the template and the id.
+It is also used as the fallback option for the filename if the filename is not set.
 
 ```yaml
 csv: unique_export
@@ -119,6 +120,36 @@ Example in `app/views/exports/duplex_seq_pcr_xp_concentrations_for_custom_poolin
 
 ```yaml
 ancestor_purpose: LDS AL Lib Dil
+```
+
+#### filename
+
+A method of specifiying what data is included in the filename of the export.
+
+```yaml
+filename:
+  # The name of the export file
+  name: 'example-name'
+  # Includes the page number at the end of the filename
+  include_page: true
+  # Includes the labware's human barcode in the file
+  labware_barcode:
+    # Includes the name of the labware in the file
+    append: true
+    # Add the name to the end of the file
+    prepend: false
+  # Includes the parent labware's human barcode
+  parent_labware_barcode:
+    append: true
+    prepend: true
+```
+
+#### file_extension
+
+The file extension of the export file. Defaults to `csv`.
+
+```yaml
+file_extension: 'tsv'
 ```
 
 ### Testing

--- a/spec/controllers/concerns/exports_filename_behaviour_spec.rb
+++ b/spec/controllers/concerns/exports_filename_behaviour_spec.rb
@@ -3,64 +3,69 @@
 require 'spec_helper'
 
 RSpec.describe ExportsFilenameBehaviour do
-    let(:dummy_class) { Struct.new(:export, :response) { include ExportsFilenameBehaviour } }
+  let(:dummy_class) { Struct.new(:export, :response) { include ExportsFilenameBehaviour } }
 
-    describe '#set_filename' do
-        let(:filename) { 'filename' }
-        let(:file_extension) { 'csv' }
-        let(:labware) do
-            double('labware', barcode: double('barcode', human: '12345'), 
-                    parents: [double('labware', barcode: double('barcode', human: '67890'))]) 
-        end
-        let(:page) { 0 }
-        let(:export) do
-            double('export', 
-                filename: { 
-                    'name' => filename,
-                    'labware_barcode' => { 
-                        'prepend' => true,
-                        'append' => true
-                    },
-                    'include_page' => true
-                }, 
-                csv: 'csv', 
-                file_extension: file_extension
-            )
-        end
-        let(:response) { double('response', headers: { }) }
-        let(:dummy_instance) { dummy_class.new(export, response)}
-
-        before do
-            allow(dummy_instance).to receive(:export).and_return(export)
-            allow(dummy_instance).to receive(:response).and_return(response)
-        end
-
-        it 'sets the correct filename and file extension for the export' do
-            dummy_instance.set_filename(labware, page)
-
-            expect(response.headers['Content-Disposition']).to eq 'attachment; filename="12345_filename_12345_1.csv"'
-        end
-
-        it 'sets the correct filename when a parent barcode is given' do
-            export = double('export', filename: { 
-                'name' => filename, 
-                'parent_labware_barcode' => { 'prepend' => true, 'append' => true },
-                'include_page' => true,
-                'file_extenion' => 'csv'
-            }, file_extension:  file_extension)
-            allow(dummy_instance).to receive(:export).and_return(export)
-            dummy_instance.set_filename(labware, page)
-
-            expect(response.headers['Content-Disposition']).to eq 'attachment; filename="67890_filename_67890_1.csv"'
-        end
-
-        it 'sets the correct filename when no extra filename data is included' do
-            export = Export.new(csv: filename)
-            allow(dummy_instance).to receive(:export).and_return(export)
-
-            dummy_instance.set_filename(labware, page)
-
-            expect(response.headers['Content-Disposition']).to eq 'attachment; filename="filename.csv"'
-        end
+  describe '#set_filename' do
+    let(:filename) { 'filename' }
+    let(:labware) do
+      double(
+        'labware',
+        barcode: double('barcode', human: '12345'),
+        parents: [double('labware', barcode: double('barcode', human: '67890'))]
+      )
     end
+    let(:page) { 0 }
+    let(:export) { Export.new(csv: filename) }
+    let(:response) { double('response', headers: {}) }
+    let(:dummy_instance) { dummy_class.new(export, response) }
+
+    before { allow(dummy_instance).to receive(:response).and_return(response) }
+
+    it 'sets the correct filename when no extra filename data is included' do
+      allow(dummy_instance).to receive(:export).and_return(export)
+
+      dummy_instance.set_filename(labware, page)
+
+      expect(response.headers['Content-Disposition']).to eq 'attachment; filename="filename.csv"'
+    end
+
+    it 'sets the correct filename and file extension for the export' do
+      export =
+        Export.new(
+          filename: {
+            'name' => filename,
+            'labware_barcode' => {
+              'prepend' => true,
+              'append' => true
+            },
+            'include_page' => true
+          },
+          csv: 'csv',
+          file_extension: 'tsv'
+        )
+      allow(dummy_instance).to receive(:export).and_return(export)
+      dummy_instance.set_filename(labware, page)
+
+      expect(response.headers['Content-Disposition']).to eq 'attachment; filename="12345_filename_12345_1.tsv"'
+    end
+
+    it 'sets the correct filename when a parent barcode is given' do
+      export =
+        Export.new(
+          csv: 'csv-filename',
+          filename: {
+            'name' => filename,
+            'parent_labware_barcode' => {
+              'prepend' => true,
+              'append' => true
+            },
+            'include_page' => true
+          }
+        )
+      allow(dummy_instance).to receive(:export).and_return(export)
+      dummy_instance.set_filename(labware, page)
+
+      expect(response.headers['Content-Disposition']).to eq 'attachment; filename="67890_filename_67890_1.csv"'
+    end
+  end
 end

--- a/spec/controllers/concerns/exports_filename_behaviour_spec.rb
+++ b/spec/controllers/concerns/exports_filename_behaviour_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ExportsFilenameBehaviour do
+    let(:dummy_class) { Struct.new(:export, :response) { include ExportsFilenameBehaviour } }
+
+    describe '#set_filename' do
+        let(:filename) { 'filename' }
+        let(:file_extension) { 'csv' }
+        let(:labware) do
+            double('labware', barcode: double('barcode', human: '12345'), 
+                    parents: [double('labware', barcode: double('barcode', human: '67890'))]) 
+        end
+        let(:page) { 0 }
+        let(:export) do
+            double('export', 
+                filename: { 
+                    'name' => filename,
+                    'labware_barcode' => { 
+                        'prepend' => true,
+                        'append' => true
+                    },
+                    'include_page' => true
+                }, 
+                csv: 'csv', 
+                file_extension: file_extension
+            )
+        end
+        let(:response) { double('response', headers: { }) }
+        let(:dummy_instance) { dummy_class.new(export, response)}
+
+        before do
+            allow(dummy_instance).to receive(:export).and_return(export)
+            allow(dummy_instance).to receive(:response).and_return(response)
+        end
+
+        it 'sets the correct filename and file extension for the export' do
+            dummy_instance.set_filename(labware, page)
+
+            expect(response.headers['Content-Disposition']).to eq 'attachment; filename="12345_filename_12345_1.csv"'
+        end
+
+        it 'sets the correct filename when a parent barcode is given' do
+            export = double('export', filename: { 
+                'name' => filename, 
+                'parent_labware_barcode' => { 'prepend' => true, 'append' => true },
+                'include_page' => true,
+                'file_extenion' => 'csv'
+            }, file_extension:  file_extension)
+            allow(dummy_instance).to receive(:export).and_return(export)
+            dummy_instance.set_filename(labware, page)
+
+            expect(response.headers['Content-Disposition']).to eq 'attachment; filename="67890_filename_67890_1.csv"'
+        end
+
+        it 'sets the correct filename when no extra filename data is included' do
+            export = Export.new(csv: filename)
+            allow(dummy_instance).to receive(:export).and_return(export)
+
+            dummy_instance.set_filename(labware, page)
+
+            expect(response.headers['Content-Disposition']).to eq 'attachment; filename="filename.csv"'
+        end
+    end
+end


### PR DESCRIPTION
Closes #1521 

#### Changes proposed in this pull request
- Extends exports.yml documentation
- Adds ability to specify independent filename for exports
- Adds ability to prepend barcodes in exports filename
- Adds ability to include parent labware barcode in exports filename

#### Instructions for Reviewers

There are no independent unit tests, mainly because the exports_controller tests it by proxy and it is has a different style of testing. But I have tested manually with a few variations and it is working.
