### PR TITLE
Y24-190-3: Use API v2 endpoint for PooledPlateCreations

### DIFF
--- a/app/models/labware_creators/custom_tagged_plate.rb
+++ b/app/models/labware_creators/custom_tagged_plate.rb
@@ -47,12 +47,11 @@ module LabwareCreators
 
     def create_plate! # rubocop:todo Metrics/AbcSize
       @child =
-        api
-          .pooled_plate_creation
+        Sequencescape::Api::V2::PooledPlateCreation
           .create!(
-            child_purpose: purpose_uuid,
-            user: user_uuid,
-            parents: [parent_uuid, tag_plate.asset_uuid].compact_blank
+            child_purpose_uuid: purpose_uuid,
+            parent_uuids: [parent_uuid, tag_plate.asset_uuid].compact_blank,
+            user_uuid: user_uuid
           )
           .child
 

--- a/app/models/labware_creators/custom_tagged_plate.rb
+++ b/app/models/labware_creators/custom_tagged_plate.rb
@@ -47,13 +47,11 @@ module LabwareCreators
 
     def create_plate! # rubocop:todo Metrics/AbcSize
       @child =
-        Sequencescape::Api::V2::PooledPlateCreation
-          .create!(
-            child_purpose_uuid: purpose_uuid,
-            parent_uuids: [parent_uuid, tag_plate.asset_uuid].compact_blank,
-            user_uuid: user_uuid
-          )
-          .child
+        Sequencescape::Api::V2::PooledPlateCreation.create!(
+          child_purpose_uuid: purpose_uuid,
+          parent_uuids: [parent_uuid, tag_plate.asset_uuid].compact_blank,
+          user_uuid: user_uuid
+        ).child
 
       transfer_material_from_parent!(@child.uuid)
 

--- a/app/models/labware_creators/merged_plate.rb
+++ b/app/models/labware_creators/merged_plate.rb
@@ -51,10 +51,10 @@ module LabwareCreators
     private
 
     def create_plate_from_parent!
-      api.pooled_plate_creation.create!(
-        child_purpose: purpose_uuid,
-        user: user_uuid,
-        parents: source_plates.map(&:uuid)
+      Sequencescape::Api::V2::PooledPlateCreation.create!(
+        child_purpose_uuid: purpose_uuid,
+        parent_uuids: source_plates.map(&:uuid),
+        user_uuid: user_uuid
       )
     end
 

--- a/app/models/labware_creators/multi_plate_pool.rb
+++ b/app/models/labware_creators/multi_plate_pool.rb
@@ -22,8 +22,7 @@ module LabwareCreators
           child_purpose_uuid: purpose_uuid,
           parent_uuids: transfers.keys,
           user_uuid: user_uuid
-        )
-        .child
+        ).child
 
       api.bulk_transfer.create!(user: user_uuid, well_transfers: well_transfers)
 

--- a/app/models/labware_creators/multi_plate_pool.rb
+++ b/app/models/labware_creators/multi_plate_pool.rb
@@ -17,10 +17,13 @@ module LabwareCreators
     private
 
     def create_labware!
-      plate_creation =
-        api.pooled_plate_creation.create!(parents: transfers.keys, child_purpose: purpose_uuid, user: user_uuid)
-
-      @child = plate_creation.child
+      @child =
+        Sequencescape::Api::V2::PooledPlateCreation.create!(
+          child_purpose_uuid: purpose_uuid,
+          parent_uuids: transfers.keys,
+          user_uuid: user_uuid
+        )
+        .child
 
       api.bulk_transfer.create!(user: user_uuid, well_transfers: well_transfers)
 

--- a/app/models/labware_creators/multi_stamp.rb
+++ b/app/models/labware_creators/multi_stamp.rb
@@ -35,8 +35,7 @@ module LabwareCreators
           child_purpose_uuid: purpose_uuid,
           parent_uuids: parent_uuids,
           user_uuid: user_uuid
-        )
-        .child
+        ).child
 
       transfer_material_from_parent!(@child.uuid)
 

--- a/app/models/labware_creators/multi_stamp.rb
+++ b/app/models/labware_creators/multi_stamp.rb
@@ -30,10 +30,13 @@ module LabwareCreators
     private
 
     def create_labware!
-      plate_creation =
-        api.pooled_plate_creation.create!(parents: parent_uuids, child_purpose: purpose_uuid, user: user_uuid)
-
-      @child = plate_creation.child
+      @child =
+        Sequencescape::Api::V2::PooledPlateCreation.create!(
+          child_purpose_uuid: purpose_uuid,
+          parent_uuids: parent_uuids,
+          user_uuid: user_uuid
+        )
+        .child
 
       transfer_material_from_parent!(@child.uuid)
 

--- a/app/models/labware_creators/multi_stamp_tubes.rb
+++ b/app/models/labware_creators/multi_stamp_tubes.rb
@@ -49,7 +49,7 @@ module LabwareCreators
         )
         .child
 
-      transfer_material_from_parent!(@child.uuid)
+      transfer_material_from_parent!
 
       yield(@child) if block_given?
       true
@@ -89,15 +89,15 @@ module LabwareCreators
       Sequencescape::Api::V2::Tube.find_all(uuid: parent_uuids, includes: 'receptacle,aliquots,aliquots.study')
     end
 
-    def transfer_material_from_parent!(child_plate)
+    def transfer_material_from_parent!
       api.transfer_request_collection.create!(
         user: user_uuid,
-        transfer_requests: transfer_request_attributes(child_plate)
+        transfer_requests: transfer_request_attributes
       )
     end
 
-    def transfer_request_attributes(child_plate)
-      transfers.map { |transfer| request_hash(transfer, child_plate) }
+    def transfer_request_attributes
+      transfers.map { |transfer| request_hash(transfer) }
     end
 
     def source_tube_outer_request_uuid(tube)
@@ -110,13 +110,13 @@ module LabwareCreators
       pending_reqs.first.uuid || nil
     end
 
-    def request_hash(transfer, child_plate)
+    def request_hash(transfer)
       tube = Sequencescape::Api::V2::Tube.find_by(uuid: transfer[:source_tube])
 
       {
         'source_asset' => transfer[:source_asset],
         'target_asset' =>
-          child_plate.wells.detect { |child_well| child_well.location == transfer.dig(:new_target, :location) }&.uuid,
+          @child.wells.detect { |child_well| child_well.location == transfer.dig(:new_target, :location) }&.uuid,
         'outer_request' => source_tube_outer_request_uuid(tube)
       }
     end

--- a/app/models/labware_creators/multi_stamp_tubes.rb
+++ b/app/models/labware_creators/multi_stamp_tubes.rb
@@ -46,8 +46,7 @@ module LabwareCreators
           child_purpose_uuid: purpose_uuid,
           parent_uuids: parent_uuids,
           user_uuid: user_uuid
-        )
-        .child
+        ).child
 
       transfer_material_from_parent!
 
@@ -90,10 +89,7 @@ module LabwareCreators
     end
 
     def transfer_material_from_parent!
-      api.transfer_request_collection.create!(
-        user: user_uuid,
-        transfer_requests: transfer_request_attributes
-      )
+      api.transfer_request_collection.create!(user: user_uuid, transfer_requests: transfer_request_attributes)
     end
 
     def transfer_request_attributes

--- a/app/models/labware_creators/multi_stamp_tubes.rb
+++ b/app/models/labware_creators/multi_stamp_tubes.rb
@@ -41,13 +41,15 @@ module LabwareCreators
       create_and_build_submission
       return if errors.size.positive?
 
-      plate_creation =
-        api.pooled_plate_creation.create!(parents: parent_uuids, child_purpose: purpose_uuid, user: user_uuid)
+      @child =
+        Sequencescape::Api::V2::PooledPlateCreation.create!(
+          child_purpose_uuid: purpose_uuid,
+          parent_uuids: parent_uuids,
+          user_uuid: user_uuid
+        )
+        .child
 
-      @child = plate_creation.child
-      child_v2 = Sequencescape::Api::V2.plate_with_wells(@child.uuid)
-
-      transfer_material_from_parent!(child_v2)
+      transfer_material_from_parent!(@child.uuid)
 
       yield(@child) if block_given?
       true

--- a/app/models/labware_creators/multi_stamp_tubes_using_tube_rack_scan.rb
+++ b/app/models/labware_creators/multi_stamp_tubes_using_tube_rack_scan.rb
@@ -73,7 +73,7 @@ module LabwareCreators
         )
         .child
 
-      transfer_material_from_parent!(@child.uuid)
+      transfer_material_from_parent!
 
       yield(@child) if block_given?
       true
@@ -234,24 +234,22 @@ module LabwareCreators
     end
 
     # Transfers material from the parent tubes to the given child plate.
-    # @param child_plate [Sequencescape::Api::V2::Plate] The plate to transfer material to.
-    def transfer_material_from_parent!(child_plate)
+    def transfer_material_from_parent!
       api.transfer_request_collection.create!(
         user: user_uuid,
-        transfer_requests: transfer_request_attributes(child_plate)
+        transfer_requests: transfer_request_attributes
       )
     end
 
     # Returns an array of hashes representing the transfer requests for the given child plate.
     # Each hash includes the UUIDs of the parent tube and child well, and the UUID of the outer request.
-    # @param child_plate [Sequencescape::Api::V2::Plate] The plate to get the transfer requests for.
     # @return [Array<Hash>] An array of hashes representing the transfer requests.
-    def transfer_request_attributes(child_plate)
+    def transfer_request_attributes
       parent_tubes.each_with_object([]) do |(foreign_barcode, parent_tube), tube_transfers|
         tube_transfers <<
           request_hash(
             parent_tube.uuid,
-            child_plate
+            @child
               .wells
               .detect { |child_well| child_well.location == csv_file.location_by_barcode_details[foreign_barcode] }
               &.uuid,

--- a/app/models/labware_creators/multi_stamp_tubes_using_tube_rack_scan.rb
+++ b/app/models/labware_creators/multi_stamp_tubes_using_tube_rack_scan.rb
@@ -65,13 +65,15 @@ module LabwareCreators
     #
     # @return [Boolean] true if the child plate was created successfully.
     def create_labware!
-      plate_creation =
-        api.pooled_plate_creation.create!(parents: parent_tube_uuids, child_purpose: purpose_uuid, user: user_uuid)
+      @child =
+        Sequencescape::Api::V2::PooledPlateCreation.create!(
+          child_purpose_uuid: purpose_uuid,
+          parent_uuids: parent_tube_uuids,
+          user_uuid: user_uuid
+        )
+        .child
 
-      @child = plate_creation.child
-      child_v2 = Sequencescape::Api::V2.plate_with_wells(@child.uuid)
-
-      transfer_material_from_parent!(child_v2)
+      transfer_material_from_parent!(@child.uuid)
 
       yield(@child) if block_given?
       true

--- a/app/models/labware_creators/multi_stamp_tubes_using_tube_rack_scan.rb
+++ b/app/models/labware_creators/multi_stamp_tubes_using_tube_rack_scan.rb
@@ -70,8 +70,7 @@ module LabwareCreators
           child_purpose_uuid: purpose_uuid,
           parent_uuids: parent_tube_uuids,
           user_uuid: user_uuid
-        )
-        .child
+        ).child
 
       transfer_material_from_parent!
 
@@ -235,10 +234,7 @@ module LabwareCreators
 
     # Transfers material from the parent tubes to the given child plate.
     def transfer_material_from_parent!
-      api.transfer_request_collection.create!(
-        user: user_uuid,
-        transfer_requests: transfer_request_attributes
-      )
+      api.transfer_request_collection.create!(user: user_uuid, transfer_requests: transfer_request_attributes)
     end
 
     # Returns an array of hashes representing the transfer requests for the given child plate.

--- a/app/sequencescape/sequencescape/api/v2/pooled_plate_creation.rb
+++ b/app/sequencescape/sequencescape/api/v2/pooled_plate_creation.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Represents a pooled plate creation in Limber via the Sequencescape API
+class Sequencescape::Api::V2::PooledPlateCreation < Sequencescape::Api::V2::Base
+  has_one :child, class_name: 'Sequencescape::Api::V2::Plate'
+  has_many :parents, class_name: 'Sequencescape::Api::V2::Labware'
+  has_one :user, class_name: 'Sequencescape::Api::V2::User'
+end

--- a/spec/features/pooling_multiple_plates_spec.rb
+++ b/spec/features/pooling_multiple_plates_spec.rb
@@ -66,12 +66,7 @@ RSpec.feature 'Multi plate pooling', js: true do
     )
   end
 
-  let(:child_plate) do
-    create :v2_plate,
-           purpose_uuid: 'child-purpose-0',
-           purpose_name: 'Pool Plate',
-           barcode_number: 3
-  end
+  let(:child_plate) { create :v2_plate, purpose_uuid: 'child-purpose-0', purpose_name: 'Pool Plate', barcode_number: 3 }
 
   let(:pooled_plate_creation) do
     response = double
@@ -83,13 +78,7 @@ RSpec.feature 'Multi plate pooling', js: true do
   def expect_pooled_plate_creation
     expect_api_v2_posts(
       'PooledPlateCreation',
-      [
-        {
-          child_purpose_uuid: 'child-purpose-0',
-          parent_uuids: [plate_uuid, plate_uuid_2],
-          user_uuid: user_uuid
-        }
-      ],
+      [{ child_purpose_uuid: 'child-purpose-0', parent_uuids: [plate_uuid, plate_uuid_2], user_uuid: user_uuid }],
       [pooled_plate_creation]
     )
   end

--- a/spec/features/pooling_multiple_plates_spec.rb
+++ b/spec/features/pooling_multiple_plates_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'Multi plate pooling', js: true do
     )
   end
 
-  let(:child_plate) { create :v2_plate, purpose_uuid: 'child-purpose-0', purpose_name: 'Pool Plate', barcode_number: 3 }
+  let(:child_plate) { create :v2_plate, purpose_name: 'Pool Plate', barcode_number: 3 }
 
   let(:pooled_plate_creation) do
     response = double
@@ -78,7 +78,9 @@ RSpec.feature 'Multi plate pooling', js: true do
   def expect_pooled_plate_creation
     expect_api_v2_posts(
       'PooledPlateCreation',
-      [{ child_purpose_uuid: 'child-purpose-0', parent_uuids: [plate_uuid, plate_uuid_2], user_uuid: user_uuid }],
+      [
+        { child_purpose_uuid: child_plate.purpose.uuid, parent_uuids: [plate_uuid, plate_uuid_2], user_uuid: user_uuid }
+      ],
       [pooled_plate_creation]
     )
   end
@@ -88,7 +90,7 @@ RSpec.feature 'Multi plate pooling', js: true do
     create :purpose_config,
            creator_class: 'LabwareCreators::MultiPlatePool',
            name: 'Pool Plate',
-           uuid: 'child-purpose-0'
+           uuid: child_plate.purpose.uuid
     create :pipeline, relationships: { 'Pooled example' => 'Pool Plate' }
 
     # We look up the user

--- a/spec/features/pooling_multiple_plates_spec.rb
+++ b/spec/features/pooling_multiple_plates_spec.rb
@@ -34,29 +34,6 @@ RSpec.feature 'Multi plate pooling', js: true do
            purpose_uuid: 'stock-plate-purpose-uuid'
   end
 
-  let(:child_plate_uuid) { SecureRandom.uuid }
-  let(:child_plate) do
-    create :v2_plate,
-           purpose_uuid: 'child-purpose-0',
-           purpose_name: 'Pool Plate',
-           uuid: child_plate_uuid,
-           barcode_number: 3
-  end
-
-  let!(:pooled_plate_creation_request) do
-    stub_api_post(
-      'pooled_plate_creations',
-      payload: {
-        pooled_plate_creation: {
-          user: user_uuid,
-          child_purpose: 'child-purpose-0',
-          parents: [plate_uuid, plate_uuid_2]
-        }
-      },
-      body: json(:plate_creation, child_uuid: child_plate_uuid)
-    )
-  end
-
   let!(:bulk_transfer_request) do
     stub_api_post(
       'bulk_transfers',
@@ -67,25 +44,53 @@ RSpec.feature 'Multi plate pooling', js: true do
             {
               'source_uuid' => plate_uuid,
               'source_location' => 'A1',
-              'destination_uuid' => child_plate_uuid,
+              'destination_uuid' => child_plate.uuid,
               'destination_location' => 'A1'
             },
             {
               'source_uuid' => plate_uuid_2,
               'source_location' => 'A1',
-              'destination_uuid' => child_plate_uuid,
+              'destination_uuid' => child_plate.uuid,
               'destination_location' => 'B1'
             },
             {
               'source_uuid' => plate_uuid_2,
               'source_location' => 'B1',
-              'destination_uuid' => child_plate_uuid,
+              'destination_uuid' => child_plate.uuid,
               'destination_location' => 'B1'
             }
           ]
         }
       },
-      body: json(:plate_creation, child_uuid: child_plate_uuid)
+      body: json(:plate_creation, child_uuid: child_plate.uuid)
+    )
+  end
+
+  let(:child_plate) do
+    create :v2_plate,
+           purpose_uuid: 'child-purpose-0',
+           purpose_name: 'Pool Plate',
+           barcode_number: 3
+  end
+
+  let(:pooled_plate_creation) do
+    response = double
+    allow(response).to receive(:child).and_return(child_plate)
+
+    response
+  end
+
+  def expect_pooled_plate_creation
+    expect_api_v2_posts(
+      'PooledPlateCreation',
+      [
+        {
+          child_purpose_uuid: 'child-purpose-0',
+          parent_uuids: [plate_uuid, plate_uuid_2],
+          user_uuid: user_uuid
+        }
+      ],
+      [pooled_plate_creation]
     )
   end
 
@@ -108,6 +113,8 @@ RSpec.feature 'Multi plate pooling', js: true do
   end
 
   scenario 'creates multiple plates' do
+    expect_pooled_plate_creation
+
     fill_in_swipecard_and_barcode(user_swipecard, plate_barcode_1)
     plate_title = find('#plate-title')
     expect(plate_title).to have_text('Pooled example')
@@ -119,7 +126,6 @@ RSpec.feature 'Multi plate pooling', js: true do
     expect(page).to have_content('DN2: A1, B1')
     click_on('Make Pre-Cap pool Plate')
     expect(page).to have_text('New empty labware added to the system')
-    expect(pooled_plate_creation_request).to have_been_made
     expect(bulk_transfer_request).to have_been_made
     expect(page).to have_text('Pool Plate')
   end

--- a/spec/models/labware_creators/custom_tagged_plate_spec.rb
+++ b/spec/models/labware_creators/custom_tagged_plate_spec.rb
@@ -95,24 +95,32 @@ RSpec.describe LabwareCreators::CustomTaggedPlate, tag_plate: true do
   context 'On create' do
     let(:tag_plate_uuid) { 'tag-plate' }
     let(:tag_template_uuid) { 'tag-layout-template' }
-    let(:child_plate_uuid) { SecureRandom.uuid }
     let(:parents) { [plate_uuid, tag_plate_uuid] }
 
-    let!(:plate_creation_request) do
-      stub_api_post(
-        'pooled_plate_creations',
-        payload: {
-          pooled_plate_creation: {
-            parents: parents,
-            child_purpose: child_purpose_uuid,
-            user: user_uuid
-          }
-        },
-        body: json(:plate_creation, child_uuid: child_plate_uuid)
-      )
+    let(:expected_transfers) { WellHelpers.stamp_hash(96) }
+
+    let(:child_plate) { create :v2_plate }
+
+    let(:pooled_plate_creation) do
+      response = double
+      allow(response).to receive(:child).and_return(child_plate)
+
+      response
     end
 
-    let(:expected_transfers) { WellHelpers.stamp_hash(96) }
+    def expect_pooled_plate_creation
+      expect_api_v2_posts(
+        'PooledPlateCreation',
+        [
+          {
+            child_purpose_uuid: child_purpose_uuid,
+            parent_uuids: parents,
+            user_uuid: user_uuid
+          }
+        ],
+        [pooled_plate_creation]
+      )
+    end
 
     def expect_state_change_creation
       expect_api_v2_posts(
@@ -134,7 +142,7 @@ RSpec.describe LabwareCreators::CustomTaggedPlate, tag_plate: true do
         [
           {
             user_uuid: user_uuid,
-            plate_uuid: child_plate_uuid,
+            plate_uuid: child_plate.uuid,
             tag_group_uuid: 'tag-group-uuid',
             tag2_group_uuid: 'tag2-group-uuid',
             direction: 'column',
@@ -153,7 +161,7 @@ RSpec.describe LabwareCreators::CustomTaggedPlate, tag_plate: true do
           {
             user_uuid: user_uuid,
             source_uuid: plate_uuid,
-            destination_uuid: child_plate_uuid,
+            destination_uuid: child_plate.uuid,
             transfer_template_uuid: transfer_template_uuid,
             transfers: expected_transfers
           }
@@ -198,15 +206,16 @@ RSpec.describe LabwareCreators::CustomTaggedPlate, tag_plate: true do
           let(:tag_plate_state) { 'available' }
 
           it 'creates a tag plate' do
+            expect_pooled_plate_creation
             expect_state_change_creation
             expect_tag_layout_creation
             expect_transfer_creation
 
             expect(subject.save).to be true
-            expect(plate_creation_request).to have_been_made.once
           end
 
           it 'has the correct child (and uuid)' do
+            stub_api_v2_post('PooledPlateCreation', pooled_plate_creation)
             stub_api_v2_post('TagLayout')
             stub_api_v2_post('Transfer')
             stub_api_v2_post('StateChange')
@@ -214,17 +223,17 @@ RSpec.describe LabwareCreators::CustomTaggedPlate, tag_plate: true do
             expect(subject.save).to be true
 
             # This will be our new plate
-            expect(subject.child.uuid).to eq(child_plate_uuid)
+            expect(subject.child.uuid).to eq(child_plate.uuid)
           end
 
           context 'when a user has exhausted the plate in another tab' do
             it 'creates a tag plate' do
+              expect_pooled_plate_creation
               expect_state_change_creation
               expect_tag_layout_creation
               expect_transfer_creation
 
               expect(subject.save).to be true
-              expect(plate_creation_request).to have_been_made.once
             end
           end
         end
@@ -236,21 +245,22 @@ RSpec.describe LabwareCreators::CustomTaggedPlate, tag_plate: true do
             # This one will be VERY different
             expect_tag_layout_creation
 
+            expect_pooled_plate_creation
             expect_transfer_creation
             expect(Sequencescape::Api::V2::StateChange).not_to receive(:create!)
 
             expect(subject.save).to be true
-            expect(plate_creation_request).to have_been_made.once
           end
 
           it 'has the correct child (and uuid)' do
+            stub_api_v2_post('PooledPlateCreation', pooled_plate_creation)
             stub_api_v2_post('TagLayout')
             stub_api_v2_post('Transfer')
 
             expect(subject.save).to be true
 
             # This will be our new plate
-            expect(subject.child.uuid).to eq(child_plate_uuid)
+            expect(subject.child.uuid).to eq(child_plate.uuid)
           end
         end
 
@@ -260,20 +270,21 @@ RSpec.describe LabwareCreators::CustomTaggedPlate, tag_plate: true do
           let(:parents) { [plate_uuid] }
 
           it 'creates a tag plate' do
+            expect_pooled_plate_creation
             expect_tag_layout_creation
             expect_transfer_creation
             expect(Sequencescape::Api::V2::StateChange).not_to receive(:create!)
 
             expect(subject.save).to be true
-            expect(plate_creation_request).to have_been_made.once
           end
 
           it 'has the correct child (and uuid)' do
+            stub_api_v2_post('PooledPlateCreation', pooled_plate_creation)
             stub_api_v2_post('TagLayout')
             stub_api_v2_post('Transfer')
 
             expect(subject.save).to be true
-            expect(subject.child.uuid).to eq(child_plate_uuid)
+            expect(subject.child.uuid).to eq(child_plate.uuid)
           end
         end
       end

--- a/spec/models/labware_creators/custom_tagged_plate_spec.rb
+++ b/spec/models/labware_creators/custom_tagged_plate_spec.rb
@@ -111,13 +111,7 @@ RSpec.describe LabwareCreators::CustomTaggedPlate, tag_plate: true do
     def expect_pooled_plate_creation
       expect_api_v2_posts(
         'PooledPlateCreation',
-        [
-          {
-            child_purpose_uuid: child_purpose_uuid,
-            parent_uuids: parents,
-            user_uuid: user_uuid
-          }
-        ],
+        [{ child_purpose_uuid: child_purpose_uuid, parent_uuids: parents, user_uuid: user_uuid }],
         [pooled_plate_creation]
       )
     end

--- a/spec/models/labware_creators/merged_plate_spec.rb
+++ b/spec/models/labware_creators/merged_plate_spec.rb
@@ -54,15 +54,6 @@ RSpec.describe LabwareCreators::MergedPlate do
            creator_class: 'LabwareCreators::MergedPlate'
   end
 
-  let(:child_plate) do
-    create :v2_plate,
-           uuid: 'child-uuid',
-           barcode_number: '4',
-           size: plate_size,
-           outer_requests: requests,
-           purpose: child_purpose
-  end
-
   let(:requests) do
     Array.new(plate_size) { |i| create :library_request, state: 'started', uuid: "request-#{i}", submission_id: 1 }
   end
@@ -70,7 +61,6 @@ RSpec.describe LabwareCreators::MergedPlate do
   let(:user_uuid) { 'user-uuid' }
 
   before do
-    stub_v2_plate(child_plate, stub_search: false)
     stub_v2_plate(source_plate_1, stub_search: false)
     stub_v2_plate(source_plate_2, stub_search: false)
   end
@@ -88,20 +78,8 @@ RSpec.describe LabwareCreators::MergedPlate do
             )
             .and_return([source_plate_1, source_plate_2])
         )
-      end
 
-      let!(:plate_creation_request) do
-        stub_api_post(
-          'pooled_plate_creations',
-          payload: {
-            pooled_plate_creation: {
-              user: user_uuid,
-              child_purpose: child_purpose_uuid,
-              parents: [source_plate_1.uuid, source_plate_2.uuid]
-            }
-          },
-          body: json(:plate_creation, child_uuid: child_plate.uuid)
-        )
+        stub_v2_plate(child_plate, stub_search: false)
       end
 
       let!(:transfer_creation_request) do
@@ -117,10 +95,42 @@ RSpec.describe LabwareCreators::MergedPlate do
         )
       end
 
+      let(:child_plate) do
+        create :v2_plate,
+               uuid: 'child-uuid',
+               barcode_number: '4',
+               size: plate_size,
+               outer_requests: requests,
+               purpose: child_purpose
+      end
+
+      let(:pooled_plate_creation) do
+        response = double
+        allow(response).to receive(:child).and_return(child_plate)
+
+        response
+      end
+
+      def expect_pooled_plate_creation
+        expect_api_v2_posts(
+          'PooledPlateCreation',
+          [
+            {
+              child_purpose_uuid: child_purpose_uuid,
+              parent_uuids: [source_plate_1.uuid, source_plate_2.uuid],
+              user_uuid: user_uuid
+            }
+          ],
+          [pooled_plate_creation]
+        )
+      end
+
       it 'makes the expected requests' do
+        expect_pooled_plate_creation
+
         expect(subject).to be_valid
         expect(subject.save!).to eq true
-        expect(plate_creation_request).to have_been_made
+
         expect(transfer_creation_request).to have_been_made
       end
     end

--- a/spec/models/labware_creators/multi_plate_pool_spec.rb
+++ b/spec/models/labware_creators/multi_plate_pool_spec.rb
@@ -77,9 +77,7 @@ RSpec.describe LabwareCreators::MultiPlatePool do
       }
     end
 
-    let(:child_plate) do
-      create :v2_plate
-    end
+    let(:child_plate) { create :v2_plate }
 
     let(:pooled_plate_creation) do
       response = double
@@ -129,13 +127,7 @@ RSpec.describe LabwareCreators::MultiPlatePool do
     def expect_pooled_plate_creation
       expect_api_v2_posts(
         'PooledPlateCreation',
-        [
-          {
-            child_purpose_uuid: child_purpose_uuid,
-            parent_uuids: [plate_uuid, plate_b_uuid],
-            user_uuid: user_uuid
-          }
-        ],
+        [{ child_purpose_uuid: child_purpose_uuid, parent_uuids: [plate_uuid, plate_b_uuid], user_uuid: user_uuid }],
         [pooled_plate_creation]
       )
     end

--- a/spec/models/labware_creators/multi_stamp_spec.rb
+++ b/spec/models/labware_creators/multi_stamp_spec.rb
@@ -562,13 +562,7 @@ RSpec.describe LabwareCreators::MultiStamp do
     def expect_pooled_plate_creation
       expect_api_v2_posts(
         'PooledPlateCreation',
-        [
-          {
-            child_purpose_uuid: child_purpose_uuid,
-            parent_uuids: [parent1_uuid, parent2_uuid],
-            user_uuid: user_uuid
-          }
-        ],
+        [{ child_purpose_uuid: child_purpose_uuid, parent_uuids: [parent1_uuid, parent2_uuid], user_uuid: user_uuid }],
         [pooled_plate_creation]
       )
     end

--- a/spec/models/labware_creators/multi_stamp_tubes_using_tube_rack_scan_spec.rb
+++ b/spec/models/labware_creators/multi_stamp_tubes_using_tube_rack_scan_spec.rb
@@ -84,30 +84,10 @@ RSpec.describe LabwareCreators::MultiStampTubesUsingTubeRackScan, with: :uploade
     [:purpose, 'receptacle.aliquots.request.request_type', 'receptacle.requests_as_source.request_type']
   end
 
-  # child aliquots
-  let(:child_aliquot1) { create :v2_aliquot }
-  let(:child_aliquot2) { create :v2_aliquot }
-
-  # child wells
-  let(:child_well1) { create :v2_well, location: 'A1', uuid: '5-well-A1', aliquots: [child_aliquot1] }
-  let(:child_well2) { create :v2_well, location: 'B1', uuid: '5-well-B1', aliquots: [child_aliquot2] }
-
   # child plate
-  let(:child_plate_uuid) { 'child-uuid' }
   let(:child_plate_purpose_uuid) { 'child-purpose' }
   let(:child_plate_purpose_name) { 'Child Purpose' }
-  let(:child_plate_v2) do
-    create :v2_plate,
-           uuid: child_plate_uuid,
-           purpose_name: child_plate_purpose_name,
-           barcode_number: '5',
-           size: 96,
-           wells: [child_well1, child_well2]
-  end
-
-  let(:child_plate_v2) do
-    create :v2_plate, uuid: child_plate_uuid, purpose_name: child_plate_purpose_name, barcode_number: '5', size: 96
-  end
+  let(:child_plate) { create :v2_plate, purpose_name: child_plate_purpose_name, barcode_number: '5', size: 96 }
 
   let(:user_uuid) { 'user-uuid' }
   let(:user) { json :v1_user, uuid: user_uuid }
@@ -132,7 +112,7 @@ RSpec.describe LabwareCreators::MultiStampTubesUsingTubeRackScan, with: :uploade
   end
 
   let(:stub_upload_file_creation) do
-    stub_request(:post, api_url_for(child_plate_uuid, 'qc_files'))
+    stub_request(:post, api_url_for(child_plate.uuid, 'qc_files'))
       .with(
         body: file_content,
         headers: {
@@ -151,7 +131,7 @@ RSpec.describe LabwareCreators::MultiStampTubesUsingTubeRackScan, with: :uploade
 
   let(:child_plate_v1) do
     # qc_files are created through the API V1. The actions attribute for qcfiles is required by the API V1.
-    json :plate, uuid: child_plate_uuid, purpose_uuid: child_plate_purpose_uuid, qc_files_actions: %w[read create]
+    json :plate, uuid: child_plate.uuid, purpose_uuid: child_plate_purpose_uuid, qc_files_actions: %w[read create]
   end
 
   before do
@@ -162,9 +142,7 @@ RSpec.describe LabwareCreators::MultiStampTubesUsingTubeRackScan, with: :uploade
       .with(barcode: 'AB10000002', includes: tube_includes)
       .and_return(parent_tube_2)
 
-    stub_v2_plate(child_plate_v2, stub_search: false, custom_query: [:plate_with_wells, child_plate_v2.uuid])
-
-    stub_api_get(child_plate_uuid, body: child_plate_v1)
+    stub_api_get(child_plate.uuid, body: child_plate_v1)
 
     stub_upload_file_creation
 
@@ -194,20 +172,6 @@ RSpec.describe LabwareCreators::MultiStampTubesUsingTubeRackScan, with: :uploade
       { user_uuid: user_uuid, purpose_uuid: child_plate_purpose_uuid, parent_uuid: parent_tube_1_uuid, file: file }
     end
 
-    let!(:ms_plate_creation_request) do
-      stub_api_post(
-        'pooled_plate_creations',
-        payload: {
-          pooled_plate_creation: {
-            user: user_uuid,
-            child_purpose: child_plate_purpose_uuid,
-            parents: [parent_tube_1_uuid, parent_tube_2_uuid]
-          }
-        },
-        body: json(:plate_creation, child_plate_uuid: child_plate_uuid)
-      )
-    end
-
     let(:transfer_requests) do
       [
         { source_asset: 'tube-1-uuid', target_asset: '5-well-A1', outer_request: 'request-1' },
@@ -228,6 +192,27 @@ RSpec.describe LabwareCreators::MultiStampTubesUsingTubeRackScan, with: :uploade
       )
     end
 
+    let(:pooled_plate_creation) do
+      response = double
+      allow(response).to receive(:child).and_return(child_plate)
+
+      response
+    end
+
+    def expect_pooled_plate_creation
+      expect_api_v2_posts(
+        'PooledPlateCreation',
+        [
+          {
+            child_purpose_uuid: child_plate_purpose_uuid,
+            parent_uuids: [parent_tube_1_uuid, parent_tube_2_uuid],
+            user_uuid: user_uuid
+          }
+        ],
+        [pooled_plate_creation]
+      )
+    end
+
     subject { LabwareCreators::MultiStampTubesUsingTubeRackScan.new(api, form_attributes) }
 
     it 'creates a plate!' do
@@ -235,10 +220,11 @@ RSpec.describe LabwareCreators::MultiStampTubesUsingTubeRackScan, with: :uploade
       subject.labware.barcode.machine = 'AB10000001'
       subject.labware.barcode.ean13 = nil
 
-      subject.save
-      expect(subject.errors.full_messages).to be_empty
+      expect_pooled_plate_creation
 
-      expect(ms_plate_creation_request).to have_been_made.once
+      subject.save
+
+      expect(subject.errors.full_messages).to be_empty
       expect(transfer_creation_request).to have_been_made.once
     end
   end

--- a/spec/models/labware_creators/quadrant_stamp_primer_panel_spec.rb
+++ b/spec/models/labware_creators/quadrant_stamp_primer_panel_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe LabwareCreators::QuadrantStampPrimerPanel do
 
   let(:parent1_uuid) { 'example-plate-uuid' }
   let(:parent2_uuid) { 'example-plate2-uuid' }
-  let(:child_uuid) { 'child-uuid' }
   let(:requests) { Array.new(96) { |i| create :gbs_library_request, state: 'started', uuid: "request-#{i}" } }
   let(:requests2) { Array.new(96) { |i| create :gbs_library_request, state: 'started', uuid: "request-#{i}" } }
   let(:stock_plate1) { create :v2_stock_plate_for_plate, barcode_number: '1' }
@@ -40,20 +39,18 @@ RSpec.describe LabwareCreators::QuadrantStampPrimerPanel do
       stock_plate: stock_plate2
     )
   end
-  let(:child_plate_v2) { create :v2_plate, uuid: child_uuid, barcode_number: '5', size: 384 }
-  let(:child_plate_v1) { json :stock_plate_with_metadata, stock_plate: { barcode: '5', uuid: child_uuid } }
+  let(:child_plate) { create :v2_plate, barcode_number: '5', size: 384 }
   let(:child_purpose_uuid) { 'child-purpose' }
   let(:child_purpose_name) { 'Child Purpose' }
 
-  let(:user_uuid) { 'user-uuid' }
-  let(:v1_user) { json :v1_user, uuid: user_uuid }
-  let(:user) { create :user, uuid: user_uuid }
+  let(:user) { create :user }
 
   before do
     create :purpose_config, name: child_purpose_name
+    stub_v2_user(user)
     stub_v2_plate(parent1, stub_search: false)
     stub_v2_plate(parent2, stub_search: false)
-    stub_v2_plate(child_plate_v2, stub_search: false, custom_query: [:plate_with_wells, child_plate_v2.uuid])
+    stub_v2_plate(child_plate, stub_search: false, custom_query: [:plate_with_wells, child_plate.uuid])
   end
 
   context 'on new' do
@@ -75,7 +72,7 @@ RSpec.describe LabwareCreators::QuadrantStampPrimerPanel do
   end
 
   context 'on create' do
-    subject { LabwareCreators::QuadrantStampPrimerPanel.new(api, form_attributes.merge(user_uuid: user_uuid)) }
+    subject { LabwareCreators::QuadrantStampPrimerPanel.new(api, form_attributes.merge(user_uuid: user.uuid)) }
 
     let(:form_attributes) do
       {
@@ -246,20 +243,6 @@ RSpec.describe LabwareCreators::QuadrantStampPrimerPanel do
       }
     end
 
-    let!(:pooled_plate_creation_request) do
-      stub_api_post(
-        'pooled_plate_creations',
-        payload: {
-          pooled_plate_creation: {
-            user: user_uuid,
-            child_purpose: child_purpose_uuid,
-            parents: [parent1_uuid, parent2_uuid]
-          }
-        },
-        body: json(:plate_creation, child_uuid: child_uuid)
-      )
-    end
-
     let(:transfer_requests) do
       [
         { source_asset: '3-well-A1', outer_request: 'request-0', target_asset: '5-well-A1' },
@@ -290,7 +273,7 @@ RSpec.describe LabwareCreators::QuadrantStampPrimerPanel do
         'transfer_request_collections',
         payload: {
           transfer_request_collection: {
-            user: user_uuid,
+            user: user.uuid,
             transfer_requests: transfer_requests
           }
         },
@@ -298,36 +281,47 @@ RSpec.describe LabwareCreators::QuadrantStampPrimerPanel do
       )
     end
 
+    let(:pooled_plate_creation) do
+      response = double
+      allow(response).to receive(:child).and_return(child_plate)
+
+      response
+    end
+
+    def expect_pooled_plate_creation
+      expect_api_v2_posts(
+        'PooledPlateCreation',
+        [
+          {
+            child_purpose_uuid: child_purpose_uuid,
+            parent_uuids: [parent1_uuid, parent2_uuid],
+            user_uuid: user.uuid
+          }
+        ],
+        [pooled_plate_creation]
+      )
+    end
+
+    def expect_custom_metadatum_collection_creation
+      expect_api_v2_posts(
+        'CustomMetadatumCollection',
+        [
+          {
+            asset_id: child_plate.id,
+            metadata: { stock_barcode_q0: stock_plate1.barcode.human, stock_barcode_q1: stock_plate2.barcode.human },
+            user_id: user.id
+          }
+        ]
+      )
+    end
+
     context '#save!' do
-      setup do
-        stub_api_get(child_plate_v2.uuid, body: child_plate_v1)
-        stub_api_get(
-          'custom_metadatum_collection-uuid',
-          body: json(:v1_custom_metadatum_collection, uuid: 'custom_metadatum_collection-uuid')
-        )
-        stub_api_get('user-uuid', body: v1_user)
-        stub_v2_user(user)
-        stub_api_get('asset-uuid', body: child_plate_v1)
-
-        metadata =
-          attributes_for(:v1_custom_metadatum_collection)
-            .fetch(:metadata, {})
-            .merge(stock_barcode_q0: stock_plate1.barcode.human, stock_barcode_q1: stock_plate2.barcode.human)
-
-        stub_api_put(
-          'custom_metadatum_collection-uuid',
-          payload: {
-            custom_metadatum_collection: {
-              metadata: metadata
-            }
-          },
-          body: json(:v1_custom_metadatum_collection)
-        )
-      end
-
       it 'creates a plate!' do
+        expect_pooled_plate_creation
+        expect_custom_metadatum_collection_creation
+
         subject.save!
-        expect(pooled_plate_creation_request).to have_been_made.once
+
         expect(transfer_creation_request).to have_been_made.once
       end
     end

--- a/spec/models/labware_creators/quadrant_stamp_primer_panel_spec.rb
+++ b/spec/models/labware_creators/quadrant_stamp_primer_panel_spec.rb
@@ -291,13 +291,7 @@ RSpec.describe LabwareCreators::QuadrantStampPrimerPanel do
     def expect_pooled_plate_creation
       expect_api_v2_posts(
         'PooledPlateCreation',
-        [
-          {
-            child_purpose_uuid: child_purpose_uuid,
-            parent_uuids: [parent1_uuid, parent2_uuid],
-            user_uuid: user.uuid
-          }
-        ],
+        [{ child_purpose_uuid: child_purpose_uuid, parent_uuids: [parent1_uuid, parent2_uuid], user_uuid: user.uuid }],
         [pooled_plate_creation]
       )
     end
@@ -308,7 +302,10 @@ RSpec.describe LabwareCreators::QuadrantStampPrimerPanel do
         [
           {
             asset_id: child_plate.id,
-            metadata: { stock_barcode_q0: stock_plate1.barcode.human, stock_barcode_q1: stock_plate2.barcode.human },
+            metadata: {
+              stock_barcode_q0: stock_plate1.barcode.human,
+              stock_barcode_q1: stock_plate2.barcode.human
+            },
             user_id: user.id
           }
         ]


### PR DESCRIPTION
Closes #1818 

#### Changes proposed in this pull request

- Make use of the new PooledPlateCreations endpoint in Sequencescape.
- Add tests to ensure these are working as expected.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
