### PR TITLE
fix: show pools when relatives tab selected

### DIFF
--- a/app/views/plates/_common_tabbed_pages.html.erb
+++ b/app/views/plates/_common_tabbed_pages.html.erb
@@ -4,7 +4,7 @@
       <a class="nav-link active" href="#summary_tab" data-toggle="tab" role="tab">Summary</a>
     </li>
     <li class="nav-item">
-      <a class="nav-link" href="#relatives_tab" data-toggle="tab" role="tab">Relatives</a>
+      <a class="nav-link" href="#relatives_tab" data-toggle="tab" role="tab" data-plate-view="pools-view">Relatives</a>
     </li>
     <% if @presenter.pooling_tab.present? %>
     <li class="nav-item">


### PR DESCRIPTION
Shows tubes that match with pools

#### Changes proposed in this pull request

- Automatically show the pools highlighting when switching to the Relatives tab

<img width="705" alt="Screenshot 2024-09-13 at 16 59 06" src="https://github.com/user-attachments/assets/fa39a5b3-e7b1-4e2f-a242-025573e9284b">

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
