### PR TITLE
FIX - added SGE library type to bespoke pcr pipeline

### DIFF
--- a/config/pipelines/bespoke_pcr.yml
+++ b/config/pipelines/bespoke_pcr.yml
@@ -32,6 +32,7 @@ Bespoke PCR:
       - Standard
       - TraDIS
       - TruSeq mRNA (RNA Seq)
+      - SGE Library v0.2
   library_pass: LBB Lib PCR-XP
   relationships:
     LBB Cherrypick: LBB Ligation


### PR DESCRIPTION
Fix for RT issue pointing out SGE library type wasn't working to show next steps in Limber.