### PR TITLE
Y24-190-3: Use v2 transfers and transfer templates

### DIFF
--- a/app/models/labware_creators/base.rb
+++ b/app/models/labware_creators/base.rb
@@ -103,12 +103,9 @@ module LabwareCreators
 
     private
 
-    # rubocop:todo Naming/MemoizedInstanceVariableName
     def transfer_template
-      @template ||= api.transfer_template.find(transfer_template_uuid)
+      @transfer_template ||= api.transfer_template.find(transfer_template_uuid)
     end
-
-    # rubocop:enable Naming/MemoizedInstanceVariableName
 
     def create_plate_with_standard_transfer!
       plate_creation = create_plate_from_parent!

--- a/app/models/labware_creators/base.rb
+++ b/app/models/labware_creators/base.rb
@@ -123,7 +123,7 @@ module LabwareCreators
     end
 
     def transfer_material_from_parent!(child_uuid)
-      transfer!(source_uuid: parent_uuid, destination_uuid: child_uuid, transfer: transfer_hash)
+      transfer!(source_uuid: parent_uuid, destination_uuid: child_uuid, transfers: transfer_hash)
     end
 
     # Override in classes with custom transfers

--- a/app/models/labware_creators/base.rb
+++ b/app/models/labware_creators/base.rb
@@ -70,7 +70,7 @@ module LabwareCreators
 
     #
     # The uuid of the transfer template to be used.
-    # Extracted from the transfer template cache base on the name
+    # Extracted from the transfer template cache based on the name
     #
     # @return [String] UUID
     #
@@ -103,10 +103,6 @@ module LabwareCreators
 
     private
 
-    def transfer_template
-      @transfer_template ||= api.transfer_template.find(transfer_template_uuid)
-    end
-
     def create_plate_with_standard_transfer!
       plate_creation = create_plate_from_parent!
       @child = plate_creation.child
@@ -120,8 +116,14 @@ module LabwareCreators
       api.plate_creation.create!(parent: parent_uuid, child_purpose: purpose_uuid, user: user_uuid)
     end
 
+    def transfer!(attributes)
+      Sequencescape::Api::V2::Template.create!(
+        attributes.merge(transfer_template_uuid: transfer_template_uuid, user_uuid: user_uuid)
+      )
+    end
+
     def transfer_material_from_parent!(child_uuid)
-      transfer_template.create!(source: parent_uuid, destination: child_uuid, user: user_uuid, transfers: transfer_hash)
+      transfer!(source_uuid: parent_uuid, destination_uuid: child_uuid, transfer: transfer_hash)
     end
 
     # Override in classes with custom transfers

--- a/app/models/labware_creators/base.rb
+++ b/app/models/labware_creators/base.rb
@@ -117,7 +117,7 @@ module LabwareCreators
     end
 
     def transfer!(attributes)
-      Sequencescape::Api::V2::Template.create!(
+      Sequencescape::Api::V2::Transfer.create!(
         attributes.merge(transfer_template_uuid: transfer_template_uuid, user_uuid: user_uuid)
       )
     end

--- a/app/models/labware_creators/final_tube.rb
+++ b/app/models/labware_creators/final_tube.rb
@@ -41,7 +41,7 @@ module LabwareCreators
     def redirection_target
       return :contents_not_transfered_to_mx_tube if all_tube_transfers.nil?
 
-      destination_uuids = all_tube_transfers.map { |tt| tt.destination.uuid }.uniq
+      destination_uuids = all_tube_transfers.map { |tt| tt.destination_uuid }.uniq
 
       # The client_api returns a 'barcoded asset' here, rather than a tube.
       # We know that its a tube though, so wrap it in this useful tool

--- a/app/models/labware_creators/final_tube.rb
+++ b/app/models/labware_creators/final_tube.rb
@@ -41,7 +41,7 @@ module LabwareCreators
     def redirection_target
       return :contents_not_transfered_to_mx_tube if all_tube_transfers.nil?
 
-      destination_uuids = all_tube_transfers.map { |tt| tt.destination_uuid }.uniq
+      destination_uuids = all_tube_transfers.map(&:destination_uuid).uniq
 
       # The client_api returns a 'barcoded asset' here, rather than a tube.
       # We know that its a tube though, so wrap it in this useful tool

--- a/app/models/labware_creators/final_tube.rb
+++ b/app/models/labware_creators/final_tube.rb
@@ -28,8 +28,7 @@ module LabwareCreators
     end
 
     def create_labware!
-      @all_tube_transfers =
-        parents.map { |this_parent_uuid| transfer_template.create!(user: user_uuid, source: this_parent_uuid) }
+      @all_tube_transfers = parents.map { |this_parent_uuid| transfer!(source_uuid: this_parent_uuid) }
       true
     end
 

--- a/app/models/labware_creators/final_tube_from_plate.rb
+++ b/app/models/labware_creators/final_tube_from_plate.rb
@@ -21,7 +21,7 @@ module LabwareCreators
     self.default_transfer_template_name = 'Transfer wells to MX library tubes by submission'
 
     def create_labware!
-      transfer_into_existing_tubes!
+      create_transfer!
       pass_tubes!
     end
 
@@ -40,15 +40,12 @@ module LabwareCreators
 
     private
 
-    # rubocop:todo Naming/MemoizedInstanceVariableName
-    def transfer_into_existing_tubes!
-      @transfer ||= transfer_template.create!(user: user_uuid, source: parent_uuid)
+    def create_transfer!
+      @create_transfer ||= transfer!(source_uuid: parent_uuid)
     end
 
-    # rubocop:enable Naming/MemoizedInstanceVariableName
-
     def pass_tubes!
-      raise StandardError, 'Tubes cannot be passed before transfer' if @transfer.nil?
+      raise StandardError, 'Tubes cannot be passed before transfer' if @create_transfer.nil?
 
       tubes_from_transfer.each do |tube_uuid|
         api.state_change.create!(user: user_uuid, target: tube_uuid, target_state: 'passed')
@@ -56,7 +53,7 @@ module LabwareCreators
     end
 
     def tubes_from_transfer
-      @transfer
+      create_transfer!
         .transfers
         .values
         .each_with_object(Set.new) { |tube_details, tube_uuids| tube_uuids << tube_details.fetch('uuid') }

--- a/app/models/labware_creators/plate_with_template.rb
+++ b/app/models/labware_creators/plate_with_template.rb
@@ -8,7 +8,7 @@ module LabwareCreators
     include SupportParent::PlateOnly
 
     def transfer_material_from_parent!(child_uuid)
-      transfer!(source_uuid: parent_uuid, child_uuid: child_uuid)
+      transfer!(source_uuid: parent_uuid, destination_uuid: child_uuid)
     end
   end
 end

--- a/app/models/labware_creators/plate_with_template.rb
+++ b/app/models/labware_creators/plate_with_template.rb
@@ -8,7 +8,7 @@ module LabwareCreators
     include SupportParent::PlateOnly
 
     def transfer_material_from_parent!(child_uuid)
-      transfer_template.create!(source: parent_uuid, destination: child_uuid, user: user_uuid)
+      transfer!(source_uuid: parent_uuid, child_uuid: child_uuid)
     end
   end
 end

--- a/app/models/labware_creators/pooled_tubes_from_whole_plates.rb
+++ b/app/models/labware_creators/pooled_tubes_from_whole_plates.rb
@@ -29,7 +29,7 @@ module LabwareCreators
           .first
 
       # Transfer EVERYTHING into it
-      parents.each { |parent_plate| transfer!(source_uuid: parent_plate.uuid, child_uuid: @child.uuid) }
+      parents.each { |parent_plate| transfer!(source_uuid: parent_plate.uuid, destination_uuid: @child.uuid) }
     end
 
     def barcodes=(input)

--- a/app/models/labware_creators/pooled_tubes_from_whole_plates.rb
+++ b/app/models/labware_creators/pooled_tubes_from_whole_plates.rb
@@ -13,7 +13,7 @@ module LabwareCreators
 
     validate :parents_suitable
 
-    def create_labware! # rubocop:todo Metrics/AbcSize
+    def create_labware!
       # Create a single tube
       # TODO: This should link to multiple parents in production
       @child =
@@ -29,9 +29,7 @@ module LabwareCreators
           .first
 
       # Transfer EVERYTHING into it
-      parents.each do |parent_plate|
-        transfer_template.create!(user: user_uuid, source: parent_plate.uuid, destination: @child.uuid)
-      end
+      parents.each { |parent_plate| transfer!(source_uuid: parent_plate.uuid, child_uuid: @child.uuid) }
     end
 
     def barcodes=(input)

--- a/app/models/labware_creators/tube_from_tube.rb
+++ b/app/models/labware_creators/tube_from_tube.rb
@@ -13,7 +13,8 @@ module LabwareCreators
       @child_tube =
         api.tube_from_tube_creation.create!(parent: parent_uuid, child_purpose: purpose_uuid, user: user_uuid).child
 
-      @tube_transfer = transfer_template.create!(user: user_uuid, source: parent_uuid, destination: @child_tube.uuid)
+      @tube_transfer = transfer!(source_uuid: parent_uuid, child_uuid: @child_tube.uuid)
+
       true
     end
 

--- a/app/models/labware_creators/tube_from_tube.rb
+++ b/app/models/labware_creators/tube_from_tube.rb
@@ -13,7 +13,7 @@ module LabwareCreators
       @child_tube =
         api.tube_from_tube_creation.create!(parent: parent_uuid, child_purpose: purpose_uuid, user: user_uuid).child
 
-      @tube_transfer = transfer!(source_uuid: parent_uuid, child_uuid: @child_tube.uuid)
+      @tube_transfer = transfer!(source_uuid: parent_uuid, destination_uuid: @child_tube.uuid)
 
       true
     end

--- a/app/sequencescape/sequencescape/api/v2/transfer.rb
+++ b/app/sequencescape/sequencescape/api/v2/transfer.rb
@@ -2,4 +2,7 @@
 
 # transfer resource
 class Sequencescape::Api::V2::Transfer < Sequencescape::Api::V2::Base
+  def self.resource_path
+    'transfers/transfers' # Transfers are nested beneath a transfers path.
+  end
 end

--- a/app/sequencescape/sequencescape/api/v2/transfer.rb
+++ b/app/sequencescape/sequencescape/api/v2/transfer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# transfer resource
+class Sequencescape::Api::V2::Transfer < Sequencescape::Api::V2::Base
+end

--- a/spec/factories/transfer_factories.rb
+++ b/spec/factories/transfer_factories.rb
@@ -1,6 +1,23 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  # API V2 Transfer
+  factory :v2_transfer, class: Sequencescape::Api::V2::Transfer do
+    skip_create
+
+    transient do
+      user
+      source { create :v2_plate }
+      destination { create :v2_plate }
+    end
+
+    uuid { SecureRandom.uuid }
+    user_uuid { user.uuid }
+    source_uuid { source.uuid }
+    destination_uuid { destination.uuid }
+    transfers { { 'A1' => 'A1', 'B1' => 'B1', 'C1' => 'C1' } }
+  end
+
   # API V1 Transfer
   factory :transfer, class: Sequencescape::Transfer, traits: [:api_object] do
     json_root { 'transfer' }

--- a/spec/factories/transfer_factories.rb
+++ b/spec/factories/transfer_factories.rb
@@ -16,6 +16,19 @@ FactoryBot.define do
     source_uuid { source.uuid }
     destination_uuid { destination.uuid }
     transfers { { 'A1' => 'A1', 'B1' => 'B1', 'C1' => 'C1' } }
+
+    factory :v2_transfer_to_tubes_by_submission do
+      transient do
+        tube_count { 2 }
+        tubes { create_list(:v2_tube, tube_count) }
+        well_coordinates { WellHelpers.column_order[0, tube_count] }
+      end
+
+      destination_uuid { nil }
+
+      # Transfers will be a hash with column names as keys and tube-like objects for the values.
+      transfers { (0..tube_count - 1).map { |i| [well_coordinates[i], { uuid: tubes[i].uuid }] }.to_h }
+    end
   end
 
   # API V1 Transfer

--- a/spec/factories/transfer_factories.rb
+++ b/spec/factories/transfer_factories.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
       destination_uuid { nil }
 
       # Transfers will be a hash with column names as keys and tube-like objects for the values.
-      transfers { (0..tube_count - 1).to_h { |i| [well_coordinates[i], { uuid: tubes[i].uuid }] } }
+      transfers { (0..destination_tube_count - 1).to_h { |i| [well_coordinates[i], { uuid: tubes[i].uuid }] } }
     end
 
     factory :v2_transfer_between_tubes do

--- a/spec/factories/transfer_factories.rb
+++ b/spec/factories/transfer_factories.rb
@@ -19,15 +19,24 @@ FactoryBot.define do
 
     factory :v2_transfer_to_tubes_by_submission do
       transient do
-        tube_count { 2 }
-        tubes { create_list(:v2_tube, tube_count) }
-        well_coordinates { WellHelpers.column_order[0, tube_count] }
+        destination_tube_count { 2 }
+        tubes { create_list(:v2_tube, destination_tube_count) }
+        well_coordinates { WellHelpers.column_order[0, destination_tube_count] }
       end
 
       destination_uuid { nil }
 
       # Transfers will be a hash with column names as keys and tube-like objects for the values.
-      transfers { (0..tube_count - 1).map { |i| [well_coordinates[i], { uuid: tubes[i].uuid }] }.to_h }
+      transfers { (0..tube_count - 1).to_h { |i| [well_coordinates[i], { uuid: tubes[i].uuid }] } }
+    end
+
+    factory :v2_transfer_between_tubes do
+      transient do
+        source { create :v2_tube }
+        destination { create :v2_tube }
+      end
+
+      transfers { nil }
     end
   end
 

--- a/spec/factories/transfer_factories.rb
+++ b/spec/factories/transfer_factories.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
       destination_uuid { nil }
 
       # Transfers will be a hash with column names as keys and tube-like objects for the values.
-      transfers { (0..destination_tube_count - 1).to_h { |i| [well_coordinates[i], { uuid: tubes[i].uuid }] } }
+      transfers { (0...destination_tube_count).to_h { |i| [well_coordinates[i], { uuid: tubes[i].uuid }] } }
     end
 
     factory :v2_transfer_between_tubes do

--- a/spec/features/creating_a_tag_plate_spec.rb
+++ b/spec/features/creating_a_tag_plate_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'Creating a tag plate', js: true, tag_plate: true do
   let(:tag_plate_uuid) { 'tag-plate-uuid' }
   let(:tag_plate_qcable) { json :tag_plate_qcable, uuid: tag_plate_qcable_uuid, lot_uuid: 'lot-uuid' }
   let(:transfer_template_uuid) { 'custom-pooling' }
-  let(:transfer_template) { json :transfer_template, uuid: transfer_template_uuid }
+  let(:expected_transfers) { WellHelpers.stamp_hash(96) }
   let(:tag_template_uuid) { 'tag-layout-template-0' }
 
   let(:submission_pools) { json(:submission_pool_collection) }
@@ -77,7 +77,22 @@ RSpec.feature 'Creating a tag plate', js: true, tag_plate: true do
   shared_examples 'it supports the plate' do
     let(:help_text) { "Click 'Create plate'" }
 
-    before { stub_v2_plate(create(:v2_plate, uuid: tag_plate_uuid, purpose_uuid: 'stock-plate-purpose-uuid')) }
+    before do
+      stub_v2_plate(create(:v2_plate, uuid: tag_plate_uuid, purpose_uuid: 'stock-plate-purpose-uuid'))
+
+      expect_api_v2_posts(
+        'Transfer',
+        [
+          {
+            user_uuid: user_uuid,
+            source_uuid: plate_uuid,
+            destination_uuid: tag_plate_uuid,
+            transfer_template_uuid: transfer_template_uuid,
+            transfers: expected_transfers
+          }
+        ]
+      )
+    end
 
     scenario 'creation with the plate' do
       fill_in_swipecard_and_barcode user_swipecard, plate_barcode

--- a/spec/features/pool_tubes_at_end_of_pipeline_spec.rb
+++ b/spec/features/pool_tubes_at_end_of_pipeline_spec.rb
@@ -18,39 +18,10 @@ RSpec.feature 'Pool tubes at end of pipeline', js: true do
   let(:example_tube) do
     json(:tube_with_siblings, uuid: tube_uuid, siblings_count: 1, state: 'passed', barcode_number: 1)
   end
-  let(:transfer_template_uuid) { 'transfer-template-uuid' }
-  let(:transfer_template) { json :transfer_template, uuid: transfer_template_uuid }
   let(:multiplexed_library_tube_uuid) { 'multiplexed-library-tube-uuid' }
-
-  let(:transfer_request) do
-    stub_api_post(
-      transfer_template_uuid,
-      payload: {
-        transfer: {
-          user: user_uuid,
-          source: tube_uuid
-        }
-      },
-      body: json(:transfer_between_tubes_by_submission, destination: multiplexed_library_tube_uuid)
-    )
-  end
-  let(:transfer_request_b) do
-    stub_api_post(
-      transfer_template_uuid,
-      payload: {
-        transfer: {
-          user: user_uuid,
-          source: sibling_uuid
-        }
-      },
-      body: json(:transfer_between_tubes_by_submission, destination: multiplexed_library_tube_uuid)
-    )
-  end
 
   # Setup stubs
   background do
-    Settings.transfer_templates['Transfer from tube to tube by submission'] = transfer_template_uuid
-
     # Set-up the tube config
     create :tube_config, name: 'Example Purpose', uuid: 'example-purpose-uuid'
     create :tube_config,
@@ -71,8 +42,15 @@ RSpec.feature 'Pool tubes at end of pipeline', js: true do
     stub_api_get('transfer-template-uuid', body: json(:transfer_template, uuid: 'transfer-template-uuid'))
     stub_v2_barcode_printers(create_list(:v2_plate_barcode_printer, 3))
     stub_v2_tube(create(:v2_tube, uuid: multiplexed_library_tube_uuid))
-    transfer_request
-    transfer_request_b
+
+    expect_api_v2_posts(
+      'Transfer',
+      [
+        { user_uuid: user_uuid, source_uuid: tube_uuid, transfer_template_uuid: 'tube-to-tube-by-sub' },
+        { user_uuid: user_uuid, source_uuid: sibling_uuid, transfer_template_uuid: 'tube-to-tube-by-sub' }
+      ],
+      create_list(:v2_transfer_between_tubes, 2, destination_uuid: multiplexed_library_tube_uuid)
+    )
   end
 
   shared_examples 'a tube validation form' do
@@ -89,8 +67,6 @@ RSpec.feature 'Pool tubes at end of pipeline', js: true do
       find_field('Tube barcode').send_keys barcode_reader_key
       click_on('Make Tube')
       expect(page).to have_content('New empty labware added to the system.')
-      expect(transfer_request).to have_been_made.once
-      expect(transfer_request_b).to have_been_made.once
     end
   end
 

--- a/spec/models/labware_creators/base_spec.rb
+++ b/spec/models/labware_creators/base_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe LabwareCreators::Base do
   context 'with a custom transfer-template' do
     before do
       create :purpose_config, transfer_template: 'Custom transfer template', uuid: 'test-purpose'
+
+      # Note this next change is persisted across the whole test run
       Settings.transfer_templates['Custom transfer template'] = 'custom-template-uuid'
     end
 

--- a/spec/models/labware_creators/final_tube_spec.rb
+++ b/spec/models/labware_creators/final_tube_spec.rb
@@ -25,32 +25,23 @@ RSpec.describe LabwareCreators::FinalTube do
     let(:user_uuid) { 'user-uuid' }
     let(:multiplexed_library_tube_uuid) { 'multiplexed-library-tube--uuid' }
     let(:transfer_template_uuid) { 'transfer-template-uuid' }
+    let(:transfer) { create :v2_transfer }
 
     let(:form_attributes) { { purpose_uuid: child_purpose_uuid, parent_uuid: parent_uuid, user_uuid: user_uuid } }
 
     context 'with a sibling-less parent tube' do
-      let(:transfer_request) do
-        stub_api_post(
-          transfer_template_uuid,
-          payload: {
-            transfer: {
-              user: user_uuid,
-              source: parent_uuid
-            }
-          },
-          body: json(:transfer_between_tubes_by_submission, destination: multiplexed_library_tube_uuid)
-        )
-      end
-
       let(:tube_json) { json(:tube_without_siblings, uuid: parent_uuid) }
-
-      before { transfer_request }
 
       describe '#save' do
         it 'should be vaild' do
+          expect_api_v2_posts(
+            'Transfer',
+            [{ user_uuid: user_uuid, source_uuid: parent_uuid, transfer_template_uuid: transfer_template_uuid }],
+            [transfer]
+          )
+
           expect(subject.save).to be true
-          expect(subject.redirection_target.to_param).to eq('multiplexed-library-tube--uuid')
-          expect(transfer_request).to have_been_made.once
+          expect(subject.redirection_target.to_param).to eq(transfer.destination_uuid)
         end
       end
     end
@@ -88,41 +79,20 @@ RSpec.describe LabwareCreators::FinalTube do
           end
 
           let(:sibling_uuid) { 'sibling-tube-0' }
-          let(:transfer_request) do
-            stub_api_post(
-              transfer_template_uuid,
-              payload: {
-                transfer: {
-                  user: user_uuid,
-                  source: parent_uuid
-                }
-              },
-              body: json(:transfer_between_tubes_by_submission, destination: multiplexed_library_tube_uuid)
-            )
-          end
-          let(:transfer_request_b) do
-            stub_api_post(
-              transfer_template_uuid,
-              payload: {
-                transfer: {
-                  user: user_uuid,
-                  source: sibling_uuid
-                }
-              },
-              body: json(:transfer_between_tubes_by_submission, destination: multiplexed_library_tube_uuid)
-            )
-          end
-
-          before do
-            transfer_request
-            transfer_request_b
-          end
+          let(:transfer_b) { create :v2_transfer }
 
           it 'should create transfers per sibling' do
+            expect_api_v2_posts(
+              'Transfer',
+              [
+                { user_uuid: user_uuid, source_uuid: parent_uuid, transfer_template_uuid: transfer_template_uuid },
+                { user_uuid: user_uuid, source_uuid: sibling_uuid, transfer_template_uuid: transfer_template_uuid }
+              ],
+              [transfer, transfer_b]
+            )
+
             expect(subject).to be_valid
             expect(subject.save).to be true
-            expect(transfer_request).to have_been_made.once
-            expect(transfer_request_b).to have_been_made.once
           end
         end
       end

--- a/spec/models/labware_creators/final_tube_spec.rb
+++ b/spec/models/labware_creators/final_tube_spec.rb
@@ -13,18 +13,14 @@ RSpec.describe LabwareCreators::FinalTube do
   context 'on creation' do
     subject { LabwareCreators::FinalTube.new(api, form_attributes) }
 
-    before do
-      Settings.transfer_templates['Transfer from tube to tube by submission'] = transfer_template_uuid
-      stub_api_get(parent_uuid, body: tube_json)
-      stub_api_get(transfer_template_uuid, body: json(:transfer_template, uuid: transfer_template_uuid))
-    end
+    before { stub_api_get(parent_uuid, body: tube_json) }
 
     let(:controller) { TubeCreationController.new }
     let(:child_purpose_uuid) { 'child-purpose-uuid' }
     let(:parent_uuid) { 'parent-uuid' }
     let(:user_uuid) { 'user-uuid' }
     let(:multiplexed_library_tube_uuid) { 'multiplexed-library-tube--uuid' }
-    let(:transfer_template_uuid) { 'transfer-template-uuid' }
+    let(:transfer_template_uuid) { 'tube-to-tube-by-sub' } # Defined in spec_helper.rb
     let(:transfer) { create :v2_transfer }
 
     let(:form_attributes) { { purpose_uuid: child_purpose_uuid, parent_uuid: parent_uuid, user_uuid: user_uuid } }

--- a/spec/models/labware_creators/plate_with_template_spec.rb
+++ b/spec/models/labware_creators/plate_with_template_spec.rb
@@ -60,25 +60,21 @@ RSpec.describe LabwareCreators::PlateWithTemplate do
 
     let!(:plate_request) { stub_api_get(parent_uuid, body: plate) }
 
-    let!(:transfer_template_request) { stub_api_get('custom-transfer-template', body: transfer_template) }
-
-    let!(:transfer_creation_request) do
-      stub_api_post(
-        transfer_template_uuid,
-        payload: {
-          transfer: {
-            destination: 'child-uuid',
-            source: parent_uuid,
-            user: user_uuid
-          }
-        },
-        body: '{}'
-      )
-    end
     it 'makes the expected requests' do
+      expect_api_v2_posts(
+        'Transfer',
+        [
+          {
+            user_uuid: user_uuid,
+            source_uuid: parent_uuid,
+            destination_uuid: 'child-uuid',
+            transfer_template_uuid: transfer_template_uuid
+          }
+        ]
+      )
+
       expect(subject.save!).to eq true
       expect(plate_creation_request).to have_been_made
-      expect(transfer_creation_request).to have_been_made
     end
   end
 end

--- a/spec/models/labware_creators/plate_with_template_spec.rb
+++ b/spec/models/labware_creators/plate_with_template_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe LabwareCreators::PlateWithTemplate do
   let(:plate) { json :plate, uuid: parent_uuid, barcode_number: '2', pool_sizes: [8, 8] }
   let(:wells) { json :well_collection, size: 16 }
   let(:wells_in_column_order) { WellHelpers.column_order }
-  let(:transfer_template_name) { 'Pool wells based on submission' }
-  let(:transfer_template_uuid) { 'custom-transfer-template' }
-  let(:transfer_template) { json :transfer_template, uuid: transfer_template_uuid, name: transfer_template_name }
+  let(:transfer_template_uuid) { 'custom-transfer-template' } # Defined in spec_helper.rb
 
   let(:child_purpose_uuid) { 'child-purpose' }
   let(:child_purpose_name) { 'Child Purpose' }
@@ -28,7 +26,6 @@ RSpec.describe LabwareCreators::PlateWithTemplate do
 
   before do
     create(:templated_transfer_config, name: child_purpose_name, uuid: child_purpose_uuid)
-    Settings.transfer_templates[transfer_template_name] = transfer_template_uuid
     stub_api_get(parent_uuid, body: plate)
     stub_api_get(parent_uuid, 'wells', body: wells)
   end

--- a/spec/models/labware_creators/pooled_tubes_from_whole_plates_spec.rb
+++ b/spec/models/labware_creators/pooled_tubes_from_whole_plates_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe LabwareCreators::PooledTubesFromWholePlates, with: :uploader do
   let(:user_uuid) { SecureRandom.uuid }
   let(:purpose_uuid) { SecureRandom.uuid }
   let(:purpose) { json :purpose, uuid: purpose_uuid }
+  let(:transfer_template_uuid) { SecureRandom.uuid }
   let(:parent_uuid) { SecureRandom.uuid }
   let(:parent2_uuid) { SecureRandom.uuid }
   let(:parent3_uuid) { SecureRandom.uuid }
@@ -39,7 +40,7 @@ RSpec.describe LabwareCreators::PooledTubesFromWholePlates, with: :uploader do
     ]
   end
 
-  before { Settings.transfer_templates['Whole plate to tube'] = 'whole-plate-to-tube' }
+  before { Settings.transfer_templates['Whole plate to tube'] = transfer_template_uuid }
 
   describe '#new' do
     it_behaves_like 'it has a custom page', 'pooled_tubes_from_whole_plates'
@@ -81,35 +82,28 @@ RSpec.describe LabwareCreators::PooledTubesFromWholePlates, with: :uploader do
     # Used to fetch the pools. This is the kind of thing we could pass through from a custom form
     let(:stub_barcode_searches) { stub_asset_search(barcodes, [parent, parent2, parent3, parent4]) }
 
-    let(:transfer_creation_request) do
-      stub_api_get('whole-plate-to-tube', body: json(:whole_plate_to_tube))
-      [parent_uuid, parent2_uuid, parent3_uuid, parent4_uuid].map do |uuid|
-        stub_api_post(
-          'whole-plate-to-tube',
-          payload: {
-            transfer: {
-              user: user_uuid,
-              source: uuid,
-              destination: 'tube-0'
-            }
-          },
-          body: '{}'
-        )
-      end
-    end
-
     before do
       stub_barcode_searches
       tube_creation_children_request
       tube_creation_request
-      transfer_creation_request
     end
 
     context 'with compatible plates' do
       it 'pools from all the plates' do
+        expect_api_v2_posts(
+          'Transfer',
+          [parent_uuid, parent2_uuid, parent3_uuid, parent4_uuid].map do |source_uuid|
+            {
+              user_uuid: user_uuid,
+              source_uuid: source_uuid,
+              destination_uuid: 'tube-0',
+              transfer_template_uuid: transfer_template_uuid
+            }
+          end
+        )
+
         expect(subject.save!).to be_truthy
         expect(tube_creation_request).to have_been_made.once
-        transfer_creation_request.each { |transfer| expect(transfer).to have_been_made.once }
       end
     end
   end

--- a/spec/models/labware_creators/pooled_tubes_from_whole_plates_spec.rb
+++ b/spec/models/labware_creators/pooled_tubes_from_whole_plates_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe LabwareCreators::PooledTubesFromWholePlates, with: :uploader do
   let(:user_uuid) { SecureRandom.uuid }
   let(:purpose_uuid) { SecureRandom.uuid }
   let(:purpose) { json :purpose, uuid: purpose_uuid }
-  let(:transfer_template_uuid) { SecureRandom.uuid }
   let(:parent_uuid) { SecureRandom.uuid }
   let(:parent2_uuid) { SecureRandom.uuid }
   let(:parent3_uuid) { SecureRandom.uuid }
@@ -39,8 +38,6 @@ RSpec.describe LabwareCreators::PooledTubesFromWholePlates, with: :uploader do
       SBCF::SangerBarcode.new(prefix: 'DN', number: 4).human_barcode
     ]
   end
-
-  before { Settings.transfer_templates['Whole plate to tube'] = transfer_template_uuid }
 
   describe '#new' do
     it_behaves_like 'it has a custom page', 'pooled_tubes_from_whole_plates'
@@ -97,7 +94,7 @@ RSpec.describe LabwareCreators::PooledTubesFromWholePlates, with: :uploader do
               user_uuid: user_uuid,
               source_uuid: source_uuid,
               destination_uuid: 'tube-0',
-              transfer_template_uuid: transfer_template_uuid
+              transfer_template_uuid: 'whole-plate-to-tube'
             }
           end
         )

--- a/spec/models/labware_creators/tagged_plate_spec.rb
+++ b/spec/models/labware_creators/tagged_plate_spec.rb
@@ -207,8 +207,6 @@ RSpec.describe LabwareCreators::TaggedPlate, tag_plate: true do
       it_behaves_like 'it has a custom page', 'tagged_plate'
 
       context 'on save' do
-        Settings.transfer_templates['Custom pooling'] = 'custom-plate-transfer-template-uuid'
-
         it 'creates a tag plate' do
           expect_api_v2_posts(
             'Transfer',

--- a/spec/models/labware_creators/tube_from_tube_spec.rb
+++ b/spec/models/labware_creators/tube_from_tube_spec.rb
@@ -33,9 +33,7 @@ RSpec.describe LabwareCreators::TubeFromTube do
 
     before do
       Settings.transfer_templates['Transfer between specific tubes'] = transfer_template_uuid
-      stub_api_get(transfer_template_uuid, body: json(:transfer_template, uuid: transfer_template_uuid))
       creation_request
-      transfer_request
     end
 
     let(:controller) { TubeCreationController.new }
@@ -61,26 +59,23 @@ RSpec.describe LabwareCreators::TubeFromTube do
       )
     end
 
-    let(:transfer_request) do
-      stub_api_post(
-        transfer_template_uuid,
-        payload: {
-          transfer: {
-            user: user_uuid,
-            source: parent_uuid,
-            destination: child_uuid
-          }
-        },
-        body: json(:transfer_between_specific_tubes, destination_uuid: child_uuid)
-      )
-    end
-
     describe '#save!' do
       it 'creates the child' do
+        expect_api_v2_posts(
+          'Transfer',
+          [
+            {
+              user_uuid: user_uuid,
+              source_uuid: parent_uuid,
+              destination_uuid: child_uuid,
+              transfer_template_uuid: transfer_template_uuid
+            }
+          ]
+        )
+
         subject.save!
         expect(subject.redirection_target.uuid).to eq(child_uuid)
         expect(creation_request).to have_been_made.once
-        expect(transfer_request).to have_been_made.once
       end
     end
   end

--- a/spec/models/labware_creators/tube_from_tube_spec.rb
+++ b/spec/models/labware_creators/tube_from_tube_spec.rb
@@ -31,17 +31,14 @@ RSpec.describe LabwareCreators::TubeFromTube do
 
     it_behaves_like 'it has no custom page'
 
-    before do
-      Settings.transfer_templates['Transfer between specific tubes'] = transfer_template_uuid
-      creation_request
-    end
+    before { creation_request }
 
     let(:controller) { TubeCreationController.new }
     let(:child_purpose_uuid) { 'child-purpose-uuid' }
     let(:parent_uuid) { 'parent-uuid' }
     let(:child_uuid) { 'child-uuid' }
     let(:user_uuid) { 'user-uuid' }
-    let(:transfer_template_uuid) { 'transfer-between-specific-tubes' }
+    let(:transfer_template_uuid) { 'transfer-between-specific-tubes' } # Defined in spec_helper.rb
 
     let(:form_attributes) { { purpose_uuid: child_purpose_uuid, parent_uuid: parent_uuid, user_uuid: user_uuid } }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -160,10 +160,12 @@ RSpec.configure do |config|
     FactoryBot.find_definitions
     Settings.robots = {}
     Settings.transfer_templates = {
-      'Transfer columns 1-12' => 'transfer-1-12',
-      'Transfer wells to MX library tubes by submission' => 'transfer-to-mx-tubes-on-submission',
       'Custom pooling' => 'custom-pooling',
+      'Pool wells based on submission' => 'custom-transfer-template',
+      'Transfer between specific tubes' => 'transfer-between-specific-tubes',
+      'Transfer columns 1-12' => 'transfer-1-12',
       'Transfer from tube to tube by submission' => 'tube-to-tube-by-sub',
+      'Transfer wells to MX library tubes by submission' => 'transfer-to-mx-tubes-on-submission',
       'Whole plate to tube' => 'whole-plate-to-tube'
     }
     YAML

--- a/spec/support/api_url_helper.rb
+++ b/spec/support/api_url_helper.rb
@@ -89,13 +89,24 @@ module ApiUrlHelper
       allow_any_instance_of(receiving_class).to receive(:save).and_return(true)
     end
 
-    def expect_api_v2_posts(klass, args_list)
-      # Expects the 'create!' method for any class beginning with
-      # 'Sequencescape::Api::V2::' to be called with given arguments, in sequence, and returns true
+    def stub_api_v2_post(klass)
+      # intercepts the 'create!' method for any class beginning with
+      # 'Sequencescape::Api::V2::' and returns true
       receiving_class = "Sequencescape::Api::V2::#{klass}".constantize
-      expect(receiving_class).to receive(:create!).exactly(args_list.count).times do |args|
-        expect(args).to eq(args_list.shift)
-      end.and_return(true)
+      allow(receiving_class).to receive(:create!).and_return(true)
+    end
+
+    def expect_api_v2_posts(klass, args_list, return_values = [])
+      # Expects the 'create!' method for any class beginning with
+      # 'Sequencescape::Api::V2::' to be called with given arguments, in sequence, and returns the given values.
+      # If return_values is empty, it will return true.
+      receiving_class = "Sequencescape::Api::V2::#{klass}".constantize
+      args_list
+        .zip(return_values)
+        .each do |args, ret|
+          ret ||= true
+          expect(receiving_class).to receive(:create!).with(args).and_return(ret)
+        end
     end
 
     def stub_barcode_search(barcode, labware)

--- a/spec/support/api_url_helper.rb
+++ b/spec/support/api_url_helper.rb
@@ -89,11 +89,11 @@ module ApiUrlHelper
       allow_any_instance_of(receiving_class).to receive(:save).and_return(true)
     end
 
-    def stub_api_v2_post(klass)
+    def stub_api_v2_post(klass, return_value = true)
       # intercepts the 'create!' method for any class beginning with
       # 'Sequencescape::Api::V2::' and returns true
       receiving_class = "Sequencescape::Api::V2::#{klass}".constantize
-      allow(receiving_class).to receive(:create!).and_return(true)
+      allow(receiving_class).to receive(:create!).and_return(return_value)
     end
 
     def expect_api_v2_posts(klass, args_list, return_values = [])

--- a/spec/support/api_url_helper.rb
+++ b/spec/support/api_url_helper.rb
@@ -76,7 +76,7 @@ module ApiUrlHelper
   module V2Helpers
     def stub_api_v2_patch(klass)
       # intercepts the 'update' and 'update!' method for any instance of the class beginning with
-      # 'Sequencescape::Api::V2::' and returns true
+      # 'Sequencescape::Api::V2::' and returns true.
       receiving_class = "Sequencescape::Api::V2::#{klass}".constantize
       allow_any_instance_of(receiving_class).to receive(:update).and_return(true)
       allow_any_instance_of(receiving_class).to receive(:update!).and_return(true)
@@ -84,15 +84,16 @@ module ApiUrlHelper
 
     def stub_api_v2_save(klass)
       # intercepts the 'save' method for any instance of the class beginning with
-      # 'Sequencescape::Api::V2::' and returns true
+      # 'Sequencescape::Api::V2::' and returns true.
       receiving_class = "Sequencescape::Api::V2::#{klass}".constantize
       allow_any_instance_of(receiving_class).to receive(:save).and_return(true)
     end
 
-    def stub_api_v2_post(klass, return_value = true)
+    def stub_api_v2_post(klass, return_value = nil)
       # intercepts the 'create!' method for any class beginning with
-      # 'Sequencescape::Api::V2::' and returns true
+      # 'Sequencescape::Api::V2::' and returns the given value or else true.
       receiving_class = "Sequencescape::Api::V2::#{klass}".constantize
+      return_value ||= true
       allow(receiving_class).to receive(:create!).and_return(return_value)
     end
 

--- a/spec/support/shared_tagging_examples.rb
+++ b/spec/support/shared_tagging_examples.rb
@@ -32,24 +32,6 @@ RSpec.shared_context 'a tag plate creator' do
     )
   end
 
-  let(:expected_transfers) { WellHelpers.stamp_hash(96) }
-
-  let!(:transfer_creation_request) do
-    stub_api_get(transfer_template_uuid, body: transfer_template)
-    stub_api_post(
-      transfer_template_uuid,
-      payload: {
-        transfer: {
-          source: plate_uuid,
-          destination: tag_plate_uuid,
-          user: user_uuid,
-          transfers: expected_transfers
-        }
-      },
-      body: '{}'
-    )
-  end
-
   let(:tag_layout_template) { json(:tag_layout_template, uuid: tag_template_uuid) }
   let(:enforce_uniqueness) { true }
 


### PR DESCRIPTION
Closes #1818 

#### Changes proposed in this pull request

- Switch over to using V2 transfers.

We no longer have to get the template from the API before we request to create the transfer since we pass the UUID to the template endpoint to create a transfer.  We already have the UUIDs in the app config from the `config:generate` rake task.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
