### PR TITLE
Refactor linting workflow to reduce setup and improve naming

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Ruby # Prettier has a Ruby dependency
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # Runs bundle install and caches gems.
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -30,6 +34,12 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true # Runs bundle install and caches gems.
+      - name: Setup Node # RuboCop has a Prettier dependency for formatting
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      - name: Install Node dependencies
+        run: yarn install
       - name: Run lint
         run: bundle exec rubocop --extra-details --display-style-guide --parallel
 


### PR DESCRIPTION
The existing lint workflow doesn't have useful names (Linting/lint) making it hard to tell at a glance which process failed.

#### Changes proposed in this pull request

- Refactors lint workflow
- ~Create common installation steps~
- Provide process-specific names for checks

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
