### PR TITLE
Y24-314: Handle relatives that are V2::Assets

### DIFF
--- a/app/views/labware/_asset.html.erb
+++ b/app/views/labware/_asset.html.erb
@@ -1,0 +1,15 @@
+<%# A Sequencescape::Api::V2::Asset type, essentially a fallback -%>
+<%# locals: (labware:) -%>
+<%
+  labware_path = "#{ Limber::Application.config.sequencescape_url }/labware/#{labware.id}"
+  open_in_new_window = true # always open an external link in a new window
+%>
+<div class="relative-item">
+    External <%= labware&.type.to_s.titleize %> -
+    <%= link_to labware_path, class: 'card-link stretched-link', target: (open_in_new_window ? '_blank' : '_self') do %>
+        <%= labware.id %> (<%= labware.name %>)
+    <% end %>
+    <% if labware.state.present? %>
+      <%= content_tag(:span, state_badge(labware.state), class: 'float-right') %>
+    <% end %>
+</div>

--- a/app/views/labware/_child_labware_item.html.erb
+++ b/app/views/labware/_child_labware_item.html.erb
@@ -10,6 +10,8 @@
   <% else %>
     <%= render partial: 'labware/simple_tube', locals: { tube: labware, open_in_new_window: open_in_new_window } %>
   <% end %>
-<% else %>
+<% elsif labware.purpose.present? %>
   <%= render partial: 'labware/basic_relative', locals: { labware: labware, open_in_new_window: open_in_new_window } %>
+<% else %>
+  <%= render partial: 'labware/asset', locals: { labware: labware } %>
 <% end %>

--- a/app/views/labware/_parent_labware_item.html.erb
+++ b/app/views/labware/_parent_labware_item.html.erb
@@ -4,6 +4,8 @@
 <% open_in_new_window = false %>
 <% if labware.tube? %>
   <%= render partial: 'labware/simple_tube', locals: { tube: labware, open_in_new_window: open_in_new_window } %>
-<% else %>
+<% elsif labware.purpose.present? %>
   <%= render partial: 'labware/basic_relative', locals: { labware: labware, open_in_new_window: open_in_new_window } %>
+<% else %>
+  <%= render partial: 'labware/asset', locals: { labware: labware } %>
 <% end %>


### PR DESCRIPTION
Closes #1910 

#### Changes proposed in this pull request

- Add a new Asset relative
- Add link from Asset relative to Sequencescape
- Add check for parent and children to use Asset relative

<img width="707" alt="Screenshot 2024-09-13 at 16 43 35" src="https://github.com/user-attachments/assets/b22c4164-1b1f-4a06-a3e6-fb033db97970">

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
