### PR TITLE
DPL-1025 amendment - remove bed verification

### DIFF
--- a/config/robots.rb
+++ b/config/robots.rb
@@ -3574,30 +3574,6 @@ ROBOT_CONFIG =
 
     # scRNA pipeline
     # Hamilton STARlet bed verification
-    # LRC PBMC Defrost PBS to LRC PBMC Pools
-    # Transfers 1:1
-    custom_robot(
-      'hamilton-starlet-lrc-pbmc-defrost-pbs-to-lrc-pbmc-pools',
-      name: 'Hamilton STARlet LRC PBMC Defrost PBS => LRC PBMC Pools',
-      require_robot: true,
-      beds: {
-        bed(15).barcode => {
-          purpose: 'LRC PBMC Defrost PBS',
-          states: ['passed'],
-          label: 'Bed 15'
-        },
-        bed(14).barcode => {
-          purpose: 'LRC PBMC Pools',
-          states: ['pending'],
-          label: 'Bed 14',
-          parent: bed(15).barcode,
-          target_state: 'passed'
-        }
-      }
-    )
-
-    # scRNA pipeline
-    # Hamilton STARlet bed verification
     # Transfers 1:1
     # LRC PBMC Pools or LRC PBMC Pools Input to LRC GEM-X 5p Chip
     custom_robot(


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- They will no longer be pooling using the STARlet so we only need the bed verification Robot Option 1 for the STAR.

See associated Integration Suite PR here - https://gitlab.internal.sanger.ac.uk/psd/integration-suite/-/merge_requests/147/diffs 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
