### PR TITLE
Y24-314: Only show relatives if they have a purpose

### DIFF
--- a/app/views/labware/_relatives_list.html.erb
+++ b/app/views/labware/_relatives_list.html.erb
@@ -7,7 +7,7 @@
   </div>
 
   <div id="parents-list" class="border-bottom">
-    <% if presenter.labware.parents&.any? %>
+    <% if presenter.labware.parents&.any? { |parent| parent.purpose.present? } %>
       <%= render partial: 'labware/parent_labware_item', collection: presenter.labware.parents, as: :labware %>
     <% else %>
       <div class="list-group-item text-muted">No parents found</div>
@@ -20,7 +20,7 @@
   </div>
 
   <div id="children-list" class="rounded-bottom">
-    <% if presenter.labware.children&.any? %>
+    <% if presenter.labware.children&.any? { |child| child.purpose.present? } %>
       <%= render partial: 'labware/child_labware_item', collection: presenter.labware.children, as: :labware, locals: { presenter: presenter, open_in_new_window: true } %>
     <% else %>
       <div class="list-group-item text-muted">No children found</div>


### PR DESCRIPTION
Closes #1910 

#### Changes proposed in this pull request

- Filter lists of parents and children to only show relatives that have a purpose defined.
 
<img width="710" alt="Screenshot 2024-09-17 at 12 06 59" src="https://github.com/user-attachments/assets/21027684-33cb-4bbd-97cd-6665b08af719">

#### Instructions for Reviewers

Compare to #1920

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
