### PR TITLE
Test fix cellaca plate label date test

### DIFF
--- a/spec/models/labels/plate_label_cellaca_qc_spec.rb
+++ b/spec/models/labels/plate_label_cellaca_qc_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Labels::PlateLabelCellacaQc, type: :model do
   describe '#qc_label_definitions' do
     subject(:qc_label_definitions) { label.qc_label_definitions }
     let(:label) { described_class.new(labware) }
+    let(:date_format) { /\A\s?\d{1,2}-[A-Z]{3}-\d{4}\z/ } # e.g., ' 4 JUL 2023' or '24 JUL 2023'
 
     context 'when creating the label of a full plate' do
       let(:labware) { create :v2_plate, pool_sizes: [96] }
@@ -25,7 +26,7 @@ RSpec.describe Labels::PlateLabelCellacaQc, type: :model do
       it 'contains four items' do
         expect(qc_label_definitions.length).to eq(4)
 
-        expect(qc_label_definitions.pluck(:top_left)).to all(eq(Time.zone.today.strftime('%d-%b-%Y').upcase))
+        expect(qc_label_definitions.pluck(:top_left)).to all(match(date_format))
         expect(qc_label_definitions.pluck(:top_right)).to all(eq('DN2T'))
         expect(qc_label_definitions.pluck(:bottom_left)).to eq(
           [

--- a/spec/models/labels/plate_label_cellaca_qc_spec.rb
+++ b/spec/models/labels/plate_label_cellaca_qc_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Labels::PlateLabelCellacaQc, type: :model do
   describe '#qc_label_definitions' do
     subject(:qc_label_definitions) { label.qc_label_definitions }
     let(:label) { described_class.new(labware) }
-    let(:date_format) { /\A\s?\d{1,2}-[A-Z]{3}-\d{4}\z/ } # e.g., ' 4 JUL 2023' or '24 JUL 2023'
 
     context 'when creating the label of a full plate' do
       let(:labware) { create :v2_plate, pool_sizes: [96] }
@@ -26,7 +25,7 @@ RSpec.describe Labels::PlateLabelCellacaQc, type: :model do
       it 'contains four items' do
         expect(qc_label_definitions.length).to eq(4)
 
-        expect(qc_label_definitions.pluck(:top_left)).to all(match(date_format))
+        expect(qc_label_definitions.pluck(:top_left)).to all(eq(Time.zone.today.strftime('%e-%^b-%Y')))
         expect(qc_label_definitions.pluck(:top_right)).to all(eq('DN2T'))
         expect(qc_label_definitions.pluck(:bottom_left)).to eq(
           [

--- a/spec/models/labels/plate_label_quad_qc_spec.rb
+++ b/spec/models/labels/plate_label_quad_qc_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Labels::PlateLabelQuadQc, type: :model do
   describe '#qc_label_definitions' do
     subject(:qc_label_definitions) { label.qc_label_definitions }
     let(:label) { described_class.new(labware) }
+    let(:date_format) { /\A\s?\d{1,2}-[A-Z]{3}-\d{4}\z/ } # e.g., ' 4 JUL 2023' or '24 JUL 2023'
 
     context 'when creating the label of a full plate' do
       let(:labware) { create :v2_plate, pool_sizes: [96] }
@@ -25,7 +26,7 @@ RSpec.describe Labels::PlateLabelQuadQc, type: :model do
       it 'contains four items' do
         expect(qc_label_definitions.length).to eq(4)
 
-        expect(qc_label_definitions.pluck(:top_left)).to all(eq(Time.zone.today.strftime('%d-%b-%Y').upcase))
+        expect(qc_label_definitions.pluck(:top_left)).to all(match(date_format))
         expect(qc_label_definitions.pluck(:top_right)).to all(eq('DN2T'))
         expect(qc_label_definitions.pluck(:bottom_left)).to eq(
           [

--- a/spec/models/labels/plate_label_quad_qc_spec.rb
+++ b/spec/models/labels/plate_label_quad_qc_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Labels::PlateLabelQuadQc, type: :model do
   describe '#qc_label_definitions' do
     subject(:qc_label_definitions) { label.qc_label_definitions }
     let(:label) { described_class.new(labware) }
-    let(:date_format) { /\A\s?\d{1,2}-[A-Z]{3}-\d{4}\z/ } # e.g., ' 4 JUL 2023' or '24 JUL 2023'
 
     context 'when creating the label of a full plate' do
       let(:labware) { create :v2_plate, pool_sizes: [96] }
@@ -26,7 +25,7 @@ RSpec.describe Labels::PlateLabelQuadQc, type: :model do
       it 'contains four items' do
         expect(qc_label_definitions.length).to eq(4)
 
-        expect(qc_label_definitions.pluck(:top_left)).to all(match(date_format))
+        expect(qc_label_definitions.pluck(:top_left)).to all(eq(Time.zone.today.strftime('%e-%^b-%Y')))
         expect(qc_label_definitions.pluck(:top_right)).to all(eq('DN2T'))
         expect(qc_label_definitions.pluck(:bottom_left)).to eq(
           [


### PR DESCRIPTION
This change is causing CI issues currently.
See: https://github.com/sanger/limber/actions/runs/9744623445/job/26890652637

#### Changes proposed in this pull request

- Updates plate_label_cellaca_qc_spec to match label date with a date regex keeping it inline with other specs
