### PR TITLE
Only run version check when develop -> master PR is not draft

### DIFF
--- a/.github/workflows/check_release_version.yml
+++ b/.github/workflows/check_release_version.yml
@@ -16,6 +16,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    # only run when PR is not draft
+    if: ${{ !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Closes https://psd-team.slack.com/archives/C01J32MB747/p1728041785804649
Related to #1930 

#### Changes proposed in this pull request

- Add gate check to prevent running action when the PR is marked as draft
  - This should reduce false positives
- Once the PR is marked as ready-to-review, then the check will run again as usual

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
