### PR TITLE
Y24-207: fix incorrect test coverage for Vue SFC components

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,3 @@
-ignore:
-  - '**/*.vue' # ignore all .vue files - TODO: remove this after Vue SFC is supported (see https://github.com/sanger/limber/pull/1585)
 codecov:
   notify:
     # do not notify until at least n builds have been uploaded from the CI pipeline


### PR DESCRIPTION
Closes https://github.com/sanger/limber/issues/1801

#### Changes proposed in this pull request
- Removed 'ignore' vue files section in codecov.yml 

With the addition of `"coverageProvider": "v8"` to vite.config.mjs, the Vue SFC code coverage is now working as expected.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
