### PR TITLE
fix: filter by pipeline or group when clicking on an edge in pipeline-graph

### DIFF
--- a/app/frontend/javascript/pipeline-graph/index.js
+++ b/app/frontend/javascript/pipeline-graph/index.js
@@ -226,6 +226,8 @@ const applyMouseEvents = function () {
   // when an edge is clicked, filter the graph to show only that pipeline
   core.on('click', 'edge', (event) => {
     const pipeline = event.target.data('pipeline')
-    applyFilter(pipeline)
+    const group = event.target.data('group')
+    const pipelineOrGroup = pipeline || group
+    applyFilter(pipelineOrGroup)
   })
 }


### PR DESCRIPTION
Closes bug where clicking a pipeline in pipeline-group-mode filtered by `undefined` instead of the pipeline-group name

#### Changes proposed in this pull request

- filter by pipeline _or_ group when clicking on an edge

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
