### PR TITLE
Customer-requested bed number change

### DIFF
--- a/config/robots.rb
+++ b/config/robots.rb
@@ -3626,16 +3626,16 @@ ROBOT_CONFIG =
       name: 'Hamilton LRC PBMC Pools (or Input) => LRC GEM-X 5p Chip',
       require_robot: true,
       beds: {
-        bed(8).barcode => {
+        bed(5).barcode => {
           purpose: ['LRC PBMC Pools', 'LRC PBMC Pools Input'],
           states: ['passed'],
-          label: 'Bed 8'
+          label: 'Bed 5'
         },
         bed(15).barcode => {
           purpose: 'LRC GEM-X 5p Chip',
           states: ['pending'],
           label: 'Bed 15',
-          parent: bed(8).barcode,
+          parent: bed(5).barcode,
           target_state: 'passed'
         }
       }
@@ -3655,10 +3655,10 @@ ROBOT_CONFIG =
           states: ['passed'],
           label: 'Bed 15'
         },
-        bed(5).barcode => {
+        bed(4).barcode => {
           purpose: 'LRC GEM-X 5p GEMs',
           states: ['pending'],
-          label: 'Bed 5',
+          label: 'Bed 4',
           parent: bed(15).barcode,
           target_state: 'passed'
         }


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

Requirements from Abby in Slack following end to end lab test:

For bed verification, 2 bed changes:
- For the LRC PBMC Pools => LRC GEM-X 5p Chip, please could the LRC PBMC Pools plate be moved to bed 5
- For the LRC GEM-X 5p Chip => LRC GEM-X 5p GEMS, please could the LRC GEM-X 5p GEMS plate be moved to bed 4

Need to add a corresponding Int Suite PR.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
