### PR TITLE
Y24-014 - Ability to re-run RVI BCL pipeline

### DIFF
--- a/config/pipelines/high_throughput_rvi_bcl.yml
+++ b/config/pipelines/high_throughput_rvi_bcl.yml
@@ -5,6 +5,7 @@ RVI Bait Capture Library: # Top of the pipeline (Library Prep)
   filters:
     request_type_key:
       - limber_bait_capture_library_prep
+      - limber_reisc # Typically this should occur on RVI Lib PCR XP
     library_type:
       - RVI-BCL
   library_pass:


### PR DESCRIPTION
Closes #1615 

#### Changes proposed in this pull request

- Adds limber_reisc request type to possible rvi bcl pipeline request keys.

#### Notes

Related Sequencescape PR: https://github.com/sanger/sequencescape/pull/4468