### PR TITLE
Y24-190-3: Use API v2 TubeFromTubeCreation endpoint

### DIFF
--- a/app/models/labware_creators/pooled_tubes_from_whole_tubes.rb
+++ b/app/models/labware_creators/pooled_tubes_from_whole_tubes.rb
@@ -65,6 +65,10 @@ module LabwareCreators
       purpose_config.fetch(:number_of_parent_labwares, 4)
     end
 
+    def redirection_target
+      TubeProxy.new(@child.uuid)
+    end
+
     private
 
     def transfer_request_attributes

--- a/app/models/labware_creators/pooled_tubes_from_whole_tubes.rb
+++ b/app/models/labware_creators/pooled_tubes_from_whole_tubes.rb
@@ -20,9 +20,12 @@ module LabwareCreators
     def create_labware!
       # Create a single tube
       # TODO: This should link to multiple parents in production
-      tc = api.tube_from_tube_creation.create!(user: user_uuid, parent: parent_uuid, child_purpose: purpose_uuid)
-
-      @child = tc.child
+      @child =
+        Sequencescape::Api::V2::TubeFromTubeCreation.create!(
+          child_purpose_uuid: purpose_uuid,
+          parent_uuid: parent_uuid,
+          user_uuid: user_uuid
+        ).child
 
       # Transfer EVERYTHING into it
       Sequencescape::Api::V2::TransferRequestCollection.create!(

--- a/app/models/labware_creators/tube_from_tube.rb
+++ b/app/models/labware_creators/tube_from_tube.rb
@@ -11,7 +11,11 @@ module LabwareCreators
 
     def create_labware!
       @child_tube =
-        api.tube_from_tube_creation.create!(parent: parent_uuid, child_purpose: purpose_uuid, user: user_uuid).child
+        Sequencescape::Api::V2::TubeFromTubeCreation.create!(
+          child_purpose_uuid: purpose_uuid,
+          parent_uuid: parent_uuid,
+          user_uuid: user_uuid
+        ).child
 
       @tube_transfer = transfer!(source_uuid: parent_uuid, destination_uuid: @child_tube.uuid)
 

--- a/app/sequencescape/sequencescape/api/v2/tube_from_tube_creation.rb
+++ b/app/sequencescape/sequencescape/api/v2/tube_from_tube_creation.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Represents a tube from tube creation in Limber via the Sequencescape API
+class Sequencescape::Api::V2::TubeFromTubeCreation < Sequencescape::Api::V2::Base
+  has_one :child, class_name: 'Sequencescape::Api::V2::Tube'
+  has_one :child_purpose, class_name: 'Sequencescape::Api::V2::TubePurpose'
+  has_one :parent, class_name: 'Sequencescape::Api::V2::Tube'
+  has_one :user, class_name: 'Sequencescape::Api::V2::User'
+end

--- a/spec/features/pooling_multiple_tubes_into_one_tube_spec.rb
+++ b/spec/features/pooling_multiple_tubes_into_one_tube_spec.rb
@@ -14,11 +14,6 @@ RSpec.feature 'Pooling multiple tubes into a tube', js: true do
 
   let(:aliquot_set_1) { create_list :v2_tagged_aliquot, 2, library_state: 'passed' }
 
-  let(:parent_1) { create :v2_plate, barcode_number: 3 }
-  let(:parent_1_v1) { json :plate_with_metadata, barcode_number: 3 }
-  let(:parent_2) { create :v2_plate, barcode_number: 4 }
-  let(:parent_2_v1) { json :plate_with_metadata, barcode_number: 4 }
-
   let(:tube_barcode_1) { SBCF::SangerBarcode.new(prefix: 'NT', number: 1).machine_barcode.to_s }
   let(:tube_uuid) { SecureRandom.uuid }
   let(:parent_purpose_name) { 'example-purpose' }
@@ -34,17 +29,13 @@ RSpec.feature 'Pooling multiple tubes into a tube', js: true do
       }
     ]
   end
-  let(:stock_plate_purpose_name) { 'Stock Plate Purpose' }
-  let(:stock_plate) { create :v2_stock_plate, purpose_name: stock_plate_purpose_name }
   let(:example_v2_tube) do
     create :v2_tube,
            barcode_number: 1,
            state: 'passed',
            uuid: tube_uuid,
            purpose_name: parent_purpose_name,
-           aliquots: aliquot_set_1,
-           stock_plate: stock_plate,
-           parents: [parent_1]
+           aliquots: aliquot_set_1
   end
   let(:example_tube) { json(*example_tube_args) }
   let(:example_tube_listed) { associated(*example_tube_args) }
@@ -61,9 +52,7 @@ RSpec.feature 'Pooling multiple tubes into a tube', js: true do
            state: 'passed',
            uuid: tube_uuid_2,
            purpose_name: parent_purpose_name,
-           aliquots: aliquot_set_2,
-           stock_plate: stock_plate,
-           parents: [parent_2]
+           aliquots: aliquot_set_2
   end
   let(:example_tube_2_listed) { associated(*example_tube2_args) }
 
@@ -129,10 +118,6 @@ RSpec.feature 'Pooling multiple tubes into a tube', js: true do
     allow(Sequencescape::Api::V2::Tube).to receive(:find_all)
       .with(barcode: [tube_barcode_1, tube_barcode_2], includes: [])
       .and_return([example_v2_tube, example_v2_tube2])
-
-    # Allow parent plates to be found in API v2
-    stub_v2_plate(parent_1, stub_search: false)
-    stub_v2_plate(parent_2, stub_search: false)
   end
 
   background do
@@ -177,9 +162,6 @@ RSpec.feature 'Pooling multiple tubes into a tube', js: true do
     # Used in the redirect. This call is probably unnecessary
     stub_v2_tube(child_tube)
     stub_v2_barcode_printers(create_list(:v2_plate_barcode_printer, 3))
-
-    allow(SearchHelper).to receive(:stock_plate_names).and_return([stock_plate_purpose_name])
-    stub_get_labware_metadata(parent_1.barcode.machine, parent_1_v1)
   end
 
   context 'unique tags' do

--- a/spec/models/labware_creators/pooled_tubes_from_whole_tubes_spec.rb
+++ b/spec/models/labware_creators/pooled_tubes_from_whole_tubes_spec.rb
@@ -9,6 +9,8 @@ require_relative 'shared_examples'
 # Each well on the plate gets transferred into a tube
 # transfer targets are determined by pool
 RSpec.describe LabwareCreators::PooledTubesFromWholeTubes do
+  has_a_working_api
+
   include FeatureHelpers
   it_behaves_like 'it only allows creation from tubes'
 
@@ -16,95 +18,45 @@ RSpec.describe LabwareCreators::PooledTubesFromWholeTubes do
 
   let(:user_uuid) { SecureRandom.uuid }
   let(:purpose_uuid) { SecureRandom.uuid }
-  let(:purpose) { json :purpose, uuid: purpose_uuid }
-  let(:parent_uuid) { SecureRandom.uuid }
-  let(:parent2_uuid) { SecureRandom.uuid }
-  let(:parent) { create :v2_tube, uuid: parent_uuid, barcode_number: 1 }
-  let(:parent2) { create :v2_tube, uuid: parent2_uuid, barcode_number: 2 }
-  let(:child_uuid) { SecureRandom.uuid }
-  let(:template_uuid) { SecureRandom.uuid }
 
-  let(:barcodes) do
-    [
-      SBCF::SangerBarcode.new(prefix: 'NT', number: 1).machine_barcode.to_s,
-      SBCF::SangerBarcode.new(prefix: 'NT', number: 2).machine_barcode.to_s
-    ]
-  end
+  let(:parents) { create_list :v2_tube, 2 }
+  let(:parent_uuid) { parents.first.uuid }
 
-  before do
-    create :purpose_config,
-           submission: {
-             template_uuid: template_uuid,
-             request_options: {
-               read_length: 150
-             }
-           },
-           uuid: purpose_uuid
-  end
+  let(:barcodes) { parents.map { |parent| parent.barcode.to_s } }
+
+  let(:child_tube) { create(:v2_tube) }
 
   describe '#new' do
     it_behaves_like 'it has a custom page', 'pooled_tubes_from_whole_tubes'
-    has_a_working_api
 
     let(:form_attributes) { { purpose_uuid: purpose_uuid, parent_uuid: parent_uuid } }
   end
 
   describe '#save!' do
-    has_a_working_api
-
     let(:form_attributes) do
       { user_uuid: user_uuid, purpose_uuid: purpose_uuid, parent_uuid: parent_uuid, barcodes: barcodes }
     end
 
-    let(:tube_creation_request_uuid) { SecureRandom.uuid }
-
-    let!(:tube_creation_request) do
-      # TODO: In reality we want to link in all four parents.
-      stub_api_post(
-        'tube_from_tube_creations',
-        payload: {
-          tube_from_tube_creation: {
-            user: user_uuid,
-            parent: parent_uuid,
-            child_purpose: purpose_uuid
-          }
-        },
-        body: json(:tube_creation, child_uuid: child_uuid)
-      )
-    end
-
-    # Find out what tubes we've just made!
-    let(:tube_creation_children_request) do
-      stub_api_get(
-        tube_creation_request_uuid,
-        'children',
-        body: json(:single_study_multiplexed_library_tube_collection, names: ['DN2+'])
-      )
-    end
-
     let(:transfer_requests_attributes) do
-      [
-        { source_asset: parent_uuid, target_asset: child_uuid },
-        { source_asset: parent2_uuid, target_asset: child_uuid }
-      ]
+      parents.map { |parent| { source_asset: parent.uuid, target_asset: child_tube.uuid } }
+    end
+
+    let(:tube_from_tubes_attributes) do
+      [{ child_purpose_uuid: purpose_uuid, parent_uuid: parent_uuid, user_uuid: user_uuid }]
     end
 
     before do
       allow(Sequencescape::Api::V2::Tube).to receive(:find_all)
         .with(barcode: barcodes, includes: [])
-        .and_return([parent, parent2])
-
-      tube_creation_request
-      tube_creation_children_request
+        .and_return(parents)
     end
 
     context 'with compatible tubes' do
       it 'pools from all the tubes' do
         expect_transfer_request_collection_creation
+        expect_tube_from_tube_creation
 
         expect(subject.save!).to be_truthy
-
-        expect(tube_creation_request).to have_been_made.once
       end
     end
   end

--- a/spec/models/labware_creators/tube_from_tube_spec.rb
+++ b/spec/models/labware_creators/tube_from_tube_spec.rb
@@ -31,14 +31,12 @@ RSpec.describe LabwareCreators::TubeFromTube do
 
     it_behaves_like 'it has no custom page'
 
-    before { creation_request }
-
     let(:controller) { TubeCreationController.new }
-    let(:child_purpose_uuid) { 'child-purpose-uuid' }
-    let(:parent_uuid) { 'parent-uuid' }
-    let(:child_uuid) { 'child-uuid' }
-    let(:user_uuid) { 'user-uuid' }
+    let(:child_purpose_uuid) { SecureRandom.uuid }
+    let(:parent_uuid) { SecureRandom.uuid }
+    let(:user_uuid) { SecureRandom.uuid }
     let(:transfer_template_uuid) { 'transfer-between-specific-tubes' } # Defined in spec_helper.rb
+    let(:child_tube) { create(:tube) }
 
     let(:transfers_attributes) do
       [
@@ -46,36 +44,26 @@ RSpec.describe LabwareCreators::TubeFromTube do
           arguments: {
             user_uuid: user_uuid,
             source_uuid: parent_uuid,
-            destination_uuid: child_uuid,
+            destination_uuid: child_tube.uuid,
             transfer_template_uuid: transfer_template_uuid
           }
         }
       ]
     end
 
-    let(:form_attributes) { { purpose_uuid: child_purpose_uuid, parent_uuid: parent_uuid, user_uuid: user_uuid } }
-
-    let(:creation_request) do
-      stub_api_post(
-        'tube_from_tube_creations',
-        payload: {
-          tube_from_tube_creation: {
-            parent: 'parent-uuid',
-            child_purpose: 'child-purpose-uuid',
-            user: 'user-uuid'
-          }
-        },
-        body: json(:tube_creation, child_uuid: child_uuid)
-      )
+    let(:tube_from_tubes_attributes) do
+      [{ child_purpose_uuid: child_purpose_uuid, parent_uuid: parent_uuid, user_uuid: user_uuid }]
     end
+
+    let(:form_attributes) { { purpose_uuid: child_purpose_uuid, parent_uuid: parent_uuid, user_uuid: user_uuid } }
 
     describe '#save!' do
       it 'creates the child' do
         expect_transfer_creation
+        expect_tube_from_tube_creation
 
         subject.save!
-        expect(subject.redirection_target.uuid).to eq(child_uuid)
-        expect(creation_request).to have_been_made.once
+        expect(subject.redirection_target.uuid).to eq(child_tube.uuid)
       end
     end
   end

--- a/spec/support/api_url_helper.rb
+++ b/spec/support/api_url_helper.rb
@@ -138,6 +138,14 @@ module ApiUrlHelper
         [{ transfer_requests_attributes: transfer_requests_attributes, user_uuid: user_uuid }]
       )
     end
+
+    def expect_tube_from_tube_creation
+      expect_api_v2_posts(
+        'TubeFromTubeCreation',
+        tube_from_tubes_attributes,
+        [double(child: child_tube)] * tube_from_tubes_attributes.size
+      )
+    end
   end
 
   # Stubs for the V2 API.


### PR DESCRIPTION
Closes https://github.com/sanger/limber/issues/1818

#### Changes proposed in this pull request

- Use `tube_from_tube_creation` endpoint from SS API v2.
- Update tests to match the expectations of method calls.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  