### PR TITLE
Bed number change requested by Abby in Slack

### DIFF
--- a/config/robots.rb
+++ b/config/robots.rb
@@ -3649,10 +3649,10 @@ ROBOT_CONFIG =
           states: ['passed'],
           label: 'Bed 15'
         },
-        bed(14).barcode => {
+        bed(13).barcode => {
           purpose: 'LRC PBMC Pools',
           states: ['pending'],
-          label: 'Bed 14',
+          label: 'Bed 13',
           parent: bed(15).barcode,
           target_state: 'passed'
         }


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Bed number change requested by Abby in Slack:

> We have recently made a change to the pooling protocol that requires the bed verification of the LRC PBMC Pools plate to move from bed 14 to bed 13.
Please would you be able to amend this when you have time?

Goes with Integration Suite PR - https://gitlab.internal.sanger.ac.uk/psd/integration-suite/-/merge_requests/164/diffs

Have run Int Suite scRNA Core test locally, but no other Int Suite tests.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
