### PR TITLE
Y24-352: Filter for any relatives that might not have a purpose

### DIFF
--- a/app/views/labware/_relatives_list.html.erb
+++ b/app/views/labware/_relatives_list.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (presenter:) %>
 <%
-  valid_parents = presenter.labware.parents&.filter{ |parent| parent.purpose.present? }
-  valid_children = presenter.labware.children&.filter{ |child| child.purpose.present? }
+  valid_parents = presenter.labware.parents&.filter{ |parent| parent.purpose.present? } || []
+  valid_children = presenter.labware.children&.filter{ |child| child.purpose.present? } || []
 %>
 <div id="relatives-information" class="list-group list-group-flush">
 


### PR DESCRIPTION
Not just when there is a single relative without a purpose.

Closes #1964 

#### Changes proposed in this pull request

- Some refactoring to not include purposeless relatives in template collections.

<img width="711" alt="Screenshot 2024-09-27 at 15 20 23" src="https://github.com/user-attachments/assets/f6c2ff7e-b34d-4d38-8602-d06b68b79b0f">

-----------

<img width="708" alt="Screenshot 2024-09-27 at 15 21 07" src="https://github.com/user-attachments/assets/89dd599c-0a11-4850-b9dc-31528a39edbd">

Compare this screenshot to #1928


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
