### PR TITLE
Fix: config:generate error

### DIFF
--- a/lib/purpose_config.rb
+++ b/lib/purpose_config.rb
@@ -82,8 +82,8 @@ class PurposeConfig
 
     def register!
       puts "Creating #{name}"
-      options = { name: name, target_type: options.fetch(:target), purpose_type: options.fetch(:type) }
-      Sequencescape::Api::V2::TubePurpose.create!(options)
+      options_for_creation = { name: name, target_type: options.fetch(:target), purpose_type: options.fetch(:type) }
+      Sequencescape::Api::V2::TubePurpose.create!(options_for_creation)
     end
   end
 

--- a/lib/purpose_config.rb
+++ b/lib/purpose_config.rb
@@ -34,7 +34,7 @@ class PurposeConfig
   def initialize(name, options, store, submission_templates, label_template_config)
     @name = name
     @options = options
-    @submission = options.delete(:submission)
+    @submission = @options.delete(:submission)
     @store = store
     @submission_templates = submission_templates
     @label_templates = label_template_config.fetch('templates')
@@ -82,7 +82,7 @@ class PurposeConfig
 
     def register!
       puts "Creating #{name}"
-      options_for_creation = { name: name, target_type: options.fetch(:target), purpose_type: options.fetch(:type) }
+      options_for_creation = { name: name, target_type: @options.fetch(:target), purpose_type: @options.fetch(:type) }
       Sequencescape::Api::V2::TubePurpose.create!(options_for_creation)
     end
   end
@@ -109,7 +109,7 @@ class PurposeConfig
       # maintains the behaviour of version 1, but includes an addditional
       # asset_shape option if configured. It raises an error if the purpose
       # cannot be created.
-      options =
+      options_for_creation =
         {
           name: name,
           stock_plate: config.fetch(:stock_plate, false),
@@ -117,7 +117,7 @@ class PurposeConfig
           input_plate: config.fetch(:input_plate, false),
           size: config.fetch(:size, 96)
         }.merge(config.slice(:asset_shape))
-      Sequencescape::Api::V2::PlatePurpose.create!(options)
+      Sequencescape::Api::V2::PlatePurpose.create!(options_for_creation)
     end
   end
 


### PR DESCRIPTION


Closes #

#### Changes proposed in this pull request

- Fixes issue when running config generate task
- error was 'undefined method fetch for nil:NilClass'
- because 'options' variable was being redefined
- changing the name of the variable works
- Bit of extra refactoring to make distinction between local and instance variables clearer

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
