### PR TITLE
Add TSISC_UDI96 and TSRNAhWGS_UDI96 to LCMT EM Lib PCR config

### DIFF
--- a/config/purposes/lcm_triomics.wip.yml
+++ b/config/purposes/lcm_triomics.wip.yml
@@ -67,6 +67,8 @@ LCMT EM Lib PCR:
     - TS_pWGSC_UDI96
     - TS_pWGSC_UDI_tag60_61_swap
     - TS_pWGSD_UDI96
+    - TSISC_UDI96
+    - TSRNAhWGS_UDI96
   :size: 96
 LCMT EM PCR XP:
   :asset_type: plate


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Add additional tag layout templates to the LCMT EM Lib PCR config. The names come from email conversations.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
