### PR TITLE
BUG - removed unneeded input_plate flag from config files

### DIFF
--- a/config/purposes/anospp.yml
+++ b/config/purposes/anospp.yml
@@ -5,7 +5,6 @@ LANS-96 Stock:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: false
-  :input_plate: true
   :presenter_class: Presenters::StockPlatePresenter
   :creator_class: LabwareCreators::Uncreatable
   :size: 96
@@ -16,7 +15,6 @@ LANS-96 Lysate:
   :asset_type: plate
   :stock_plate: false
   :cherrypickable_target: false
-  :input_plate: false
   :label_template: plate_96_lysate
   :presenter_class: Presenters::StockPlatePresenter
   :state_changer_class: StateChangers::AutomaticPlateStateChanger

--- a/config/purposes/bespoke.yml
+++ b/config/purposes/bespoke.yml
@@ -5,7 +5,6 @@ LBB Cherrypick:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :presenter_class: Presenters::StockPlatePresenter
 LBB Ligation:
   :asset_type: plate

--- a/config/purposes/bespoke_chromium_shared.yml
+++ b/config/purposes/bespoke_chromium_shared.yml
@@ -3,5 +3,4 @@ LBC Stock:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :presenter_class: Presenters::StockPlatePresenter

--- a/config/purposes/bioscan.yml
+++ b/config/purposes/bioscan.yml
@@ -5,7 +5,6 @@ LILYS-96 Stock:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: false
-  :input_plate: true
   :presenter_class: Presenters::StockPlatePresenter
   :creator_class: LabwareCreators::Uncreatable
   :size: 96
@@ -19,7 +18,6 @@ LBSN-96 Lysate:
   :stock_plate: true
   :cherrypickable_target: false
   # LYSATE plate can be created from LILYS as well. The following must be false.
-  :input_plate: false
   :type: PlatePurpose::AdditionalInput
   :label_template: plate_96_lysate
   :presenter_class: Presenters::StockPlatePresenter

--- a/config/purposes/cardinal.yml
+++ b/config/purposes/cardinal.yml
@@ -7,7 +7,6 @@
 LCA Blood Vac:
   :asset_type: tube
   :stock_plate: false
-  :input_plate: false
   :target: SampleTube
   :type: Tube::Purpose
   :presenter_class: Presenters::VacTubePresenter
@@ -21,7 +20,6 @@ LCA Blood Array:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: false
-  :input_plate: false
   :creator_class: LabwareCreators::MultiStampTubes
   :submission_options:
     Cardinal library prep:
@@ -116,7 +114,6 @@ LCA Custom Pool Norm:
 LCA Blood Bank:
   :asset_type: plate
   :stock_plate: false
-  :input_plate: false
   :creator_class:
     name: LabwareCreators::MultiStampTubes
     params:

--- a/config/purposes/combined_lcm_dna_and_rna_seq.yml
+++ b/config/purposes/combined_lcm_dna_and_rna_seq.yml
@@ -2,7 +2,6 @@
 CLCM Stock:
   :asset_type: plate
   :stock_plate: true
-  :input_plate: true
   :creator_class: LabwareCreators::Uncreatable
 CLCM Lysate DNA:
   :asset_type: plate

--- a/config/purposes/deep_well_96_stamping.yml
+++ b/config/purposes/deep_well_96_stamping.yml
@@ -6,7 +6,6 @@ LDW-96 Stock:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: false
-  :input_plate: true
   :creator_class: LabwareCreators::Uncreatable
   :presenter_class: Presenters::SubmissionPlatePresenter
   :submission_options:
@@ -22,7 +21,6 @@ LSW-96 Stock:
   :asset_type: plate
   :stock_plate: false
   :cherrypickable_target: false
-  :input_plate: false
   :state_changer_class: StateChangers::AutomaticPlateStateChanger
   :work_completion_request_type: deep_well_plate_stamping
   :creator_class: LabwareCreators::StampedPlate

--- a/config/purposes/duplex_seq.yml
+++ b/config/purposes/duplex_seq.yml
@@ -5,13 +5,11 @@ LDS Stock:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: false
-  :input_plate: true
   :presenter_class: Presenters::StockPlatePresenter
 LDS Cherrypick:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :presenter_class: Presenters::StockPlatePresenter
 LDS Stock XP:
   :asset_type: plate

--- a/config/purposes/genotype_by_sequencing.yml
+++ b/config/purposes/genotype_by_sequencing.yml
@@ -4,21 +4,18 @@ GBS Stock:
   :stock_plate: true
   :cherrypickable_target: false
   :presenter_class: Presenters::MinimalStockPlatePresenter
-  :input_plate: true
   :size: 384
 GBS-96 Stock:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: false
   :presenter_class: Presenters::MinimalStockPlatePresenter
-  :input_plate: true
   :size: 96
 GBS PCR1:
   :asset_type: plate
   :stock_plate: false
   :cherrypickable_target: false
   :presenter_class: Presenters::MinimalPcrPlatePresenter
-  :input_plate: false
   :creator_class: LabwareCreators::QuadrantStampPrimerPanel
   :size: 384
   :pcr_stage: 'pcr 1'
@@ -34,7 +31,6 @@ GBS PCR2:
     - GbS Tag Set C
     - GbS Tag Set D
   :presenter_class: Presenters::MinimalPcrPlatePresenter
-  :input_plate: false
   :size: 384
   :pcr_stage: 'pcr 2'
   :label_template: plate_6mm_double

--- a/config/purposes/gnt.yml
+++ b/config/purposes/gnt.yml
@@ -3,12 +3,10 @@ GnT Stock:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :presenter_class: Presenters::StockPlatePresenter
 GnT scDNA:
   :asset_type: plate
   :cherrypickable_target: false
-  :input_plate: false
 GnT Pico-XP:
   :asset_type: plate
 GnT Pico End Prep:

--- a/config/purposes/heron.yml
+++ b/config/purposes/heron.yml
@@ -7,7 +7,6 @@ LHR RT:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :default_printer_type: :plate_a
   :presenter_class: Presenters::StockPlatePresenter
 LHR PCR 1:

--- a/config/purposes/heron_384.yml
+++ b/config/purposes/heron_384.yml
@@ -7,7 +7,6 @@ LHR-384 RT:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :default_printer_type: :plate_a
   :presenter_class: Presenters::StockPlatePresenter
   :label_template: plate_6mm_double

--- a/config/purposes/heron_lthr_384.yml
+++ b/config/purposes/heron_lthr_384.yml
@@ -3,7 +3,6 @@ LTHR-384 RT:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :presenter_class: Presenters::StockPlatePresenter
   :creator_class: LabwareCreators::Uncreatable
   :label_template: plate_6mm_double

--- a/config/purposes/heron_lthr_96.yml
+++ b/config/purposes/heron_lthr_96.yml
@@ -3,7 +3,6 @@ LTHR RT:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :presenter_class: Presenters::StockPlatePresenter
   :creator_class: LabwareCreators::Uncreatable
 LTHR RT-S: # Stamp from the LTHR Cherrypick plates.

--- a/config/purposes/heron_lthr_entry.yml
+++ b/config/purposes/heron_lthr_entry.yml
@@ -6,7 +6,6 @@ LTHR Cherrypick:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :creator_class: LabwareCreators::Uncreatable
   :presenter_class: Presenters::SubmissionPlatePresenter
   :submission_options:

--- a/config/purposes/isc_bottom.yml
+++ b/config/purposes/isc_bottom.yml
@@ -4,7 +4,6 @@ LB Lib PrePool:
   :stock_plate: false
   :creator_class: LabwareCreators::MultiPlatePool
   :cherrypickable_target: false
-  :input_plate: false
   :default_printer_type: :plate_b
   :csv_template: 'show_extended'
   # This attribute (alternative_workline_identifier) defines this plate purpose

--- a/config/purposes/lcmb.yml
+++ b/config/purposes/lcmb.yml
@@ -3,7 +3,6 @@ LCMB Cherrypick:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :presenter_class: Presenters::StockPlatePresenter
 LCMB End Prep:
   :asset_type: plate

--- a/config/purposes/pcrfree.yml
+++ b/config/purposes/pcrfree.yml
@@ -3,7 +3,6 @@ PF Cherrypicked:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :default_printer_type: :plate_a
   :presenter_class: Presenters::StockPlatePresenter
 PF Shear:

--- a/config/purposes/rna_plates.yml
+++ b/config/purposes/rna_plates.yml
@@ -3,7 +3,6 @@ LBR Cherrypick:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :presenter_class: Presenters::StockPlatePresenter
 LBR mRNA Cap:
   :asset_type: plate

--- a/config/purposes/rvi.yml
+++ b/config/purposes/rvi.yml
@@ -2,7 +2,6 @@ RVI Cherrypick:
   :asset_type: plate
   :stock_plate: false
   :cherrypickable_target: true
-  :input_plate: false
   :presenter_class: Presenters::PermissivePresenter
 
 RVI RT:

--- a/config/purposes/scrna.yml
+++ b/config/purposes/scrna.yml
@@ -3,13 +3,11 @@ scRNA Stock:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :presenter_class: Presenters::StockPlatePresenter
 scRNA-384 Stock:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :presenter_class: Presenters::MinimalStockPlatePresenter
   :label_template: plate_6mm_double
   :size: 384

--- a/config/purposes/scrna_core_cdna_prep.wip.yml
+++ b/config/purposes/scrna_core_cdna_prep.wip.yml
@@ -11,7 +11,6 @@ LRC PBMC Cryostor:
   :asset_type: plate
   :size: 96
   :stock_plate: false
-  :input_plate: false
   :creator_class:
     name: LabwareCreators::MultiStampTubesUsingTubeRackScan
     args:
@@ -38,7 +37,6 @@ LRC PBMC Defrost PBS:
       default_threshold: 400000
       decimal_places: 0
   :stock_plate: false
-  :input_plate: false
 # Plate containing pooled PBMCs from different donors.
 # This plate has come from the LRC PBMC Defrost PBS plate, in SeqOps.
 LRC PBMC Pools:
@@ -67,7 +65,6 @@ LRC PBMC Pools:
       # configuration is provided.
       pooling: interim_scrna_core_donor_pooling
   :stock_plate: false
-  :input_plate: false
   :file_links:
     - name: 'Download Hamilton LRC PBMC Defrost PBS to LRC PBMC Pools CSV'
       id: hamilton_lrc_pbmc_defrost_pbs_to_lrc_pbmc_pools
@@ -77,8 +74,7 @@ LRC PBMC Pools Input:
   :asset_type: plate
   # stock_plate has to be true so that it appears in the 'Purpose' list when generating a sample manifest in Sequencescape
   :stock_plate: true
-  # input_plate has to be true so that the statechanger shows the plate as passed in the initial presenter
-  :input_plate: true
+  # NB. in the SS config input_plate has to be true so statechanger shows the plate as passed in the initial presenter
   :cherrypickable_target: true
   # display as a stock plate in the UI
   :presenter_class: Presenters::StockPlatePresenter
@@ -94,7 +90,6 @@ LRC GEM-X 5p Chip:
   :asset_shape: Shape8x1
   :size: 8
   :stock_plate: false
-  :input_plate: false
   :creator_class: LabwareCreators::StampedPlateReorderingColumnsToRows
   # ChromiumChipPresenter has been added to disable the incompatible pooling tab.
   :presenter_class: Presenters::ChromiumChipPresenter
@@ -105,20 +100,17 @@ LRC GEM-X 5p Chip:
 LRC GEM-X 5p GEMs:
   :asset_type: plate
   :stock_plate: false
-  :input_plate: false
   :creator_class: LabwareCreators::StampedPlateCompressed
 # Plate containing cDNA (converted from RNA), straight stamp from above.
 LRC GEM-X 5p cDNA PCR:
   :asset_type: plate
   :stock_plate: false
-  :input_plate: false
 # Plate containing cleaned up cDNA, duplicate wells consolidated back together.
 # TODO: check whether the stock and or input plate flags are correct to allow an aggregation
 # submission to be created on this plate
 LRC GEM-X 5p cDNA PCR XP:
   :asset_type: plate
   :stock_plate: false
-  :input_plate: false
   # close off the submission when the plate is created
   :state_changer_class: StateChangers::AutomaticPlateStateChanger
   :work_completion_request_type: 'limber_scrna_core_cdna_prep_input'
@@ -126,7 +118,6 @@ LRC GEM-X 5p cDNA PCR XP:
 LRC GEM-X 5p cDNA Input:
   :asset_type: plate
   :stock_plate: true
-  :input_plate: true
   # display as a stock plate in the UI
   :presenter_class: Presenters::StockPlatePresenter
   # will not be creatable in Limber (created by manifest in Sequencescape)

--- a/config/purposes/scrna_core_cell_extraction.yml
+++ b/config/purposes/scrna_core_cell_extraction.yml
@@ -8,7 +8,6 @@
 LRC Blood Vac:
   :asset_type: tube
   :stock_plate: false
-  :input_plate: false
   :target: SampleTube
   :type: Tube::Purpose
   :presenter_class: Presenters::VacTubePresenter
@@ -18,7 +17,6 @@ LRC Blood Vac:
 LRC Blood Aliquot:
   :asset_type: tube
   :stock_plate: false
-  :input_plate: false
   :target: SampleTube
   :type: Tube::Purpose
   :presenter_class: Presenters::SimpleTubePresenter
@@ -33,7 +31,6 @@ LRC Blood Aliquot:
 LRC Blood Bank:
   :asset_type: plate
   :stock_plate: false
-  :input_plate: false
   :creator_class:
     name: LabwareCreators::MultiStampTubes
     params:

--- a/config/purposes/scrna_core_library_prep.wip.yml
+++ b/config/purposes/scrna_core_library_prep.wip.yml
@@ -9,7 +9,6 @@
 LRC GEM-X 5p Aggregate:
   :asset_type: plate
   :stock_plate: false
-  :input_plate: false
   :creator_class: LabwareCreators::TenStamp
   :file_links: []
 # NB. QC concentrations need to be uploaded via QuantHub for the Cherrypick plate in order for the binning
@@ -17,7 +16,6 @@ LRC GEM-X 5p Aggregate:
 LRC GEM-X 5p Cherrypick:
   :asset_type: plate
   :stock_plate: false
-  :input_plate: false
   :cherrypickable_target: true
   :creator_class: LabwareCreators::TenStamp
   :state_changer_class: StateChangers::AutomaticPlateStateChanger
@@ -33,7 +31,6 @@ LRC GEM-X 5p Cherrypick:
 LRC GEM-X 5p GE Dil:
   :asset_type: plate
   :stock_plate: false
-  :input_plate: false
   :presenter_class: Presenters::ConcentrationBinnedPlatePresenter
   :creator_class: LabwareCreators::ConcentrationBinnedPlate
   :dilutions:

--- a/config/purposes/targeted_nanoseq.yml
+++ b/config/purposes/targeted_nanoseq.yml
@@ -5,13 +5,11 @@ LTN Stock:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: false
-  :input_plate: true
   :presenter_class: Presenters::StockPlatePresenter
 LTN Cherrypick:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :presenter_class: Presenters::StockPlatePresenter
 LTN Shear:
   :asset_type: plate

--- a/config/purposes/wgs_isc_top.yml
+++ b/config/purposes/wgs_isc_top.yml
@@ -3,7 +3,6 @@ LB Cherrypick:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :presenter_class: Presenters::StockPlatePresenter
 LB Shear:
   :asset_type: plate

--- a/docs/purposes_yaml_files.md
+++ b/docs/purposes_yaml_files.md
@@ -41,7 +41,6 @@ LB Cherrypick:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :presenter_class: Presenters::StockPlatePresenter
 LB Shear:
   :asset_type: plate
@@ -111,7 +110,6 @@ Example plate:
   :asset_type: plate
   :stock_plate: false
   :cherrypickable_target: false
-  :input_plate: false
   :size: 96
   :presenter_class: Presenters::StandardPresenter
   :state_changer_class: StateChangers::DefaultStateChanger
@@ -139,20 +137,6 @@ in Sequencescape. Usually only true for the first plate in the pipeline.
 
 ```yaml
 :stock_plate: false
-```
-
-Default: `false`
-
-#### :input_plate
-
-**(plate only)**
-Boolean, indicates that the plate has the input_plate flag set
-in Sequencescape. Usually only true for the first plate in the pipeline. Also
-used to determine if the plate shows in the 'New Input Plates' inbox, and to
-determine which barcode gets shown on downstream ancestors
-
-```yaml
-:input_plate: false
 ```
 
 Default: `false`

--- a/spec/fixtures/config/purposes/test_set_a.yml
+++ b/spec/fixtures/config/purposes/test_set_a.yml
@@ -3,7 +3,6 @@ LB Cherrypick:
   :asset_type: plate
   :stock_plate: true
   :cherrypickable_target: true
-  :input_plate: true
   :presenter_class: Presenters::StockPlatePresenter
 LB Shear:
   :asset_type: plate

--- a/spec/fixtures/config/purposes/test_set_b.yml
+++ b/spec/fixtures/config/purposes/test_set_b.yml
@@ -4,7 +4,6 @@ LB Lib PrePool:
   :stock_plate: false
   :creator_class: LabwareCreators::MultiPlatePool
   :cherrypickable_target: false
-  :input_plate: false
   :default_printer_type: :plate_b
   :csv_template: 'show_extended'
 LB Hyb:


### PR DESCRIPTION
Update to resource highlighted that input_plate flag being included in purpose config files was pointless as cannot be set through the API. Removed as unneeded. Those labwares that are inputs should be configured as such in the Sequencescape configuration in any case.