### PR TITLE
Fix automatic state change on LRC GEM-X 5p cDNA PCR XP plate

### DIFF
--- a/app/javascript/multi-stamp/components/PrimerPanelFilter.spec.js
+++ b/app/javascript/multi-stamp/components/PrimerPanelFilter.spec.js
@@ -16,15 +16,15 @@ describe('PrimerPanelFilter', () => {
 
   it('provides a list of filter options', () => {
     const requestsAsSource1 = [
-      requestFactory({ primer_panel: { name: 'Common Panel' } }),
-      requestFactory({ primer_panel: { name: 'Distinct Panel' } }),
+      requestFactory({ uuid: 'req1-uuid', primer_panel: { name: 'Common Panel' } }),
+      requestFactory({ uuid: 'req2-uuid', primer_panel: { name: 'Distinct Panel' } }),
     ]
     const requestsOnAliquot1 = requestFactory({
       primer_panel: { name: 'Shared Panel' },
     })
     const requestsAsSource2 = [
-      requestFactory({ primer_panel: { name: 'Common Panel' } }),
-      requestFactory({ primer_panel: { name: 'Shared Panel' } }),
+      requestFactory({ uuid: 'req3-uuid', primer_panel: { name: 'Common Panel' } }),
+      requestFactory({ uuid: 'req4-uuid', primer_panel: { name: 'Shared Panel' } }),
     ]
     const well1 = wellFactory({
       requests_as_source: requestsAsSource1,

--- a/app/javascript/shared/wellHelpers.js
+++ b/app/javascript/shared/wellHelpers.js
@@ -33,8 +33,23 @@ const quadrantTargetFor = function (plateIndex, wellName, rowOffset, colOffset) 
   return wellCoordinateToName([destinationColumn, destinationRow])
 }
 
+// Given a well, return the requests that are relevant to it.
 const requestsForWell = function (well) {
-  return [...well.requests_as_source, ...well.aliquots.map((aliquot) => aliquot.request)].filter((request) => request)
+  const arr = [
+    // If the well is in the plate that the submission was done on,
+    // the requests originate in these wells and can be retrieved using requests_as_source.
+    ...well.requests_as_source,
+    // If the well in on a plate downstream of the one the submission was done on,
+    // the relevant request ids are stored on the aliquots.
+    ...well.aliquots.map((aliquot) => aliquot.request)
+  ].filter((request) => request)
+
+  // Turn the array into a Map and back again, to remove duplicate requests.
+  // Duplicates could arise if:
+  // a) there are multiple aliquots in a well that reference the same request, or
+  // b) the same request is present in both requests_as_source and aliquots
+  const mp = new Map(arr.map((request) => [request.id, request]));
+  return Array.from(mp.values());
 }
 
 const rowNumToLetter = function (value) {

--- a/app/javascript/shared/wellHelpers.js
+++ b/app/javascript/shared/wellHelpers.js
@@ -48,7 +48,7 @@ const requestsForWell = function (well) {
   // Duplicates could arise if:
   // a) there are multiple aliquots in a well that reference the same request, or
   // b) the same request is present in both requests_as_source and aliquots
-  const mp = new Map(arr.map((request) => [request.id, request]))
+  const mp = new Map(arr.map((request) => [request.uuid, request]))
   return Array.from(mp.values())
 }
 

--- a/app/javascript/shared/wellHelpers.js
+++ b/app/javascript/shared/wellHelpers.js
@@ -41,15 +41,15 @@ const requestsForWell = function (well) {
     ...well.requests_as_source,
     // If the well in on a plate downstream of the one the submission was done on,
     // the relevant request ids are stored on the aliquots.
-    ...well.aliquots.map((aliquot) => aliquot.request)
+    ...well.aliquots.map((aliquot) => aliquot.request),
   ].filter((request) => request)
 
   // Turn the array into a Map and back again, to remove duplicate requests.
   // Duplicates could arise if:
   // a) there are multiple aliquots in a well that reference the same request, or
   // b) the same request is present in both requests_as_source and aliquots
-  const mp = new Map(arr.map((request) => [request.id, request]));
-  return Array.from(mp.values());
+  const mp = new Map(arr.map((request) => [request.id, request]))
+  return Array.from(mp.values())
 }
 
 const rowNumToLetter = function (value) {

--- a/app/javascript/shared/wellHelpers.spec.js
+++ b/app/javascript/shared/wellHelpers.spec.js
@@ -17,27 +17,27 @@ describe('wellHelpers', () => {
   })
 
   describe('requestsForWell', () => {
-    const request1 = { id: "1" }
-    const request2 = { id: "2" }
+    const request1 = { id: '1' }
+    const request2 = { id: '2' }
 
     const well = {
-      id: "1",
-      position: { name: "A1" },
+      id: '1',
+      position: { name: 'A1' },
       aliquots: [
         {
-          id: "1",
-          request: request1
+          id: '1',
+          request: request1,
         },
         {
-          id: "2",
-          request: null
-        }
+          id: '2',
+          request: null,
+        },
       ],
-      requests_as_source: [ request1, request2 ]
+      requests_as_source: [request1, request2],
     }
 
-    it('combines requests from both data sources and de-duplicate', () => {
-      expect(requestsForWell(well)).toEqual([ request1, request2 ])
+    it('combines requests from both data sources and de-duplicates', () => {
+      expect(requestsForWell(well)).toEqual([request1, request2])
     })
   })
 })

--- a/app/javascript/shared/wellHelpers.spec.js
+++ b/app/javascript/shared/wellHelpers.spec.js
@@ -1,4 +1,4 @@
-import { findUniqueIndex } from './wellHelpers'
+import { findUniqueIndex, requestsForWell } from './wellHelpers'
 
 describe('wellHelpers', () => {
   describe('findUniqueIndex', () => {
@@ -13,6 +13,31 @@ describe('wellHelpers', () => {
       expect(findUniqueIndex([5, 1, 2, 1, 2, 3], 2)).toBe(2)
       expect(findUniqueIndex([5, 1, 2, 1, 2, 3], 3)).toBe(3)
       expect(findUniqueIndex([5, 1, 2, 1, 2, 3], 5)).toBe(0)
+    })
+  })
+
+  describe('requestsForWell', () => {
+    const request1 = { id: "1" }
+    const request2 = { id: "2" }
+
+    const well = {
+      id: "1",
+      position: { name: "A1" },
+      aliquots: [
+        {
+          id: "1",
+          request: request1
+        },
+        {
+          id: "2",
+          request: null
+        }
+      ],
+      requests_as_source: [ request1, request2 ]
+    }
+
+    it('combines requests from both data sources and de-duplicate', () => {
+      expect(requestsForWell(well)).toEqual([ request1, request2 ])
     })
   })
 })

--- a/app/javascript/shared/wellHelpers.spec.js
+++ b/app/javascript/shared/wellHelpers.spec.js
@@ -17,19 +17,19 @@ describe('wellHelpers', () => {
   })
 
   describe('requestsForWell', () => {
-    const request1 = { id: '1' }
-    const request2 = { id: '2' }
+    const request1 = { uuid: '1' }
+    const request2 = { uuid: '2' }
 
     const well = {
-      id: '1',
+      uuid: '3',
       position: { name: 'A1' },
       aliquots: [
         {
-          id: '1',
+          uuid: '4',
           request: request1,
         },
         {
-          id: '2',
+          uuid: '5',
           request: null,
         },
       ],

--- a/app/models/state_changers.rb
+++ b/app/models/state_changers.rb
@@ -83,8 +83,17 @@ module StateChangers
       @purpose_config ||= Settings.purposes[purpose_uuid]
     end
 
-    def work_completion_request_type
-      @work_completion_request_type ||= purpose_config[:work_completion_request_type]
+    def work_completion_request_types
+      @work_completion_request_types ||= parse_work_completion_request_types
+    end
+
+    # config can be a single request type or an array of request types
+    # convert them here into a consistent array format
+    def parse_work_completion_request_types
+      config = purpose_config[:work_completion_request_type]
+      return config if config.is_a?(Array)
+
+      [config]
     end
 
     # rubocop:todo Style/OptionalBooleanParameter
@@ -97,7 +106,7 @@ module StateChangers
 
     def complete_outstanding_requests
       in_prog_submissions =
-        v2_labware.in_progress_submission_uuids(request_type_to_complete: work_completion_request_type)
+        v2_labware.in_progress_submission_uuids(request_types_to_complete: work_completion_request_types)
       return if in_prog_submissions.blank?
 
       api.work_completion.create!(submissions: in_prog_submissions, target: v2_labware.uuid, user: user_uuid)

--- a/app/sequencescape/sequencescape/api/v2/shared/has_requests.rb
+++ b/app/sequencescape/sequencescape/api/v2/shared/has_requests.rb
@@ -57,20 +57,20 @@ module Sequencescape::Api::V2::Shared
     end
 
     # Finding in progress requests (set directly on aliquots on transfer into a new labware)
-    def requests_in_progress(request_type_to_complete: nil)
+    def requests_in_progress(request_types_to_complete: nil)
       requests = aliquots&.flat_map(&:request)&.compact
       return [] if requests.blank?
 
-      if request_type_to_complete.present?
-        requests.select { |r| r.request_type_key == request_type_to_complete }
+      if request_types_to_complete.present?
+        requests.select { |r| request_types_to_complete.include? r.request_type_key }
       else
         requests
       end
     end
 
     # Based on in_progress requests
-    def in_progress_submission_uuids(request_type_to_complete: nil)
-      requests_in_progress(request_type_to_complete: request_type_to_complete).flat_map(&:submission_uuid).uniq
+    def in_progress_submission_uuids(request_types_to_complete: nil)
+      requests_in_progress(request_types_to_complete: request_types_to_complete).flat_map(&:submission_uuid).uniq
     end
 
     def all_requests

--- a/config/purposes/scrna_core_cdna_prep.wip.yml
+++ b/config/purposes/scrna_core_cdna_prep.wip.yml
@@ -121,7 +121,7 @@ LRC GEM-X 5p cDNA PCR XP:
   :input_plate: false
   # close off the submission when the plate is created
   :state_changer_class: StateChangers::AutomaticPlateStateChanger
-  :work_completion_request_type: 'limber_scrna_core_cdna_prep_input'
+  :work_completion_request_type: ['limber_scrna_core_cdna_prep_input', 'limber_scrna_core_cdna_prep_v2']
 # faculty input plate (alternate to LRC GEM-X 5p cDNA PCR XP intermediate plate)
 LRC GEM-X 5p cDNA Input:
   :asset_type: plate

--- a/spec/models/state_changers_spec.rb
+++ b/spec/models/state_changers_spec.rb
@@ -125,6 +125,24 @@ RSpec.describe StateChangers::DefaultStateChanger do
           expect(work_completion_creation).to_not have_been_made
         end
       end
+
+      # The ability to have multiple request types in the config was added for scRNA Core pipeline.
+      # The expectation was that any one plate would only have one of the request types on it,
+      # so I haven't tested a plate with a mix of request types.
+      context 'when one of the multiple config request types matches the in progress submissions' do
+        before do
+          create :aggregation_purpose_config,
+                 uuid: plate.purpose.uuid,
+                 name: plate_purpose_name,
+                 work_completion_request_type: ['limber_bespoke_aggregation', 'another_request_type']
+        end
+
+        it 'changes plate state and triggers a work completion' do
+          subject.move_to!(target_state, reason, customer_accepts_responsibility)
+
+          expect(work_completion_creation).to have_been_made.once
+        end
+      end
     end
 
     after { expect(state_change_request).to have_been_made.once }

--- a/spec/models/state_changers_spec.rb
+++ b/spec/models/state_changers_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe StateChangers::DefaultStateChanger do
           create :aggregation_purpose_config,
                  uuid: plate.purpose.uuid,
                  name: plate_purpose_name,
-                 work_completion_request_type: ['limber_bespoke_aggregation', 'another_request_type']
+                 work_completion_request_type: %w[limber_bespoke_aggregation another_request_type]
         end
 
         it 'changes plate state and triggers a work completion' do


### PR DESCRIPTION
2 fixes based on UAT testing:

1. Fix automatic state change on LRC GEM-X 5p cDNA PCR XP plate
- It wasn't completing the requests when coming down the SeqOps cDNA Prep route
- It only worked for the Faculty input route
- This is because the only request type specified in the 'work_completion_request_type' config was 'limber_scrna_core_cdna_prep_input'
- Had to enhance the AutomaticStateChange functionality to allow multiple request types

2. De-duplicate requests in the requestsForWell function
- in the aggregation pipeline for scRNA Core, the plates that the submission is done on may contain multiple aliquots
- if this is the case, each aliquot in the well references the same request
- this method was pulling the request from each of the aliquots - presumably with the assumption that each aliquot would have a different request
- in our case, it created duplicates in the array
- there could also theoretically by duplicates if the same request was referenced on the aliquot and in requests_as_source (although I think this shouldn't happen)
- therefore I added de-duplication to the end of the function chain, based on request id

Closes #

#### Changes proposed in this pull request

- 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
