### PR TITLE
DPL-918 extra setting

### DIFF
--- a/config/purposes/scrna_core_cdna_prep.yml
+++ b/config/purposes/scrna_core_cdna_prep.yml
@@ -36,7 +36,7 @@ LRC PBMC Defrost PBS:
     total_cell_count:
       name: Total cell count
       units: 'cells/ml'
-      default_threshold: 400000
+      default_threshold: 500000
       decimal_places: 0
   :stock_plate: false
   :input_plate: false

--- a/config/purposes/scrna_core_cell_extraction.yml
+++ b/config/purposes/scrna_core_cell_extraction.yml
@@ -80,7 +80,7 @@ LRC PBMC Bank:
   :qc_thresholds:
     viability:
       units: '%'
-      default_threshold: 50
+      default_threshold: 85
     total_cell_count:
       name: Total cell count
       units: 'cells/ml'


### PR DESCRIPTION
LRC PBMC Defrost PBS total cell count/ml defaults to 500000 
LRC PBMC Bank defaults to  85%