### PR TITLE
Y24-190-1: Update config generate to SS API v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ log/*.log*
 # Release
 release.tar.gz
 REVISION
+
+# Bye-bug history
+.byebug_history

--- a/app/helpers/barcode_labels_helper.rb
+++ b/app/helpers/barcode_labels_helper.rb
@@ -13,7 +13,7 @@ module BarcodeLabelsHelper # rubocop:todo Style/Documentation
 
     print_job =
       PrintJob.new(
-        number_of_copies: Settings.printers['default_count'],
+        number_of_copies: Settings.printers[:default_count],
         printer_name: default_printer_name,
         label_templates_by_service: JSON.generate(labels.first.label_templates_by_service)
       )

--- a/app/models/presenters/presenter.rb
+++ b/app/models/presenters/presenter.rb
@@ -40,11 +40,11 @@ module Presenters::Presenter # rubocop:todo Style/Documentation
   end
 
   def default_label_count
-    @default_label_count ||= Settings.printers['default_count']
+    @default_label_count ||= Settings.printers[:default_count]
   end
 
   def printer_limit
-    @printer_limit ||= Settings.printers['limit']
+    @printer_limit ||= Settings.printers[:limit]
   end
 
   def summary

--- a/app/sequencescape/sequencescape/api/v2/submission_template.rb
+++ b/app/sequencescape/sequencescape/api/v2/submission_template.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# submission template resource
+class Sequencescape::Api::V2::SubmissionTemplate < Sequencescape::Api::V2::Base
+end

--- a/app/sequencescape/sequencescape/api/v2/transfer_template.rb
+++ b/app/sequencescape/sequencescape/api/v2/transfer_template.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# transfer template resource
+class Sequencescape::Api::V2::TransferTemplate < Sequencescape::Api::V2::Base
+end

--- a/app/sequencescape/sequencescape/api/v2/tube_purpose.rb
+++ b/app/sequencescape/sequencescape/api/v2/tube_purpose.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# tube purpose resource
+class Sequencescape::Api::V2::TubePurpose < Sequencescape::Api::V2::Base
+end

--- a/lib/purpose_config.rb
+++ b/lib/purpose_config.rb
@@ -8,20 +8,20 @@
 # files into the serialized versions in the config/settings/*.yml
 # It also handles the registration of new purposes within Sequencescape.
 class PurposeConfig
-  attr_reader :name, :options, :store, :api
+  attr_reader :name, :options, :store
 
   class_attribute :default_state_changer, :default_options
 
   self.default_state_changer = 'StateChangers::DefaultStateChanger'
 
-  def self.load(name, options, store, api, submission_templates, label_template_config)
+  def self.load(name, options, store, submission_templates, label_template_config)
     case options.fetch(:asset_type)
     when 'plate'
-      PurposeConfig::Plate.new(name, options, store, api, submission_templates, label_template_config)
+      PurposeConfig::Plate.new(name, options, store, submission_templates, label_template_config)
     when 'tube'
-      PurposeConfig::Tube.new(name, options, store, api, submission_templates, label_template_config)
+      PurposeConfig::Tube.new(name, options, store, submission_templates, label_template_config)
     when 'tube_rack'
-      PurposeConfig::TubeRack.new(name, options, store, api, submission_templates, label_template_config)
+      PurposeConfig::TubeRack.new(name, options, store, submission_templates, label_template_config)
     else
       raise "Unknown purpose type #{options.fetch(:asset_type)} for #{name}"
     end
@@ -32,12 +32,11 @@ class PurposeConfig
   # @param options [Hash] values under the name key from the purposes.yml file
   # @param label_template_config [Hash] hash version of the label_template_config.yml file
   #
-  def initialize(name, options, store, api, submission_templates, label_template_config)
+  def initialize(name, options, store, submission_templates, label_template_config)
     @name = name
     @options = options
     @submission = options.delete(:submission)
     @store = store
-    @api = api
     @submission_templates = submission_templates
     @label_templates = label_template_config.fetch('templates')
     @label_template_defaults = label_template_config.fetch('defaults_by_printer_type')
@@ -84,7 +83,8 @@ class PurposeConfig
 
     def register!
       puts "Creating #{name}"
-      api.tube_purpose.create!(name: name, target_type: options.fetch(:target), type: options.fetch(:type))
+      options = { name: name, target_type: options.fetch(:target), purpose_type: options.fetch(:type) }
+      Sequencescape::Api::V2::TubePurpose.create!(options)
     end
   end
 

--- a/lib/purpose_config.rb
+++ b/lib/purpose_config.rb
@@ -2,7 +2,6 @@
 
 # This is used as part of a rake task, and will be run within a console.
 # rubocop:disable Rails/Output
-# rubocop:disable Metrics/ParameterLists
 
 # Purpose config is used to translate the configuration options in the purposes/*.yml
 # files into the serialized versions in the config/settings/*.yml
@@ -147,5 +146,4 @@ class PurposeConfig
     }
   end
 end
-# rubocop:enable Metrics/ParameterLists
 # rubocop:enable Rails/Output

--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -45,6 +45,8 @@ namespace :config do
     # Build the configuration file based on the server we are connected to.
     CONFIG = # rubocop:todo Lint/ConstantDefinitionInBlock
       {}.tap do |configuration|  # rubocop:todo Metrics/BlockLength
+        # TODO: Y24-190 - Remove this once we have moved everything else over to V2;
+        #                 also the config entries for :searches
         puts 'Preparing searches ...'
         configuration[:searches] =
           api.search.all.each_with_object({}) { |search, searches| searches[search.name] = search.uuid }

--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -27,7 +27,8 @@ namespace :config do
     label_template_config = YAML.load_file(Rails.root.join('config/label_templates.yml'))
 
     puts 'Fetching submission_templates...'
-    submission_templates = api.order_template.all.each_with_object({}) { |st, store| store[st.name] = st.uuid }
+    query = Sequencescape::Api::V2::SubmissionTemplate.select(:uuid, :name).paginate(per_page: 100)
+    submission_templates = Sequencescape::Api::V2.merge_page_results(query).to_h { |st| [st.name, st.uuid] }
 
     puts 'Fetching purposes...'
     query = Sequencescape::Api::V2::Purpose.select(:uuid, :name).paginate(per_page: 100)

--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -52,13 +52,9 @@ namespace :config do
           api.search.all.each_with_object({}) { |search, searches| searches[search.name] = search.uuid }
 
         puts 'Preparing transfer templates ...'
-        configuration[:transfer_templates] =
-          api
-            .transfer_template
-            .all
-            .each_with_object({}) do |transfer_template, transfer_templates|
-              transfer_templates[transfer_template.name] = transfer_template.uuid
-            end
+        query = Sequencescape::Api::V2::TransferTemplate.select(:uuid, :name).paginate(per_page: 100)
+        transfer_templates = Sequencescape::Api::V2.merge_page_results(query).to_h { |tt| [tt.name, tt.uuid] }
+        configuration[:transfer_templates] = transfer_templates
 
         configuration[:printers] = {
           plate_a: 'g316bc',

--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -60,15 +60,14 @@ namespace :config do
               transfer_templates[transfer_template.name] = transfer_template.uuid
             end
 
-        configuration[:printers] =
-          {}.tap do |printers|
-            printers[:plate_a] = 'g316bc'
-            printers[:plate_b] = 'g311bc2'
-            printers[:tube_rack] = 'heron-bc2'
-            printers[:tube] = 'g311bc1'
-            printers['limit'] = 5
-            printers['default_count'] = 2
-          end
+        configuration[:printers] = {
+          plate_a: 'g316bc',
+          plate_b: 'g311bc2',
+          tube_rack: 'heron-bc2',
+          tube: 'g311bc1',
+          limit: 5,
+          default_count: 2
+        }
 
         configuration[:purposes] =
           {}.tap do |labware_purposes|

--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -36,7 +36,7 @@ namespace :config do
 
     purpose_config =
       ConfigLoader::PurposesLoader.new.config.map do |name, options|
-        PurposeConfig.load(name, options, all_purposes, api, submission_templates, label_template_config)
+        PurposeConfig.load(name, options, all_purposes, submission_templates, label_template_config)
       end
 
     puts 'Preparing purposes...'

--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -44,7 +44,7 @@ namespace :config do
 
     # Build the configuration file based on the server we are connected to.
     CONFIG = # rubocop:todo Lint/ConstantDefinitionInBlock
-      {}.tap do |configuration|  # rubocop:todo Metrics/BlockLength
+      {}.tap do |configuration|
         # TODO: Y24-190 - Remove this once we have moved everything else over to V2;
         #                 also the config entries for :searches
         puts 'Preparing searches ...'

--- a/spec/data/settings.yml
+++ b/spec/data/settings.yml
@@ -11,8 +11,8 @@
     :plate_a: bac135c0-222b-11e4-8ce2-44fb42fffecc
     :plate_b: bac2e370-222b-11e4-8ce2-44fb42fffecc
     :tube: bacaf9c0-222b-11e4-8ce2-44fb42fffecc
-  limit: 5
-  default_count: 2
+  :limit: 5
+  :default_count: 2
 :purposes: {}
 :purpose_uuids: {}
 :robots:


### PR DESCRIPTION
Closes #1794 

#### Changes proposed in this pull request

- Use new V2 endpoints for operations during `config:generate`.
- Still to do:  Remove the searches config population, but these are still used throughout the application and I want to confirm they are no longer needed before creating a new endpoint unnecessarily.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  