### PR TITLE
Fix yarn test output

### DIFF
--- a/app/frontend/javascript/labware-custom-metadata/components/LabwareCustomMetadataAddForm.spec.js
+++ b/app/frontend/javascript/labware-custom-metadata/components/LabwareCustomMetadataAddForm.spec.js
@@ -31,7 +31,17 @@ describe('LabwareCustomMetadataAddForm', () => {
       })
     )
 
+    // This is a workaround for the following warning:
+    // [BootstrapVue warn]: tooltip - The provided target is no valid HTML element.
+    const createContainer = (tag = 'div') => {
+      const container = document.createElement(tag)
+      document.body.appendChild(container)
+
+      return container
+    }
+
     return mount(LabwareCustomMetadataAddForm, {
+      attachTo: createContainer(),
       localVue,
       parentComponent: parent,
       propsData: {
@@ -41,9 +51,7 @@ describe('LabwareCustomMetadataAddForm', () => {
         sequencescapeApiUrl,
         sequencescapeUrl,
       },
-      // Getting:
-      // [BootstrapVue warn]: tooltip - The provided target is no valid HTML element.
-      // Here https://github.com/molgenis/molgenis-frontend/issues/466 suggests it's a bug
+      // b-icon is unknown to the component so we stub it
       stubs: {
         'b-icon': true,
       },

--- a/app/frontend/javascript/multi-stamp-tubes/components/MultiStampTubes.vue
+++ b/app/frontend/javascript/multi-stamp-tubes/components/MultiStampTubes.vue
@@ -272,7 +272,7 @@ export default {
       let colour_index = -1
 
       const tube = this.tubes[tubeIndex]
-      if (tube.state !== 'valid') return colour_index
+      if (!tube || tube.state !== 'valid') return colour_index
 
       const tube_machine_barcode = tube.labware.labware_barcode.machine_barcode
       const tube_machine_barcodes = this.tubes

--- a/app/frontend/javascript/shared/components/LabwareScan.spec.js
+++ b/app/frontend/javascript/shared/components/LabwareScan.spec.js
@@ -238,7 +238,11 @@ describe('LabwareScan', () => {
       //         ]
       //       }
       //     }
-      // Please do not panic, but it would be nice to suppress _only this output_ this in the console
+      // We suppress this error with the below spy.
+      vi.spyOn(console, 'log').mockImplementation((log) => {
+        if (log.includes('devour error')) return false
+      })
+
       const api = mockApi()
       api.mockFail(
         'tubes',

--- a/app/frontend/javascript/shared/components/Plate.spec.js
+++ b/app/frontend/javascript/shared/components/Plate.spec.js
@@ -1,13 +1,17 @@
 // Import the component being tested
 import { shallowMount } from '@vue/test-utils'
+import { plateFactory } from '@/javascript/test_support/factories.js'
 
 import LbPlate from '@/javascript/shared/components/Plate.vue'
 // Here are some Jasmine 2.0 tests, though you can
 // use any test runner / assertion library combo you prefer
 describe('LbPlate', () => {
   const myCaption = 'Caption'
+  const wells = {}
+  // Populate the wells props with a full plate worth of wells
+  plateFactory({ _wellOptions: { colour_index: 1 } }).wells.forEach((well) => (wells[well.position.name] = well))
   const wrapper = shallowMount(LbPlate, {
-    propsData: { columns: 12, rows: 8, caption: myCaption, wells: { B3: {} } },
+    propsData: { columns: 12, rows: 8, caption: myCaption, wells: wells },
   })
 
   // Inspect the raw component options

--- a/app/frontend/javascript/shared/components/Well.spec.js
+++ b/app/frontend/javascript/shared/components/Well.spec.js
@@ -4,7 +4,17 @@ import { shallowMount } from '@vue/test-utils'
 import Well from '@/javascript/shared/components/Well.vue'
 
 describe('Well', () => {
+  // This is a workaround for the following warning:
+  // [BootstrapVue warn]: tooltip - The provided target is no valid HTML element.
+  const createContainer = (tag = 'div') => {
+    const container = document.createElement(tag)
+    document.body.appendChild(container)
+
+    return container
+  }
+
   const wrapperWithoutAliquot = shallowMount(Well, {
+    attachTo: createContainer(),
     propsData: { position: 'A1', colour_index: null },
   })
 
@@ -17,6 +27,7 @@ describe('Well', () => {
   })
 
   const wrapperWithAliquot = shallowMount(Well, {
+    attachTo: createContainer(),
     propsData: {
       position: 'A1',
       colour_index: 2,
@@ -51,12 +62,14 @@ describe('Well', () => {
 
   it('renders a tooltip with the specified label', () => {
     const wrapperWithTooltipLabel = shallowMount(Well, {
+      attachTo: createContainer(),
       propsData: { position: 'A1', tooltip_label: 'Test' },
     })
     expect(wrapperWithTooltipLabel.vm.tooltipText).toEqual('A1 - Test')
   })
 
   const wrapperWithTagMapIds = shallowMount(Well, {
+    attachTo: createContainer(),
     propsData: { position: 'A1', colour_index: 1, tagMapIds: [5] },
   })
 
@@ -65,6 +78,7 @@ describe('Well', () => {
   })
 
   const wrapperWithPosition = shallowMount(Well, {
+    attachTo: createContainer(),
     propsData: { position: 'B3' },
   })
 
@@ -73,6 +87,7 @@ describe('Well', () => {
   })
 
   const wrapperWithTagClash = shallowMount(Well, {
+    attachTo: createContainer(),
     propsData: {
       position: 'A1',
       colour_index: 1,
@@ -90,6 +105,7 @@ describe('Well', () => {
   })
 
   const wrapperWithInvalidTag = shallowMount(Well, {
+    attachTo: createContainer(),
     propsData: {
       position: 'A1',
       colour_index: 1,
@@ -104,6 +120,7 @@ describe('Well', () => {
 
   it('renders a well with multiple Tag Map Ids displayed according to the value of tagIndex', async () => {
     const wrapperWithMultipleAliquots = shallowMount(Well, {
+      attachTo: createContainer(),
       propsData: {
         position: 'A1',
         colour_index: 1,

--- a/app/frontend/javascript/shared/components/Well.spec.js
+++ b/app/frontend/javascript/shared/components/Well.spec.js
@@ -15,7 +15,7 @@ describe('Well', () => {
 
   const wrapperWithoutAliquot = shallowMount(Well, {
     attachTo: createContainer(),
-    propsData: { position: 'A1', colour_index: null },
+    propsData: { position: 'A1', colour_index: 1 },
   })
 
   it('renders a well', () => {
@@ -63,7 +63,7 @@ describe('Well', () => {
   it('renders a tooltip with the specified label', () => {
     const wrapperWithTooltipLabel = shallowMount(Well, {
       attachTo: createContainer(),
-      propsData: { position: 'A1', tooltip_label: 'Test' },
+      propsData: { position: 'A1', tooltip_label: 'Test', colour_index: 1 },
     })
     expect(wrapperWithTooltipLabel.vm.tooltipText).toEqual('A1 - Test')
   })
@@ -79,7 +79,7 @@ describe('Well', () => {
 
   const wrapperWithPosition = shallowMount(Well, {
     attachTo: createContainer(),
-    propsData: { position: 'B3' },
+    propsData: { position: 'B3', colour_index: 1 },
   })
 
   it('renders a well with tag name', () => {

--- a/app/frontend/javascript/shared/components/Well.vue
+++ b/app/frontend/javascript/shared/components/Well.vue
@@ -21,7 +21,7 @@ export default {
   name: 'LbWell',
   props: {
     position: { type: String, required: true },
-    colour_index: { type: Number, default: null },
+    colour_index: { type: Number, required: true },
     tooltip_label: { type: String, default: null },
     tagMapIds: {
       type: Array,

--- a/app/frontend/javascript/shared/components/Well.vue
+++ b/app/frontend/javascript/shared/components/Well.vue
@@ -21,8 +21,7 @@ export default {
   name: 'LbWell',
   props: {
     position: { type: String, required: true },
-    // Previously this was pool index, and was not required. Caused a silent failure (invisible wells)
-    colour_index: { type: Number, required: true },
+    colour_index: { type: Number, default: null },
     tooltip_label: { type: String, default: null },
     tagMapIds: {
       type: Array,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@prettier/plugin-ruby": "^2.1.0",
     "@vitejs/plugin-vue2": "^2.3.1",
     "@vitest/coverage-v8": "^2.0.5",
-    "@vue/test-utils": "^1.0.0-beta.25",
+    "@vue/test-utils": "^1.3.6",
     "autoprefixer": "^10.4.19",
     "axios-mock-adapter": "^1.22.0",
     "eslint": "^8.0.0",

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -15,8 +15,8 @@ export default defineConfig({
       reporter: ['lcov', 'text'],
     },
     // This hides the "Download the Vue Devtools extension" message from the console
-    onConsoleLog (log) {
+    onConsoleLog(log) {
       if (log.includes('Download the Vue Devtools extension')) return false
-    }
+    },
   },
 })

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -14,5 +14,9 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['lcov', 'text'],
     },
+    // This hides the "Download the Vue Devtools extension" message from the console
+    onConsoleLog (log) {
+      if (log.includes('Download the Vue Devtools extension')) return false
+    }
   },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -842,7 +842,7 @@
   optionalDependencies:
     prettier "^1.18.2 || ^2.0.0"
 
-"@vue/test-utils@^1.0.0-beta.25":
+"@vue/test-utils@^1.3.6":
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.3.6.tgz#6656bd8fa44dd088b4ad80ff1ee28abe7e5ddf87"
   integrity sha512-udMmmF1ts3zwxUJEIAj5ziioR900reDrt6C9H3XpWPsLBx2lpHKoA4BTdd9HNIYbkGltWw+JjWJ+5O6QBwiyEw==


### PR DESCRIPTION
`yarn test` was outputting a large amount of logs and errors. This PR attempts to _nicely_ clean them up.

#### Changes proposed in this pull request

- Bumps vue test utils version.
- Adds console suppression for `Download the Vue Devtools extension` warning.
  - This is probably something to do with not setting the correct Vue environment for testing but Limber has Vue instances all over the place so I am not sure of a way to configure this.
- Suppresses devour console logs where appropriate.
- Implements `[BootstrapVue warn]: tooltip - The provided target is no valid HTML element.` workaround fix.
- Fixes test data using Well.vue without colour_index prop causing console warnings.

