### PR TITLE
Y24-190-3: Use API v2 StateChange resource

### DIFF
--- a/app/controllers/plates_controller.rb
+++ b/app/controllers/plates_controller.rb
@@ -14,13 +14,13 @@ class PlatesController < LabwareController
         notice: 'No wells were selected to fail' # rubocop:todo Rails/I18nLocaleTexts
       )
     else
-      api.state_change.create!(
-        user: current_user_uuid,
-        target: params[:id],
+      Sequencescape::Api::V2::StateChange.create!(
         contents: wells_to_fail,
-        target_state: 'failed',
+        customer_accepts_responsibility: params[:customer_accepts_responsibility],
         reason: 'Individual Well Failure',
-        customer_accepts_responsibility: params[:customer_accepts_responsibility]
+        target_state: 'failed',
+        target_uuid: params[:id],
+        user_uuid: current_user_uuid
       )
       redirect_to(
         limber_plate_path(params[:id]),

--- a/app/models/concerns/labware_creators/tagged_plate_behaviour.rb
+++ b/app/models/concerns/labware_creators/tagged_plate_behaviour.rb
@@ -17,11 +17,11 @@ module LabwareCreators::TaggedPlateBehaviour
   # @return [Sequencescape::Api::StateChange] The created state change
   #
   def flag_tag_plate_as_exhausted
-    api.state_change.create!(
-      user: user_uuid,
-      target: tag_plate.asset_uuid,
+    Sequencescape::Api::V2::StateChange.create!(
       reason: 'Used in Library creation',
-      target_state: 'exhausted'
+      target_state: 'exhausted',
+      target_uuid: tag_plate.asset_uuid,
+      user_uuid: user_uuid
     )
   end
 

--- a/app/models/labware_creators/final_tube_from_plate.rb
+++ b/app/models/labware_creators/final_tube_from_plate.rb
@@ -48,7 +48,11 @@ module LabwareCreators
       raise StandardError, 'Tubes cannot be passed before transfer' if @create_transfer.nil?
 
       tubes_from_transfer.each do |tube_uuid|
-        api.state_change.create!(user: user_uuid, target: tube_uuid, target_state: 'passed')
+        Sequencescape::Api::V2::StateChange.create!(
+          target_state: 'passed',
+          target_uuid: tube_uuid,
+          user_uuid: user_uuid
+        )
       end
     end
 

--- a/app/models/state_changers.rb
+++ b/app/models/state_changers.rb
@@ -24,15 +24,14 @@ module StateChangers
 
     # rubocop:todo Style/OptionalBooleanParameter
     def move_to!(state, reason = nil, customer_accepts_responsibility = false)
-      state_details = {
-        target: labware_uuid,
-        user: user_uuid,
-        target_state: state,
-        reason: reason,
+      Sequencescape::Api::V2::StateChange.create!(
+        contents: contents_for(state),
         customer_accepts_responsibility: customer_accepts_responsibility,
-        contents: contents_for(state)
-      }
-      api.state_change.create!(state_details)
+        reason: reason,
+        target_state: state,
+        target_uuid: labware_uuid,
+        user_uuid: user_uuid
+      )
     end
 
     # rubocop:enable Style/OptionalBooleanParameter

--- a/app/sequencescape/sequencescape/api/v2/state_change.rb
+++ b/app/sequencescape/sequencescape/api/v2/state_change.rb
@@ -2,5 +2,6 @@
 
 # Represents a state change in Limber via the Sequencescape API
 class Sequencescape::Api::V2::StateChange < Sequencescape::Api::V2::Base
-  has_one :labware, class_name: 'Sequencescape::Api::V2::Labware'
+  has_one :target, class_name: 'Sequencescape::Api::V2::Labware'
+  has_one :user, class_name: 'Sequencescape::Api::V2::User'
 end

--- a/spec/controllers/plates_controller_spec.rb
+++ b/spec/controllers/plates_controller_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe PlatesController, type: :controller do
   let(:barcode_printers_request) { stub_v2_barcode_printers(create_list(:v2_plate_barcode_printer, 3)) }
   let(:user_uuid) { SecureRandom.uuid }
 
+  def expect_state_change_create(attributes)
+    expect_api_v2_posts(
+      'StateChange',
+      [{ target_state: 'failed', target_uuid: plate_uuid, user_uuid: user_uuid }.merge(attributes)]
+    )
+  end
+
   describe '#show' do
     before do
       create :stock_plate_config, uuid: 'stock-plate-purpose-uuid'
@@ -46,24 +53,10 @@ RSpec.describe PlatesController, type: :controller do
     let(:old_api_example_plate) do
       json :plate, barcode_number: v2_plate.labware_barcode.number, uuid: plate_uuid, state: 'passed'
     end
-    let!(:state_change_request) do
-      stub_api_post(
-        'state_changes',
-        payload: {
-          'state_change' => {
-            user: user_uuid,
-            target: plate_uuid,
-            target_state: 'failed',
-            reason: 'Because testing',
-            customer_accepts_responsibility: true,
-            contents: nil
-          }
-        },
-        body: '{}'
-      ) # We don't care about the response
-    end
 
     it 'transitions the plate' do
+      expect_state_change_create(contents: nil, customer_accepts_responsibility: true, reason: 'Because testing')
+
       put :update,
           params: {
             id: plate_uuid,
@@ -77,30 +70,19 @@ RSpec.describe PlatesController, type: :controller do
           session: {
             user_uuid: user_uuid
           }
-      expect(state_change_request).to have_been_made
+
       expect(response).to redirect_to(search_path)
     end
   end
 
   describe '#fail_wells' do
-    let!(:state_change_request) do
-      stub_api_post(
-        'state_changes',
-        payload: {
-          'state_change' => {
-            user: user_uuid,
-            target: plate_uuid,
-            contents: ['A1'],
-            target_state: 'failed',
-            reason: 'Individual Well Failure',
-            customer_accepts_responsibility: nil
-          }
-        },
-        body: '{}'
-      ) # We don't care about the response
-    end
-
     it 'fails the selected wells' do
+      expect_state_change_create(
+        contents: ['A1'],
+        customer_accepts_responsibility: nil,
+        reason: 'Individual Well Failure'
+      )
+
       post :fail_wells,
            params: {
              id: plate_uuid,
@@ -114,7 +96,7 @@ RSpec.describe PlatesController, type: :controller do
            session: {
              user_uuid: user_uuid
            }
-      expect(state_change_request).to have_been_made
+
       expect(response).to redirect_to(limber_plate_path(plate_uuid))
     end
   end

--- a/spec/controllers/tubes_controller_spec.rb
+++ b/spec/controllers/tubes_controller_spec.rb
@@ -34,24 +34,21 @@ RSpec.describe TubesController, type: :controller do
       tube_request
     end
 
-    let!(:state_change_request) do
-      stub_api_post(
-        'state_changes',
-        payload: {
-          'state_change' => {
-            user: user_uuid,
-            target: tube_uuid,
-            target_state: 'cancelled',
-            reason: 'Because testing',
-            customer_accepts_responsibility: true,
-            contents: nil
-          }
-        },
-        body: '{}'
-      ) # We don't care about the response
-    end
-
     it 'transitions the tube' do
+      expect_api_v2_posts(
+        'StateChange',
+        [
+          {
+            contents: nil,
+            customer_accepts_responsibility: true,
+            reason: 'Because testing',
+            target_state: 'cancelled',
+            target_uuid: tube_uuid,
+            user_uuid: user_uuid
+          }
+        ]
+      )
+
       put :update,
           params: {
             id: tube_uuid,
@@ -65,7 +62,7 @@ RSpec.describe TubesController, type: :controller do
           session: {
             user_uuid: user_uuid
           }
-      expect(state_change_request).to have_been_made
+
       expect(response).to redirect_to(search_path)
     end
   end

--- a/spec/features/creating_a_tag_plate_spec.rb
+++ b/spec/features/creating_a_tag_plate_spec.rb
@@ -5,6 +5,7 @@ require_relative '../support/shared_tagging_examples'
 
 RSpec.feature 'Creating a tag plate', js: true, tag_plate: true do
   has_a_working_api
+
   let(:user_uuid) { 'user-uuid' }
   let(:user) { create :user, uuid: user_uuid }
   let(:user_swipecard) { 'abcdef' }
@@ -92,6 +93,8 @@ RSpec.feature 'Creating a tag plate', js: true, tag_plate: true do
           }
         ]
       )
+
+      stub_api_v2_post('StateChange')
     end
 
     scenario 'creation with the plate' do

--- a/spec/features/failing_quadrants_spec.rb
+++ b/spec/features/failing_quadrants_spec.rb
@@ -28,21 +28,15 @@ RSpec.feature 'Failing quadrants', js: true do
            size: 384
   end
 
-  let!(:state_change_request) do
-    stub_api_post(
-      'state_changes',
-      payload: {
-        'state_change' => {
-          user: user_uuid,
-          target: plate_uuid,
-          contents: %w[A1 A3],
-          target_state: 'failed',
-          reason: 'Individual Well Failure',
-          customer_accepts_responsibility: nil
-        }
-      },
-      body: '{}' # We don't care about the response
-    )
+  let(:state_change_attributes) do
+    {
+      contents: %w[A1 A3],
+      customer_accepts_responsibility: nil,
+      reason: 'Individual Well Failure',
+      target_state: 'failed',
+      target_uuid: plate_uuid,
+      user_uuid: user_uuid
+    }
   end
 
   # Setup stubs
@@ -69,6 +63,8 @@ RSpec.feature 'Failing quadrants', js: true do
   end
 
   scenario 'failing wells' do
+    expect_api_v2_posts('StateChange', [state_change_attributes])
+
     fill_in_swipecard_and_barcode user_swipecard, plate_barcode
     click_on('Fail Wells')
 
@@ -77,6 +73,5 @@ RSpec.feature 'Failing quadrants', js: true do
 
     click_on('Fail selected wells')
     expect(find('#flashes')).to have_content('Selected wells have been failed')
-    expect(state_change_request).to have_been_made
   end
 end

--- a/spec/features/failing_thresholds_spec.rb
+++ b/spec/features/failing_thresholds_spec.rb
@@ -25,23 +25,6 @@ RSpec.feature 'Failing thresholds', js: true do
     create :v2_plate, uuid: plate_uuid, purpose_uuid: 'stock-plate-purpose-uuid', state: 'passed', wells: wells
   end
 
-  let!(:state_change_request) do
-    stub_api_post(
-      'state_changes',
-      payload: {
-        'state_change' => {
-          user: user_uuid,
-          target: plate_uuid,
-          contents: %w[A1 A3],
-          target_state: 'failed',
-          reason: 'Individual Well Failure',
-          customer_accepts_responsibility: nil
-        }
-      },
-      body: '{}' # We don't care about the response
-    )
-  end
-
   # Setup stubs
   background do
     # Set-up the plate config
@@ -66,14 +49,25 @@ RSpec.feature 'Failing thresholds', js: true do
   end
 
   scenario 'failing wells' do
+    expect_api_v2_posts(
+      'StateChange',
+      [
+        {
+          contents: %w[A1 A3],
+          customer_accepts_responsibility: nil,
+          reason: 'Individual Well Failure',
+          target_state: 'failed',
+          target_uuid: plate_uuid,
+          user_uuid: user_uuid
+        }
+      ]
+    )
+
     fill_in_swipecard_and_barcode user_swipecard, plate_barcode
-
     click_on('Fail Wells')
-
     fill_in 'Molarity', with: 15
-
     click_on('Fail selected wells')
+
     expect(find('#flashes')).to have_content('Selected wells have been failed')
-    expect(state_change_request).to have_been_made
   end
 end

--- a/spec/features/failing_wells_spec.rb
+++ b/spec/features/failing_wells_spec.rb
@@ -23,23 +23,6 @@ RSpec.feature 'Failing wells', js: true do
     create :v2_plate, uuid: plate_uuid, purpose_uuid: 'stock-plate-purpose-uuid', state: 'passed', wells: wells
   end
 
-  let!(:state_change_request) do
-    stub_api_post(
-      'state_changes',
-      payload: {
-        'state_change' => {
-          user: user_uuid,
-          target: plate_uuid,
-          contents: %w[A2 A3],
-          target_state: 'failed',
-          reason: 'Individual Well Failure',
-          customer_accepts_responsibility: nil
-        }
-      },
-      body: '{}' # We don't care about the response
-    )
-  end
-
   # Setup stubs
   background do
     # Set-up the plate config
@@ -65,6 +48,20 @@ RSpec.feature 'Failing wells', js: true do
   end
 
   scenario 'failing wells' do
+    expect_api_v2_posts(
+      'StateChange',
+      [
+        {
+          contents: %w[A2 A3],
+          customer_accepts_responsibility: nil,
+          reason: 'Individual Well Failure',
+          target_state: 'failed',
+          target_uuid: plate_uuid,
+          user_uuid: user_uuid
+        }
+      ]
+    )
+
     fill_in_swipecard_and_barcode user_swipecard, plate_barcode
     click_on('Fail Wells')
     within_fieldset('Select wells to fail') do
@@ -76,6 +73,5 @@ RSpec.feature 'Failing wells', js: true do
 
     click_on('Fail selected wells')
     expect(find('#flashes')).to have_content('Selected wells have been failed')
-    expect(state_change_request).to have_been_made
   end
 end

--- a/spec/models/labware_creators/tagged_plate_spec.rb
+++ b/spec/models/labware_creators/tagged_plate_spec.rb
@@ -221,14 +221,26 @@ RSpec.describe LabwareCreators::TaggedPlate, tag_plate: true do
             ]
           )
 
+          expect_api_v2_posts(
+            'StateChange',
+            [
+              {
+                reason: 'Used in Library creation',
+                target_state: 'exhausted',
+                target_uuid: tag_plate_uuid,
+                user_uuid: user_uuid
+              }
+            ]
+          )
+
           expect(subject.save).to be true
-          expect(state_change_tag_plate_request).to have_been_made.once
           expect(plate_conversion_request).to have_been_made.once
           expect(tag_layout_creation_request).to have_been_made.once
         end
 
         it 'has the correct child (and uuid)' do
           stub_api_v2_post('Transfer')
+          stub_api_v2_post('StateChange')
 
           expect(subject.save).to be true
           expect(subject.child.uuid).to eq(tag_plate_uuid)

--- a/spec/models/robots/pooling_and_splitting_robot_spec.rb
+++ b/spec/models/robots/pooling_and_splitting_robot_spec.rb
@@ -354,40 +354,6 @@ RSpec.describe Robots::PoolingAndSplittingRobot, robots: true do
   end
 
   describe '#perform_transfer' do
-    let(:state_change_target_1_request) do
-      stub_api_post(
-        'state_changes',
-        payload: {
-          state_change: {
-            target_state: 'passed',
-            reason: 'Robot Pooling And Splitting Robot started',
-            customer_accepts_responsibility: false,
-            target: target_plate_1_uuid,
-            user: user_uuid,
-            contents: nil
-          }
-        },
-        body: json(:state_change, target_state: 'passed')
-      )
-    end
-
-    let(:state_change_target_2_request) do
-      stub_api_post(
-        'state_changes',
-        payload: {
-          state_change: {
-            target_state: 'passed',
-            reason: 'Robot Pooling And Splitting Robot started',
-            customer_accepts_responsibility: false,
-            target: target_plate_2_uuid,
-            user: user_uuid,
-            contents: nil
-          }
-        },
-        body: json(:state_change, target_state: 'passed')
-      )
-    end
-
     let(:scanned_layout) do
       {
         'bed1_barcode' => [source_1_barcode],
@@ -396,15 +362,30 @@ RSpec.describe Robots::PoolingAndSplittingRobot, robots: true do
       }
     end
 
-    before do
-      state_change_target_1_request
-      state_change_target_2_request
-    end
-
     it 'performs transfers from started to passed for all destination plates' do
+      expect_api_v2_posts(
+        'StateChange',
+        [
+          {
+            contents: nil,
+            customer_accepts_responsibility: false,
+            reason: 'Robot Pooling And Splitting Robot started',
+            target_state: 'passed',
+            target_uuid: target_plate_1_uuid,
+            user_uuid: user_uuid
+          },
+          {
+            contents: nil,
+            customer_accepts_responsibility: false,
+            reason: 'Robot Pooling And Splitting Robot started',
+            target_state: 'passed',
+            target_uuid: target_plate_2_uuid,
+            user_uuid: user_uuid
+          }
+        ]
+      )
+
       robot.perform_transfer(scanned_layout)
-      expect(state_change_target_1_request).to have_been_requested
-      expect(state_change_target_2_request).to have_been_requested
     end
   end
 end

--- a/spec/models/robots/pooling_robot_spec.rb
+++ b/spec/models/robots/pooling_robot_spec.rb
@@ -212,28 +212,22 @@ RSpec.describe Robots::PoolingRobot, robots: true do
   end
 
   describe '#perform_transfer' do
-    let(:state_change_request) do
-      stub_api_post(
-        'state_changes',
-        payload: {
-          state_change: {
-            target_state: 'passed',
-            reason: 'Robot Pooling Robot started',
-            customer_accepts_responsibility: false,
-            target: target_plate_uuid,
-            user: user_uuid,
-            contents: nil
-          }
-        },
-        body: json(:state_change, target_state: 'passed')
-      )
-    end
-
-    before { state_change_request }
-
     it 'performs transfer from started to passed' do
+      expect_api_v2_posts(
+        'StateChange',
+        [
+          {
+            contents: nil,
+            customer_accepts_responsibility: false,
+            reason: 'Robot Pooling Robot started',
+            target_state: 'passed',
+            target_uuid: target_plate_uuid,
+            user_uuid: user_uuid
+          }
+        ]
+      )
+
       robot.perform_transfer('bed1_barcode' => [source_barcode], 'bed5_barcode' => [target_barcode])
-      expect(state_change_request).to have_been_requested
     end
 
     context 'if the bed is unexpectedly invalid' do

--- a/spec/models/robots/quadrant_robot_spec.rb
+++ b/spec/models/robots/quadrant_robot_spec.rb
@@ -262,28 +262,22 @@ RSpec.describe Robots::QuadrantRobot, robots: true do
   end
 
   describe '#perform_transfer' do
-    let(:state_change_request) do
-      stub_api_post(
-        'state_changes',
-        payload: {
-          state_change: {
-            target_state: 'passed',
-            reason: 'Robot Pooling Robot started',
-            customer_accepts_responsibility: false,
-            target: target_plate_uuid,
-            user: user_uuid,
-            contents: nil
-          }
-        },
-        body: json(:state_change, target_state: 'passed')
-      )
-    end
-
-    before { state_change_request }
-
     it 'performs transfer from started to passed' do
+      expect_api_v2_posts(
+        'StateChange',
+        [
+          {
+            contents: nil,
+            customer_accepts_responsibility: false,
+            reason: 'Robot Pooling Robot started',
+            target_state: 'passed',
+            target_uuid: target_plate_uuid,
+            user_uuid: user_uuid
+          }
+        ]
+      )
+
       robot.perform_transfer('bed1_barcode' => [source_barcode], 'bed5_barcode' => [target_barcode])
-      expect(state_change_request).to have_been_requested
     end
   end
 end

--- a/spec/models/robots/robot_spec.rb
+++ b/spec/models/robots/robot_spec.rb
@@ -714,23 +714,6 @@ RSpec.describe Robots::Robot, robots: true do
     end
     let(:target_plate_state) { 'started' }
 
-    let(:state_change_request) do
-      stub_api_post(
-        'state_changes',
-        payload: {
-          state_change: {
-            target_state: 'passed',
-            reason: 'Robot bravo LB End Prep started',
-            customer_accepts_responsibility: false,
-            target: plate.uuid,
-            user: user_uuid,
-            contents: nil
-          }
-        },
-        body: json(:state_change, target_state: 'passed')
-      )
-    end
-
     let(:plate) do
       create :v2_plate,
              barcode_number: '123',
@@ -741,13 +724,25 @@ RSpec.describe Robots::Robot, robots: true do
 
     before do
       create :purpose_config, uuid: 'lb_end_prep_uuid', state_changer_class: 'StateChangers::DefaultStateChanger'
-      state_change_request
       bed_labware_lookup(plate)
     end
 
     it 'performs transfer from started to passed' do
+      expect_api_v2_posts(
+        'StateChange',
+        [
+          {
+            contents: nil,
+            customer_accepts_responsibility: false,
+            reason: 'Robot bravo LB End Prep started',
+            target_state: 'passed',
+            target_uuid: plate.uuid,
+            user_uuid: user_uuid
+          }
+        ]
+      )
+
       robot.perform_transfer('580000014851' => [plate.human_barcode])
-      expect(state_change_request).to have_been_requested
     end
 
     context 'if the bed is unexpectedly invalid' do

--- a/spec/models/robots/splitting_robot_spec.rb
+++ b/spec/models/robots/splitting_robot_spec.rb
@@ -143,23 +143,6 @@ RSpec.describe Robots::SplittingRobot, robots: true do
       }
     end
 
-    let(:state_change_request) do
-      stub_api_post(
-        'state_changes',
-        payload: {
-          state_change: {
-            target_state: 'passed',
-            reason: 'Robot bravo LB End Prep started',
-            customer_accepts_responsibility: false,
-            target: plate.uuid,
-            user: user_uuid,
-            contents: nil
-          }
-        },
-        body: json(:state_change, target_state: 'passed')
-      )
-    end
-
     let(:plate) do
       create :v2_plate,
              barcode_number: '123',
@@ -170,13 +153,25 @@ RSpec.describe Robots::SplittingRobot, robots: true do
 
     before do
       create :purpose_config, uuid: 'lb_end_prep_uuid', state_changer_class: 'StateChangers::DefaultStateChanger'
-      state_change_request
       bed_plate_lookup(plate, [:purpose, { wells: :downstream_plates }])
     end
 
     it 'performs transfer from started to passed' do
+      expect_api_v2_posts(
+        'StateChange',
+        [
+          {
+            contents: nil,
+            customer_accepts_responsibility: false,
+            reason: 'Robot bravo LB End Prep started',
+            target_state: 'passed',
+            target_uuid: plate.uuid,
+            user_uuid: user_uuid
+          }
+        ]
+      )
+
       robot.perform_transfer('580000014851' => [plate.human_barcode])
-      expect(state_change_request).to have_been_requested
     end
   end
 end

--- a/spec/models/state_changers_spec.rb
+++ b/spec/models/state_changers_spec.rb
@@ -15,13 +15,19 @@ RSpec.describe StateChangers::DefaultStateChanger do
   subject { StateChangers::DefaultStateChanger.new(api, plate_uuid, user_uuid) }
 
   describe '#move_to!' do
-    let!(:state_change_request) do
-      stub_api_post(
-        'state_changes',
-        payload: {
-          state_change: expected_parameters
-        },
-        body: '{}' # We don't care
+    before do
+      expect_api_v2_posts(
+        'StateChange',
+        [
+          {
+            contents: wells_to_pass,
+            customer_accepts_responsibility: customer_accepts_responsibility,
+            reason: reason,
+            target_state: target_state,
+            target_uuid: plate_uuid,
+            user_uuid: user_uuid
+          }
+        ]
       )
     end
 
@@ -29,17 +35,6 @@ RSpec.describe StateChangers::DefaultStateChanger do
       it 'generates a state change' do
         subject.move_to!(target_state, reason, customer_accepts_responsibility)
       end
-    end
-
-    let(:expected_parameters) do
-      {
-        target: plate_uuid,
-        user: user_uuid,
-        target_state: target_state,
-        reason: reason,
-        customer_accepts_responsibility: customer_accepts_responsibility,
-        contents: wells_to_pass
-      }
     end
 
     context 'on a fully pending plate' do
@@ -144,7 +139,5 @@ RSpec.describe StateChangers::DefaultStateChanger do
         end
       end
     end
-
-    after { expect(state_change_request).to have_been_made.once }
   end
 end

--- a/spec/support/shared_tagging_examples.rb
+++ b/spec/support/shared_tagging_examples.rb
@@ -1,22 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.shared_context 'a tag plate creator' do
-  # Requests that might get made
-  let!(:state_change_tag_plate_request) do
-    stub_api_post(
-      'state_changes',
-      payload: {
-        state_change: {
-          user: user_uuid,
-          target: tag_plate_uuid,
-          reason: 'Used in Library creation',
-          target_state: 'exhausted'
-        }
-      },
-      body: json(:state_change)
-    )
-  end
-
   let!(:plate_conversion_request) do
     stub_api_post(
       'plate_conversions',


### PR DESCRIPTION
Closes #1818 

#### Changes proposed in this pull request

- Create new StateChanges with the API v2 endpoint on Sequencescape.
- Update tests to match expected calls.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  