### PR TITLE
Add blank line into robot driver file, for consistency

### DIFF
--- a/app/views/exports/hamilton_lrc_pbmc_defrost_pbs_to_lrc_pbmc_pools.csv.erb
+++ b/app/views/exports/hamilton_lrc_pbmc_defrost_pbs_to_lrc_pbmc_pools.csv.erb
@@ -1,10 +1,11 @@
 <%# This is a picking file for a Hamilton robot for LRC PBMC Defrost plate to LRC PBMC Pools plate transfers %>
 <%= CSV.generate_line [
-    'Workflow', 
+    'Workflow',
     @workflow
-  ], 
-  row_sep: '' 
+  ],
+  row_sep: ''
 %>
+<%= CSV.generate_line [], row_sep: "" %>
 <%= CSV.generate_line [
     'Source Plate',
     'Source Well',
@@ -21,7 +22,7 @@
   args = Settings.purposes[@plate.purpose.uuid][:presenter_class][:args]
   default_required_number_of_cells = args[:default_required_number_of_cells]
   study_required_number_of_cells_key = args[:study_required_number_of_cells_key]
-  
+
   maximum_sample_volume = 50.0  # microlitres
   resuspension_volume_per_sample = 2.2  # microlitres
   minimum_resuspension_volume = 10.0  # microlitres

--- a/spec/views/exports/hamilton_lrc_pbmc_defrost_pbs_to_lrc_pbmc_pools.csv.erb_spec.rb
+++ b/spec/views/exports/hamilton_lrc_pbmc_defrost_pbs_to_lrc_pbmc_pools.csv.erb_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe 'exports/hamilton_lrc_pbmc_defrost_pbs_to_lrc_pbmc_pools.csv.erb'
   let(:expected_content) do
     [
       ['Workflow', workflow],
+      [],
       [
         'Source Plate',
         'Source Well',
@@ -181,6 +182,7 @@ RSpec.describe 'exports/hamilton_lrc_pbmc_defrost_pbs_to_lrc_pbmc_pools.csv.erb'
     let(:expected_content) do
       [
         ['Workflow', workflow],
+        [],
         [
           'Source Plate',
           'Source Well',


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Add blank line into hamilton_lrc_pbmc_defrost_pbs_to_lrc_pbmc_pools file, to be consistent with other files in the same pipeline

See file in bold below, in context of all the other files in the pipeline. Everything in the cell extraction and cDNA prep stages has a blank second line, while everything in the library prep stage doesn't. 

We decided to change hamilton_lrc_pbmc_defrost_pbs_to_lrc_pbmc_pools to make it consistent with its surroundings. 

The library prep files are left as-is, because the library prep stage will use the existing robot methods set up for the existing bespoke chromium pipelines - so if we change the driver files, it will create work for R&D.

Purpose | export file | Blank second line or not?
-- | -- | --
LRC Blood Bank | scrna_core_cell_extraction_sample_arraying_tube_layout | yes
LRC PBMC Bank | hamilton_lrc_blood_bank_to_lrc_pbmc_bank | Yes
LRC PBMC Bank | hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare | Yes
LRC PBMC Bank | pbmc_bank_tubes_content_report | Yes
LRC PBMC Bank | hamilton_lrc_pbmc_bank_to_cellaca_first_count | Yes
LRC PBMC Bank | hamilton_lrc_pbmc_bank_to_cellaca_second_count | Yes
LRC PBMC Defrost PBS | hamilton_lrc_pbmc_defrost_pbs_to_cellaca_count | Yes
**LRC PBMC Pools** | **hamilton_lrc_pbmc_defrost_pbs_to_lrc_pbmc_pools** | **No**
LRC GEM-X 5p Chip | hamilton_gem_x_5p_chip_loading | Yes
LRC GEM-X 5p Cherrypick | hamilton_aggregate_cherrypick | No
LRC GEM-X 5p GE Dil | hamilton_lrc_gem_x_5p_cherrypick_to_lrc_gem_x_5p_ge_dil | No
LRC GEM-X 5p GE Frag 2XP | hamilton_gex_dil_to_gex_frag_2xp | No
LRC GEM-X 5p GE LigXP | hamilton_gex_frag_2xp_to_gex_ligxp | No
LRC GEM-X 5p Cherrypick LRC GEM-X 5p GE Dil LRC GEM-X 5p GE PCR 2XP | concentrations_ngul | Yes

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
