### PR TITLE
DPL-1023 - Sample arraying restrict tube type

### DIFF
--- a/app/frontend/javascript/multi-stamp-tubes/components/MultiStampTubes.spec.js
+++ b/app/frontend/javascript/multi-stamp-tubes/components/MultiStampTubes.spec.js
@@ -29,7 +29,7 @@ describe('MultiStampTubes', () => {
         transfersCreator: 'multi-stamp-tubes',
         allowTubeDuplicates: 'false',
         requireTubePassed: 'false',
-        permittedPurposes: [],
+        acceptablePurposes: '[]',
         ...options,
       },
       localVue,
@@ -518,9 +518,9 @@ describe('MultiStampTubes', () => {
     })
   })
 
-  describe('when tubes are required to be in the permittedPurposes list', () => {
-    it('is not valid when we scan tubes with purposes not in the permittedPurposes list', async () => {
-      const wrapper = wrapperFactory({ permittedPurposes: ['A Purpose'] })
+  describe('when tubes are required to be in the acceptablePurposes list', () => {
+    it('is not valid when we scan tubes with purposes not in the acceptablePurposes list', async () => {
+      const wrapper = wrapperFactory({ acceptablePurposes: JSON.stringify(['A Purpose']) })
       const tube1 = {
         state: 'valid',
         labware: tubeFactory({ uuid: 'tube-uuid-1', purpose: { name: 'Another Purpose' } }),
@@ -529,15 +529,15 @@ describe('MultiStampTubes', () => {
       wrapper.vm.updateTube(1, tube1)
 
       const validationMessage = {
-        message: "Tube purpose 'Another Purpose' is not in the permitted purpose list: A Purpose",
+        message: "Tube purpose 'Another Purpose' is not in the acceptable purpose list: A Purpose",
         valid: false,
       }
       expect(wrapper.vm.scanValidation.length).toEqual(2)
       expect(aggregate(wrapper.vm.scanValidation, tube1.labware)).toEqual(validationMessage)
     })
 
-    it('is valid when we scan tubes with purposes in the permittedPurposes list', async () => {
-      const wrapper = wrapperFactory({ permittedPurposes: ['A Purpose'] })
+    it('is valid when we scan tubes with purposes in the acceptablePurposes list', async () => {
+      const wrapper = wrapperFactory({ acceptablePurposes: JSON.stringify(['A Purpose']) })
       const tube1 = {
         state: 'valid',
         labware: tubeFactory({ uuid: 'tube-uuid-1', purpose: { name: 'A Purpose' } }),

--- a/app/frontend/javascript/multi-stamp-tubes/components/MultiStampTubes.spec.js
+++ b/app/frontend/javascript/multi-stamp-tubes/components/MultiStampTubes.spec.js
@@ -29,6 +29,7 @@ describe('MultiStampTubes', () => {
         transfersCreator: 'multi-stamp-tubes',
         allowTubeDuplicates: 'false',
         requireTubePassed: 'false',
+        permittedPurposes: [],
         ...options,
       },
       localVue,
@@ -512,6 +513,39 @@ describe('MultiStampTubes', () => {
       wrapper.vm.updateTube(1, passedTube)
 
       const validation = aggregate(wrapper.vm.scanValidation, passedTube.labware)
+      expect(validation).toHaveProperty('valid')
+      expect(validation.valid).toEqual(true)
+    })
+  })
+
+  describe('when tubes are required to be in the permittedPurposes list', () => {
+    it('is not valid when we scan tubes with purposes not in the permittedPurposes list', async () => {
+      const wrapper = wrapperFactory({ permittedPurposes: ['A Purpose'] })
+      const tube1 = {
+        state: 'valid',
+        labware: tubeFactory({ uuid: 'tube-uuid-1', purpose: { name: 'Another Purpose' } }),
+      }
+
+      wrapper.vm.updateTube(1, tube1)
+
+      const validationMessage = {
+        message: "Tube purpose 'Another Purpose' is not in the permitted purpose list: A Purpose",
+        valid: false,
+      }
+      expect(wrapper.vm.scanValidation.length).toEqual(2)
+      expect(aggregate(wrapper.vm.scanValidation, tube1.labware)).toEqual(validationMessage)
+    })
+
+    it('is valid when we scan tubes with purposes in the permittedPurposes list', async () => {
+      const wrapper = wrapperFactory({ permittedPurposes: ['A Purpose'] })
+      const tube1 = {
+        state: 'valid',
+        labware: tubeFactory({ uuid: 'tube-uuid-1', purpose: { name: 'A Purpose' } }),
+      }
+
+      wrapper.vm.updateTube(1, tube1)
+
+      const validation = aggregate(wrapper.vm.scanValidation, tube1.labware)
       expect(validation).toHaveProperty('valid')
       expect(validation.valid).toEqual(true)
     })

--- a/app/frontend/javascript/multi-stamp-tubes/components/MultiStampTubes.vue
+++ b/app/frontend/javascript/multi-stamp-tubes/components/MultiStampTubes.vue
@@ -55,7 +55,7 @@ import Plate from '@/javascript/shared/components/Plate.vue'
 import {
   checkDuplicates,
   checkState,
-  checkPermittedPurposes,
+  checkAcceptablePurposes,
 } from '@/javascript/shared/components/tubeScanValidators.js'
 import devourApi from '@/javascript/shared/devourApi.js'
 import { handleFailedRequest } from '@/javascript/shared/requestHelpers.js'
@@ -147,9 +147,11 @@ export default {
     // Also referenced as require-tube-passed and require_tube_passed
     requireTubePassed: { type: String, required: true },
 
-    // A permitted list of purpose names that can be scanned
-    // If left empty all purposes are permitted
-    permittedPurposes: { type: Array, required: false, default: () => [] },
+    // A acceptable list of purpose names that can be scanned
+    // If left empty all purposes are acceptable
+    // Also referenced as data-acceptable-purposes and data_acceptable_purposes
+    // See computed method acceptablePurposesArray for conversion to array.
+    acceptablePurposes: { type: String, required: false, default: '[]' },
   },
   data() {
     return {
@@ -186,6 +188,9 @@ export default {
     },
     targetColumnsNumber() {
       return Number.parseInt(this.targetColumns)
+    },
+    acceptablePurposesArray() {
+      return JSON.parse(this.acceptablePurposes)
     },
     // Returns a boolean indicating whether the provided tubes are valid.
     // Used to enable and disable the 'Create' button.
@@ -255,8 +260,8 @@ export default {
     scanValidation() {
       const validators = []
 
-      // If any permittedPurposes specified then ensure we validate against them
-      if (this.permittedPurposes.length) validators.push(checkPermittedPurposes(this.permittedPurposes))
+      // If any acceptablePurposes specified then ensure we validate against them
+      if (this.acceptablePurposesArray.length) validators.push(checkAcceptablePurposes(this.acceptablePurposesArray))
 
       if (this.requireTubePassed === 'true') validators.push(checkState(['passed']))
 

--- a/app/frontend/javascript/multi-stamp-tubes/components/MultiStampTubes.vue
+++ b/app/frontend/javascript/multi-stamp-tubes/components/MultiStampTubes.vue
@@ -52,7 +52,11 @@
 import LabwareScan from '@/javascript/shared/components/LabwareScan.vue'
 import LoadingModal from '@/javascript/shared/components/LoadingModal.vue'
 import Plate from '@/javascript/shared/components/Plate.vue'
-import { checkDuplicates, checkState } from '@/javascript/shared/components/tubeScanValidators.js'
+import {
+  checkDuplicates,
+  checkState,
+  checkPermittedPurposes,
+} from '@/javascript/shared/components/tubeScanValidators.js'
 import devourApi from '@/javascript/shared/devourApi.js'
 import { handleFailedRequest } from '@/javascript/shared/requestHelpers.js'
 import resources from '@/javascript/shared/resources.js'
@@ -142,6 +146,10 @@ export default {
     // Should tubes be required to be in passed state
     // Also referenced as require-tube-passed and require_tube_passed
     requireTubePassed: { type: String, required: true },
+
+    // A permitted list of purpose names that can be scanned
+    // If left empty all purposes are permitted
+    permittedPurposes: { type: Array, required: false, default: () => [] },
   },
   data() {
     return {
@@ -246,6 +254,9 @@ export default {
     },
     scanValidation() {
       const validators = []
+
+      // If any permittedPurposes specified then ensure we validate against them
+      if (this.permittedPurposes.length) validators.push(checkPermittedPurposes(this.permittedPurposes))
 
       if (this.requireTubePassed === 'true') validators.push(checkState(['passed']))
 

--- a/app/frontend/javascript/multi-stamp-tubes/components/filterProps.js
+++ b/app/frontend/javascript/multi-stamp-tubes/components/filterProps.js
@@ -6,7 +6,7 @@ const filterProps = {
     aliquots: 'request',
   },
   plateIncludes: 'wells,wells.requests_as_source,wells.aliquots.request',
-  tubeIncludes: 'receptacle',
+  tubeIncludes: 'receptacle,purpose',
   requestsFilter: 'lb-null-filter',
 }
 

--- a/app/frontend/javascript/shared/components/LabwareScan.spec.js
+++ b/app/frontend/javascript/shared/components/LabwareScan.spec.js
@@ -134,7 +134,7 @@ describe('LabwareScan', () => {
           include: '',
           filter: { barcode: 'DN12345' },
           fields: {
-            tubes: 'labware_barcode,uuid,receptacle,state',
+            tubes: 'labware_barcode,uuid,receptacle,state,purpose',
             receptacles: 'uuid',
           },
         },
@@ -166,7 +166,7 @@ describe('LabwareScan', () => {
           filter: { barcode: 'not a barcode' },
           include: '',
           fields: {
-            tubes: 'labware_barcode,uuid,receptacle,state',
+            tubes: 'labware_barcode,uuid,receptacle,state,purpose',
             receptacles: 'uuid',
           },
         },
@@ -198,7 +198,7 @@ describe('LabwareScan', () => {
           include: '',
           filter: { barcode: 'Good barcode' },
           fields: {
-            tubes: 'labware_barcode,uuid,receptacle,state',
+            tubes: 'labware_barcode,uuid,receptacle,state,purpose',
             receptacles: 'uuid',
           },
         },
@@ -246,7 +246,7 @@ describe('LabwareScan', () => {
           filter: { barcode: 'Good barcode' },
           include: '',
           fields: {
-            tubes: 'labware_barcode,uuid,receptacle,state',
+            tubes: 'labware_barcode,uuid,receptacle,state,purpose',
             receptacles: 'uuid',
           },
         },

--- a/app/frontend/javascript/shared/components/LabwareScan.vue
+++ b/app/frontend/javascript/shared/components/LabwareScan.vue
@@ -239,7 +239,7 @@ export default {
 
       if (this.labwareType == 'tube') {
         return {
-          tubes: 'labware_barcode,uuid,receptacle,state',
+          tubes: 'labware_barcode,uuid,receptacle,state,purpose',
           receptacles: 'uuid',
         }
       } else {

--- a/app/frontend/javascript/shared/components/tubeScanValidators.js
+++ b/app/frontend/javascript/shared/components/tubeScanValidators.js
@@ -100,6 +100,22 @@ const checkMatchingPurposes = (purpose) => {
   }
 }
 
+// Returns a validator than ensures the purpose names of all tubes is in the permitted purpose list
+const checkPermittedPurposes = (permittedPurposeList) => {
+  return (tube) => {
+    if (tube && permittedPurposeList && !permittedPurposeList.includes(tube.purpose?.name)) {
+      return {
+        valid: false,
+        message: `Tube purpose '${
+          tube.purpose?.name || 'UNKNOWN'
+        }' is not in the permitted purpose list: ${permittedPurposeList}`,
+      }
+    } else {
+      return validScanMessage()
+    }
+  }
+}
+
 // Returns a validator that ensures the tube contains at least one QC result
 // for molarity in nM.
 const checkMolarityResult = () => {
@@ -150,4 +166,12 @@ const checkTransferParameters = (purposeConfigs) => {
   }
 }
 
-export { checkDuplicates, checkId, checkMatchingPurposes, checkMolarityResult, checkState, checkTransferParameters }
+export {
+  checkDuplicates,
+  checkId,
+  checkMatchingPurposes,
+  checkPermittedPurposes,
+  checkMolarityResult,
+  checkState,
+  checkTransferParameters,
+}

--- a/app/frontend/javascript/shared/components/tubeScanValidators.js
+++ b/app/frontend/javascript/shared/components/tubeScanValidators.js
@@ -100,15 +100,15 @@ const checkMatchingPurposes = (purpose) => {
   }
 }
 
-// Returns a validator than ensures the purpose names of all tubes is in the permitted purpose list
-const checkPermittedPurposes = (permittedPurposeList) => {
+// Returns a validator than ensures the purpose names of all tubes is in the acceptable purpose list
+const checkAcceptablePurposes = (acceptablePurposesList) => {
   return (tube) => {
-    if (tube && permittedPurposeList && !permittedPurposeList.includes(tube.purpose?.name)) {
+    if (tube && acceptablePurposesList && !acceptablePurposesList.includes(tube.purpose?.name)) {
       return {
         valid: false,
         message: `Tube purpose '${
           tube.purpose?.name || 'UNKNOWN'
-        }' is not in the permitted purpose list: ${permittedPurposeList}`,
+        }' is not in the acceptable purpose list: ${acceptablePurposesList.join(',')}`,
       }
     } else {
       return validScanMessage()
@@ -170,7 +170,7 @@ export {
   checkDuplicates,
   checkId,
   checkMatchingPurposes,
-  checkPermittedPurposes,
+  checkAcceptablePurposes,
   checkMolarityResult,
   checkState,
   checkTransferParameters,

--- a/app/frontend/javascript/shared/components/tubeScanValidators.spec.js
+++ b/app/frontend/javascript/shared/components/tubeScanValidators.spec.js
@@ -2,7 +2,7 @@ import {
   checkDuplicates,
   checkId,
   checkMatchingPurposes,
-  checkPermittedPurposes,
+  checkAcceptablePurposes,
   checkMolarityResult,
   checkState,
   checkTransferParameters,
@@ -148,39 +148,39 @@ describe('checkMatchingPurposes', () => {
   })
 })
 
-describe('checkPermittedPurposes', () => {
+describe('checkAcceptablePurposes', () => {
   it('passes if the tube has a matching purpose', () => {
     const tube = { purpose: { name: 'A Purpose' } }
-    expect(checkPermittedPurposes(['A Purpose'])(tube)).toEqual({
+    expect(checkAcceptablePurposes(['A Purpose'])(tube)).toEqual({
       valid: true,
     })
   })
 
   it('passes if the tube is undefined', () => {
     const tube = undefined
-    expect(checkPermittedPurposes(['A Purpose'])(tube)).toEqual({
+    expect(checkAcceptablePurposes(['A Purpose'])(tube)).toEqual({
       valid: true,
     })
   })
 
-  it('passes if the permittedPurposeList is undefined', () => {
+  it('passes if the acceptablePurposesList is undefined', () => {
     const tube = { purpose: { name: 'A Purpose' } }
-    expect(checkPermittedPurposes(undefined)(tube)).toEqual({ valid: true })
+    expect(checkAcceptablePurposes(undefined)(tube)).toEqual({ valid: true })
   })
 
   it('fails if the tube purpose is undefined', () => {
     const tube = {}
-    expect(checkPermittedPurposes(['A Purpose'])(tube)).toEqual({
+    expect(checkAcceptablePurposes(['A Purpose'])(tube)).toEqual({
       valid: false,
-      message: "Tube purpose 'UNKNOWN' is not in the permitted purpose list: A Purpose",
+      message: "Tube purpose 'UNKNOWN' is not in the acceptable purpose list: A Purpose",
     })
   })
 
-  it('fails if the tube purpose is not in the permittedPurposeList', () => {
+  it('fails if the tube purpose is not in the acceptablePurposesList', () => {
     const tube = { purpose: { name: 'Another Purpose' } }
-    expect(checkPermittedPurposes(['A Purpose'])(tube)).toEqual({
+    expect(checkAcceptablePurposes(['A Purpose'])(tube)).toEqual({
       valid: false,
-      message: "Tube purpose 'Another Purpose' is not in the permitted purpose list: A Purpose",
+      message: "Tube purpose 'Another Purpose' is not in the acceptable purpose list: A Purpose",
     })
   })
 })

--- a/app/frontend/javascript/shared/components/tubeScanValidators.spec.js
+++ b/app/frontend/javascript/shared/components/tubeScanValidators.spec.js
@@ -2,6 +2,7 @@ import {
   checkDuplicates,
   checkId,
   checkMatchingPurposes,
+  checkPermittedPurposes,
   checkMolarityResult,
   checkState,
   checkTransferParameters,
@@ -143,6 +144,43 @@ describe('checkMatchingPurposes', () => {
     expect(checkMatchingPurposes({ name: 'A Purpose' })(tube)).toEqual({
       valid: false,
       message: "Tube purpose 'Another Purpose' doesn't match other tubes",
+    })
+  })
+})
+
+describe('checkPermittedPurposes', () => {
+  it('passes if the tube has a matching purpose', () => {
+    const tube = { purpose: { name: 'A Purpose' } }
+    expect(checkPermittedPurposes(['A Purpose'])(tube)).toEqual({
+      valid: true,
+    })
+  })
+
+  it('passes if the tube is undefined', () => {
+    const tube = undefined
+    expect(checkPermittedPurposes(['A Purpose'])(tube)).toEqual({
+      valid: true,
+    })
+  })
+
+  it('passes if the permittedPurposeList is undefined', () => {
+    const tube = { purpose: { name: 'A Purpose' } }
+    expect(checkPermittedPurposes(undefined)(tube)).toEqual({ valid: true })
+  })
+
+  it('fails if the tube purpose is undefined', () => {
+    const tube = {}
+    expect(checkPermittedPurposes(['A Purpose'])(tube)).toEqual({
+      valid: false,
+      message: "Tube purpose 'UNKNOWN' is not in the permitted purpose list: A Purpose",
+    })
+  })
+
+  it('fails if the tube purpose is not in the permittedPurposeList', () => {
+    const tube = { purpose: { name: 'Another Purpose' } }
+    expect(checkPermittedPurposes(['A Purpose'])(tube)).toEqual({
+      valid: false,
+      message: "Tube purpose 'Another Purpose' is not in the permitted purpose list: A Purpose",
     })
   })
 })

--- a/app/frontend/javascript/shared/resources.js
+++ b/app/frontend/javascript/shared/resources.js
@@ -302,6 +302,7 @@ const resources = [
       uuid: "",
       name: "",
       size: "",
+      lifespan: ""
     },
     options: {},
   },

--- a/app/models/labware_creators/multi_stamp_tubes.rb
+++ b/app/models/labware_creators/multi_stamp_tubes.rb
@@ -31,6 +31,10 @@ module LabwareCreators
       params.fetch('require_tube_passed', false)
     end
 
+    def permitted_purposes
+      params.fetch('permitted_purposes', [])
+    end
+
     private
 
     def create_labware!

--- a/app/models/labware_creators/multi_stamp_tubes.rb
+++ b/app/models/labware_creators/multi_stamp_tubes.rb
@@ -31,8 +31,8 @@ module LabwareCreators
       params.fetch('require_tube_passed', false)
     end
 
-    def permitted_purposes
-      params.fetch('permitted_purposes', [])
+    def acceptable_purposes
+      params.fetch('acceptable_purposes', [])
     end
 
     private

--- a/app/views/plate_creation/multi_stamp_tubes.html.erb
+++ b/app/views/plate_creation/multi_stamp_tubes.html.erb
@@ -13,7 +13,7 @@
      data-source-tubes="<%= @labware_creator.source_tubes %>"
      data-allow-tube-duplicates="<%= @labware_creator.allow_tube_duplicates? %>"
      data-require-tube-passed="<%= @labware_creator.require_tube_passed? %>"
-     data-permitted-purposes="<%= @labware_creator.permitted_purposes %>"
+     data-acceptable-purposes="<%= @labware_creator.acceptable_purposes %>"
      >
   <div class="spinner-dark">Loading...</div>
 </div>

--- a/app/views/plate_creation/multi_stamp_tubes.html.erb
+++ b/app/views/plate_creation/multi_stamp_tubes.html.erb
@@ -13,6 +13,7 @@
      data-source-tubes="<%= @labware_creator.source_tubes %>"
      data-allow-tube-duplicates="<%= @labware_creator.allow_tube_duplicates? %>"
      data-require-tube-passed="<%= @labware_creator.require_tube_passed? %>"
+     data-permitted-purposes="<%= @labware_creator.permitted_purposes %>"
      >
   <div class="spinner-dark">Loading...</div>
 </div>

--- a/config/purposes/scrna_core_cell_extraction.yml
+++ b/config/purposes/scrna_core_cell_extraction.yml
@@ -39,6 +39,7 @@ LRC Blood Bank:
     params:
       allow_tube_duplicates: yes
       require_tube_passed: yes
+      permitted_purposes: ['LRC Blood Aliquot']
   :submission_options:
     scRNA core cell extraction:
       template_name: 'Limber - scRNA Core Cell Extraction'

--- a/config/purposes/scrna_core_cell_extraction.yml
+++ b/config/purposes/scrna_core_cell_extraction.yml
@@ -39,7 +39,7 @@ LRC Blood Bank:
     params:
       allow_tube_duplicates: yes
       require_tube_passed: yes
-      permitted_purposes: ['LRC Blood Aliquot']
+      acceptable_purposes: ['LRC Blood Aliquot']
   :submission_options:
     scRNA core cell extraction:
       template_name: 'Limber - scRNA Core Cell Extraction'


### PR DESCRIPTION
Closes #1501 

#### Changes proposed in this pull request

- Adds acceptablePurposes to MultiStampTubes component to enable pipeline specific purpose restriction.
- Adds checkAcceptablePurposes validator to tubeScanValidators.
- Enforces 'LRC Blood Aliquot' purpose type for scRNA core sample arraying.

#### Screenshots

![Screenshot 2024-08-30 at 14 13 05](https://github.com/user-attachments/assets/4349b032-f2f0-4e35-82d2-b0acce928c99)


#### Additional notes
I have tested this against both the scrna and cardinal int suite and it works as expected
