### PR TITLE
Y24-377: Reword libraries warning messages for improved clarity

### DIFF
--- a/app/models/validators/failed_validator.rb
+++ b/app/models/validators/failed_validator.rb
@@ -11,8 +11,8 @@ module Validators
       affected_range = WellHelpers.formatted_range(problem_wells, presenter.size)
 
       presenter.errors.add(
-        :libraries,
-        "on this plate have already been failed (#{affected_range}). You should not carry out further work. " \
+        :submission,
+        "on this plate has already been failed (#{affected_range}). You should not carry out further work. " \
           'Any further work conducted from this plate will run into issues at the end of the pipeline.'
       )
     end

--- a/app/models/validators/in_progress_validator.rb
+++ b/app/models/validators/in_progress_validator.rb
@@ -7,8 +7,8 @@ module Validators
       return true unless presenter.labware.any_complete_requests?
 
       presenter.errors.add(
-        :libraries,
-        'on this plate have already been completed. ' \
+        :submission,
+        '(active) is not present for this labware. ' \
           'Any further work conducted from this plate may run into issues at the end of the pipeline.'
       )
     end

--- a/spec/features/viewing_a_minimal_plate_spec.rb
+++ b/spec/features/viewing_a_minimal_plate_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature 'Viewing a plate', js: true do
     scenario 'there is a warning' do
       fill_in_swipecard_and_barcode user_swipecard, plate_barcode
       expect(find('.asset-warnings')).to have_content(
-        'Libraries on this plate have already been completed. ' \
+        'Submission (active) is not present for this labware. ' \
           'Any further work conducted from this plate may run into issues at the end of the pipeline.'
       )
     end
@@ -76,7 +76,7 @@ RSpec.feature 'Viewing a plate', js: true do
     scenario 'there is a warning' do
       fill_in_swipecard_and_barcode user_swipecard, plate_barcode
       expect(find('.asset-warnings')).to have_content(
-        'Libraries on this plate have already been failed (A1-E1). You should not carry out further work. ' \
+        'Submission on this plate has already been failed (A1-E1). You should not carry out further work. ' \
           'Any further work conducted from this plate will run into issues at the end of the pipeline.'
       )
     end
@@ -105,7 +105,7 @@ RSpec.feature 'Viewing a plate', js: true do
     scenario 'there is a warning' do
       fill_in_swipecard_and_barcode user_swipecard, plate_barcode
       expect(find('.asset-warnings')).to have_content(
-        'Libraries on this plate have already been completed. ' \
+        'Submission (active) is not present for this labware. ' \
           'Any further work conducted from this plate may run into issues at the end of the pipeline.'
       )
     end

--- a/spec/features/viewing_a_plate_spec.rb
+++ b/spec/features/viewing_a_plate_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature 'Viewing a plate', js: true do
     scenario 'there is a warning' do
       fill_in_swipecard_and_barcode user_swipecard, plate_barcode
       expect(find('.asset-warnings')).to have_content(
-        'Libraries on this plate have already been completed. ' \
+        'Submission (active) is not present for this labware. ' \
           'Any further work conducted from this plate may run into issues at the end of the pipeline.'
       )
     end


### PR DESCRIPTION
Closes #1987 
From https://psd-team.slack.com/archives/C01J32MB747/p1728552344836709

#### Changes proposed in this pull request

Reword warning messages:

- `Libraries on this plate have already been completed.`
  - Replaced with `Submission (active) is not present for this labware.`
- `Libraries on this plate have already been failed (A1-E1).`
  - Replaced with `Submission on this plate has already been failed (A1-E1).` 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
