### PR TITLE
Revert "Adding Norm plate after LBB Lib PCR-XP for tracking Beckman normalisation"

### DIFF
--- a/config/pipelines/bespoke_pcr.yml
+++ b/config/pipelines/bespoke_pcr.yml
@@ -88,6 +88,5 @@ Bespoke PCR MX:
     request_type_key:
       - limber_multiplexing
   relationships:
-    LBB Lib PCR-XP: LBB Lib PCR-XP Norm
-    LBB Lib PCR-XP Norm: LBB Lib Pool Stock
+    LBB Lib PCR-XP: LBB Lib Pool Stock
     LBB Lib Pool Stock: LB Lib Pool Norm

--- a/config/purposes/bespoke.yml
+++ b/config/purposes/bespoke.yml
@@ -13,8 +13,6 @@ LBB Lib PCR-XP:
   :asset_type: plate
   :presenter_class: Presenters::PcrPresenter
   :creator_class: LabwareCreators::CustomTaggedPlate
-LBB Lib PCR-XP Norm:
-  :asset_type: plate
 LBB Ligation Tagged:
   :asset_type: plate
   :presenter_class: Presenters::PcrPresenter


### PR DESCRIPTION
Reverts sanger/limber#1988 because there're some additional changes to be made.