### PR TITLE
Bait Library Layout Preview fix 

### DIFF
--- a/app/models/labware_creators/baited_plate.rb
+++ b/app/models/labware_creators/baited_plate.rb
@@ -26,7 +26,10 @@ module LabwareCreators
 
     def bait_library_layout_preview
       @bait_library_layout_preview ||=
-        Sequencescape::Api::V2::BaitLibraryLayout.preview(plate_uuid: parent_uuid, user_uuid: user_uuid).first.layout
+        Sequencescape::Api::V2::BaitLibraryLayout
+          .preview(plate_uuid: parent_uuid, user_uuid: user_uuid)
+          .first
+          .well_layout
     end
 
     def create_labware!

--- a/spec/factories/bait_library_layout_factories.rb
+++ b/spec/factories/bait_library_layout_factories.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     # For example:
     # { 'A1' => 'Human all exon 50MB', 'B1' => 'Human all exon 50MB',
     #   'C1' => 'Mouse all exon', 'D1' => 'Mouse all exon'}
-    layout do
+    well_layout do
       wells = WellHelpers.column_order.dup
       pools.each_with_object({}) { |pool, hash| wells.shift(pool[:size]).each { |well| hash[well] = pool[:bait] } }
     end


### PR DESCRIPTION
#### Changes proposed in this pull request

- Fixes regression from bait library preview v2 api where layout was returned instead of well_layout causing the bait library layout preview page to show no baits despite baits being present.

#### Instructions for Reviewers

Linked Sequencescape PR: https://github.com/sanger/sequencescape/pull/4478
There is also an integration suite PR.