### PR TITLE
Y24-193 add volume columns to driver file for PMBC pools to GEM-X 5p chip

### DIFF
--- a/app/views/exports/hamilton_gem_x_5p_chip_loading.csv.erb
+++ b/app/views/exports/hamilton_gem_x_5p_chip_loading.csv.erb
@@ -31,13 +31,17 @@
   # Destination wells are mapped to numbers: A1 -> 17, A2 -> 18, ..., A8 -> 24
   mapping = (1..8).each_with_object({}) { |i, hash| hash["A#{i}"] = (16 + i).to_s }
 
-   # Make a mapping { src_location => src_well  }
+  # Make a mapping { src_location => src_well  }
   ancestral_plate_wells = @ancestor_plate.wells.index_by(&:location)
   rows_array = []
   each_source_metadata_for_plate(@plate) do |src_barcode, src_location, dest_well|
     number_of_samples =  ancestral_plate_wells[src_location].aliquots.length
+    # The formula is:
+    # resuspension_volume = (number_of_samples * required_number_of_cells * wastage_factor) / chip_loading_concentration
     resuspension_volume = (number_of_samples * required_number_of_cells * wastage_factor).to_f / chip_loading_concentration
+    # The source well volume is the resuspension volume - the volume taken for cell counting
     source_well_volume = resuspension_volume - volume_taken_for_cell_counting
+ 
     sample_volume = desired_number_of_cells_per_chip_well.to_f/chip_loading_concentration 
     pbs_volume = desired_sample_volume - sample_volume
     rows_array << [

--- a/app/views/exports/hamilton_gem_x_5p_chip_loading.csv.erb
+++ b/app/views/exports/hamilton_gem_x_5p_chip_loading.csv.erb
@@ -10,20 +10,44 @@
                         'Source Plate ID',
                         'Source Plate Well',
                         'Destination Plate ID',
-                        'Destination Plate Well'
+                        'Destination Plate Well',
+                        'Source Well Volume',
+                        'Sample Volume',
+                        'PBS Volume',
+
                       ],
                       row_sep: ""
 %>
 <%
+  # Configuration specific to this export
+
+  required_number_of_cells = 30000 
+  wastage_factor = 0.95238 # accounting for wastage of material when transferring between labware
+  chip_loading_concentration = 2400 
+  desired_number_of_cells_per_chip_well = 90000
+  desired_sample_volume = 37.5 # microlitres
+  volume_taken_for_cell_counting = 10.0 # microlitres
+
   # Destination wells are mapped to numbers: A1 -> 17, A2 -> 18, ..., A8 -> 24
   mapping = (1..8).each_with_object({}) { |i, hash| hash["A#{i}"] = (16 + i).to_s }
+
+   # Make a mapping { src_location => src_well  }
+  ancestral_plate_wells = @ancestor_plate.wells.index_by(&:location)
   rows_array = []
   each_source_metadata_for_plate(@plate) do |src_barcode, src_location, dest_well|
+    number_of_samples =  ancestral_plate_wells[src_location].aliquots.length
+    resuspension_volume = (number_of_samples * required_number_of_cells * wastage_factor).to_f / chip_loading_concentration
+    source_well_volume = resuspension_volume - volume_taken_for_cell_counting
+    sample_volume = desired_number_of_cells_per_chip_well.to_f/chip_loading_concentration 
+    pbs_volume = desired_sample_volume - sample_volume
     rows_array << [
       src_barcode,
       src_location,
       @plate.labware_barcode.human,
-      mapping[dest_well.location]
+      mapping[dest_well.location],
+       '%0.2f' % source_well_volume,
+       '%0.2f' % sample_volume,
+       '%0.2f' % pbs_volume
     ]
   end
 %>

--- a/app/views/exports/hamilton_gem_x_5p_chip_loading.csv.erb
+++ b/app/views/exports/hamilton_gem_x_5p_chip_loading.csv.erb
@@ -36,12 +36,8 @@
   rows_array = []
   each_source_metadata_for_plate(@plate) do |src_barcode, src_location, dest_well|
     number_of_samples =  ancestral_plate_wells[src_location].aliquots.length
-    # The formula is:
-    # resuspension_volume = (number_of_samples * required_number_of_cells * wastage_factor) / chip_loading_concentration
     resuspension_volume = (number_of_samples * required_number_of_cells * wastage_factor).to_f / chip_loading_concentration
-    # The source well volume is the resuspension volume - the volume taken for cell counting
     source_well_volume = resuspension_volume - volume_taken_for_cell_counting
- 
     sample_volume = desired_number_of_cells_per_chip_well.to_f/chip_loading_concentration 
     pbs_volume = desired_sample_volume - sample_volume
     rows_array << [

--- a/spec/views/exports/hamilton_gem_x_5p_chip_loading.csv.erb_spec.rb
+++ b/spec/views/exports/hamilton_gem_x_5p_chip_loading.csv.erb_spec.rb
@@ -9,9 +9,11 @@ RSpec.describe 'exports/hamilton_gem_x_5p_chip_loading.csv.erb' do
   # Destination wells are mapped to numbers: A1 -> 17, A2 -> 18, ..., A8 -> 24
   let(:mapping) { ('A1'..'A8').zip((17..24).map(&:to_s)).to_h }
 
+  let(:aliquots_a1) { create_list(:v2_aliquot, 2) }
+  let(:aliquots_b1) { create_list(:v2_aliquot, 10) }
   # Source wells
-  let(:source_well_a1) { create(:v2_well, location: 'A1') }
-  let(:source_well_b1) { create(:v2_well, location: 'B1') }
+  let(:source_well_a1) { create(:v2_well, location: 'A1', aliquots:aliquots_a1) }
+  let(:source_well_b1) { create(:v2_well, location: 'B1', aliquots:aliquots_b1 ) }
 
   # Transfer requests from source wells
   let(:transfer_request1) { create(:v2_transfer_request, source_asset: source_well_a1, target_asset: nil) }
@@ -44,25 +46,26 @@ RSpec.describe 'exports/hamilton_gem_x_5p_chip_loading.csv.erb' do
     ]
   end
 
-  # The number of samples is 1, so the sample volume is 1.90 µL ((1*30000*0.95238)/2400 -10.0)
+  # The number of samples is 2, so the sample volume is 13.81 µL ((2*30000*0.95238)/2400 -10.0)
   let(:row_source_a1) do
     [
       source_plate.barcode.human,
       source_well_a1.location,
       dest_plate.barcode.human,
       mapping[dest_well_a1.location],
-      '1.90',
+      '13.81',
       '37.50',
       '0.00'
     ]
   end
+  # The number of samples is 10, so the sample volume is 109.05 µL ((10*30000*0.95238)/2400 -10.0)
   let(:row_source_b1) do
     [
       source_plate.barcode.human,
       source_well_b1.location,
       dest_plate.barcode.human,
       mapping[dest_well_a2.location],
-      '1.90',
+      '109.05',
       '37.50',
       '0.00'
     ]

--- a/spec/views/exports/hamilton_gem_x_5p_chip_loading.csv.erb_spec.rb
+++ b/spec/views/exports/hamilton_gem_x_5p_chip_loading.csv.erb_spec.rb
@@ -33,16 +33,39 @@ RSpec.describe 'exports/hamilton_gem_x_5p_chip_loading.csv.erb' do
   let(:workflow_row) { ['Workflow', workflow] }
   let(:empty_row) { [] }
   let(:header_row) do
- ['Source Plate ID', 'Source Plate Well', 'Destination Plate ID', 'Destination Plate Well', 'Source Well Volume',
-'Sample Volume', 'PBS Volume'] end
+    [
+      'Source Plate ID',
+      'Source Plate Well',
+      'Destination Plate ID',
+      'Destination Plate Well',
+      'Source Well Volume',
+      'Sample Volume',
+      'PBS Volume'
+    ]
+  end
+
   # The number of samples is 1, so the sample volume is 1.90 µL ((1*30000*0.95238)/2400 -10.0)
   let(:row_source_a1) do
-    [source_plate.barcode.human, source_well_a1.location, dest_plate.barcode.human, mapping[dest_well_a1.location],
-'1.90','37.50','0.00']
+    [
+      source_plate.barcode.human,
+      source_well_a1.location,
+      dest_plate.barcode.human,
+      mapping[dest_well_a1.location],
+      '1.90',
+      '37.50',
+      '0.00'
+    ]
   end
   let(:row_source_b1) do
-    [source_plate.barcode.human, source_well_b1.location, dest_plate.barcode.human, mapping[dest_well_a2.location],
-'1.90','37.50','0.00']
+    [
+      source_plate.barcode.human,
+      source_well_b1.location,
+      dest_plate.barcode.human,
+      mapping[dest_well_a2.location],
+      '1.90',
+      '37.50',
+      '0.00'
+    ]
   end
 
   before do

--- a/spec/views/exports/hamilton_gem_x_5p_chip_loading.csv.erb_spec.rb
+++ b/spec/views/exports/hamilton_gem_x_5p_chip_loading.csv.erb_spec.rb
@@ -11,9 +11,10 @@ RSpec.describe 'exports/hamilton_gem_x_5p_chip_loading.csv.erb' do
 
   let(:aliquots_a1) { create_list(:v2_aliquot, 2) }
   let(:aliquots_b1) { create_list(:v2_aliquot, 10) }
+
   # Source wells
-  let(:source_well_a1) { create(:v2_well, location: 'A1', aliquots:aliquots_a1) }
-  let(:source_well_b1) { create(:v2_well, location: 'B1', aliquots:aliquots_b1 ) }
+  let(:source_well_a1) { create(:v2_well, location: 'A1', aliquots: aliquots_a1) }
+  let(:source_well_b1) { create(:v2_well, location: 'B1', aliquots: aliquots_b1) }
 
   # Transfer requests from source wells
   let(:transfer_request1) { create(:v2_transfer_request, source_asset: source_well_a1, target_asset: nil) }
@@ -58,6 +59,7 @@ RSpec.describe 'exports/hamilton_gem_x_5p_chip_loading.csv.erb' do
       '0.00'
     ]
   end
+
   # The number of samples is 10, so the sample volume is 109.05 µL ((10*30000*0.95238)/2400 -10.0)
   let(:row_source_b1) do
     [

--- a/spec/views/exports/hamilton_gem_x_5p_chip_loading.csv.erb_spec.rb
+++ b/spec/views/exports/hamilton_gem_x_5p_chip_loading.csv.erb_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'pry-byebug'
 
 # Test for export Hamilton LRC PBMC Pools (or Input) to LRC GEM-X 5p Chip
 RSpec.describe 'exports/hamilton_gem_x_5p_chip_loading.csv.erb' do
@@ -32,12 +33,17 @@ RSpec.describe 'exports/hamilton_gem_x_5p_chip_loading.csv.erb' do
   # Expected content
   let(:workflow_row) { ['Workflow', workflow] }
   let(:empty_row) { [] }
-  let(:header_row) { ['Source Plate ID', 'Source Plate Well', 'Destination Plate ID', 'Destination Plate Well'] }
+  let(:header_row) do
+ ['Source Plate ID', 'Source Plate Well', 'Destination Plate ID', 'Destination Plate Well', 'Source Well Volume', 
+'Sample Volume', 'PBS Volume'] end
+  # The number of samples is 1, so the sample volume is 1.90 µL ((1*30000*0.95238)/2400 -10.0)
   let(:row_source_a1) do
-    [source_plate.barcode.human, source_well_a1.location, dest_plate.barcode.human, mapping[dest_well_a1.location]]
+    [source_plate.barcode.human, source_well_a1.location, dest_plate.barcode.human, mapping[dest_well_a1.location], 
+'1.90','37.50','0.00']
   end
   let(:row_source_b1) do
-    [source_plate.barcode.human, source_well_b1.location, dest_plate.barcode.human, mapping[dest_well_a2.location]]
+    [source_plate.barcode.human, source_well_b1.location, dest_plate.barcode.human, mapping[dest_well_a2.location],
+'1.90','37.50','0.00']
   end
 
   before do

--- a/spec/views/exports/hamilton_gem_x_5p_chip_loading.csv.erb_spec.rb
+++ b/spec/views/exports/hamilton_gem_x_5p_chip_loading.csv.erb_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'pry-byebug'
 
 # Test for export Hamilton LRC PBMC Pools (or Input) to LRC GEM-X 5p Chip
 RSpec.describe 'exports/hamilton_gem_x_5p_chip_loading.csv.erb' do
@@ -34,11 +33,11 @@ RSpec.describe 'exports/hamilton_gem_x_5p_chip_loading.csv.erb' do
   let(:workflow_row) { ['Workflow', workflow] }
   let(:empty_row) { [] }
   let(:header_row) do
- ['Source Plate ID', 'Source Plate Well', 'Destination Plate ID', 'Destination Plate Well', 'Source Well Volume', 
+ ['Source Plate ID', 'Source Plate Well', 'Destination Plate ID', 'Destination Plate Well', 'Source Well Volume',
 'Sample Volume', 'PBS Volume'] end
   # The number of samples is 1, so the sample volume is 1.90 µL ((1*30000*0.95238)/2400 -10.0)
   let(:row_source_a1) do
-    [source_plate.barcode.human, source_well_a1.location, dest_plate.barcode.human, mapping[dest_well_a1.location], 
+    [source_plate.barcode.human, source_well_a1.location, dest_plate.barcode.human, mapping[dest_well_a1.location],
 '1.90','37.50','0.00']
   end
   let(:row_source_b1) do


### PR DESCRIPTION
Closes https://github.com/sanger/limber/issues/1779

#### Changes proposed in this pull request

- Adds Source well volume, Sample volume and PBS volume columns in the driver files for PBMC Pools (or Input) plate to GEM-X 5p transfer 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
