### PR TITLE
fix: restore removed data-plate-views

### DIFF
--- a/app/frontend/javascript/legacy_scripts_a.js
+++ b/app/frontend/javascript/legacy_scripts_a.js
@@ -1,6 +1,10 @@
 import $ from 'jquery'
 import { ENTER_KEYCODE, TAB_KEYCODE } from '@/javascript/lib/keycodes.js'
 
+// The majority of the code below is for the data-plate-view data attribute used to
+// show differing colours based on the view selected, eg: pools, binning, etc.
+// The pattern is to have a data-plate-view attribute on all tab links, but only have the
+// required views defined below. This allows for easy extension of the views in the future.
 let PlateViewModel = function (plateElement) {
   this['pools-view'] = {
     activate: function () {

--- a/app/views/labware/_tube.html.erb
+++ b/app/views/labware/_tube.html.erb
@@ -5,13 +5,13 @@
   <div id="plate-view-control" class="card-header">
     <ul class="nav nav-tabs card-header-tabs float-xs-left" role="tablist">
       <li class="nav-item">
-        <a class="nav-link active" href="#summary_tab" data-toggle="tab" role="tab">Summary</a>
+        <a class="nav-link active" href="#summary_tab" data-toggle="tab" role="tab" data-plate-view="summary-view">Summary</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="#relatives_tab" data-toggle="tab" role="tab">Relatives</a>
+        <a class="nav-link" href="#relatives_tab" data-toggle="tab" role="tab" data-plate-view="pools-view">Relatives</a>
       </li>
       <li class="nav-item">
-        <a id='comments-tab-link' class="nav-link" href="#comments_tab" data-toggle="tab" role="tab">Comments <%= count_badge(nil, 'asset-comments-counter') %></a>
+        <a id='comments-tab-link' class="nav-link" href="#comments_tab" data-toggle="tab" role="tab" data-plate-view="comments-view">Comments <%= count_badge(nil, 'asset-comments-counter') %></a>
       </li>
     </ul>
   </div>

--- a/app/views/labware/plates/_binned_summary.html.erb
+++ b/app/views/labware/plates/_binned_summary.html.erb
@@ -4,10 +4,10 @@
 
 <%= content_for :additional_tabs do %>
   <li class="nav-item">
-    <a class="nav-link" href="#samples_tab" data-toggle="tab" role="tab">Samples</a>
+    <a class="nav-link" href="#samples_tab" data-toggle="tab" role="tab" data-plate-view="samples-view">Samples</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="#binned_tab" data-toggle="tab" role="tab">Binning</a>
+    <a class="nav-link" href="#binned_tab" data-toggle="tab" role="tab" data-plate-view="binned-view">Binning</a>
   </li>
 <% end %>
 

--- a/app/views/labware/plates/_standard_summary.html.erb
+++ b/app/views/labware/plates/_standard_summary.html.erb
@@ -4,7 +4,7 @@
 
 <%= content_for :additional_tabs do %>
   <li class="nav-item">
-    <a class="nav-link" href="#samples_tab" data-toggle="tab" role="tab">Samples</a>
+    <a class="nav-link" href="#samples_tab" data-toggle="tab" role="tab" data-plate-view="samples-view">Samples</a>
   </li>
 <% end %>
 

--- a/app/views/plates/_common_tabbed_pages.html.erb
+++ b/app/views/plates/_common_tabbed_pages.html.erb
@@ -1,10 +1,10 @@
 <nav id="plate-view-control" class="card-header">
   <ul class="nav nav-tabs card-header-tabs float-xs-left" role="tablist">
     <li class="nav-item">
-      <a class="nav-link active" href="#summary_tab" data-toggle="tab" role="tab">Summary</a>
+      <a class="nav-link active" href="#summary_tab" data-toggle="tab" role="tab" data-plate-view="summary-view">Summary</a>
     </li>
     <li class="nav-item">
-      <a class="nav-link" href="#relatives_tab" data-toggle="tab" role="tab">Relatives</a>
+      <a class="nav-link" href="#relatives_tab" data-toggle="tab" role="tab" data-plate-view="pools-view">Relatives</a>
     </li>
     <% if @presenter.pooling_tab.present? %>
     <li class="nav-item">
@@ -13,10 +13,10 @@
     <% end %>
     <%= yield(:additional_tabs) if content_for?(:additional_tabs) %>
     <li class="nav-item">
-      <a id='files-tab-link' class="nav-link" href="#files_tab" data-toggle="tab" role="tab">Files</a>
+      <a id='files-tab-link' class="nav-link" href="#files_tab" data-toggle="tab" role="tab" data-plate-view="files-view">Files</a>
     </li>
     <li class="nav-item">
-      <a id='comments-tab-link' class="nav-link" href="#comments_tab" data-toggle="tab" role="tab">Comments <%= count_badge(nil, 'asset-comments-counter') %></a>
+      <a id='comments-tab-link' class="nav-link" href="#comments_tab" data-toggle="tab" role="tab" role="tab" data-plate-view="comments-view">Comments <%= count_badge(nil, 'asset-comments-counter') %></a>
     </li>
   </ul>
 </nav>

--- a/app/views/tube_racks/summaries/_default.html.erb
+++ b/app/views/tube_racks/summaries/_default.html.erb
@@ -5,10 +5,10 @@
 <div id="plate-view-control" class="card-header">
   <ul class="nav nav-tabs card-header-tabs float-xs-left" role="tablist">
     <li class="nav-item">
-      <a class="nav-link active" href="#summary_tab" data-toggle="tab" role="tab">Summary</a>
+      <a class="nav-link active" href="#summary_tab" data-toggle="tab" role="tab" data-plate-view="summary-view">Summary</a>
     </li>
     <li class="nav-item">
-      <a id='comments-tab-link' class="nav-link" href="#comments_tab" data-toggle="tab" role="tab">Comments <%= count_badge(nil, 'asset-comments-counter') %></a>
+      <a id='comments-tab-link' class="nav-link" href="#comments_tab" data-toggle="tab" role="tab" data-plate-view="comments-view">Comments <%= count_badge(nil, 'asset-comments-counter') %></a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
Closes #1934 

#### Changes proposed in this pull request

- Restores plate-views inadvertedly removed in #1641 
- All labware tabs with `role="tab"` now have a `data-plate-view` defined

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
