### PR TITLE
build: remove rspec-rails version lock and update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ group :test do
   gem 'launchy' # Used by capybara for eg. save_and_open_screenshot
   gem 'rails-controller-testing'
   gem 'rspec-json_expectations'
-  gem 'rspec-rails', '6.1.3'
+  gem 'rspec-rails'
   gem 'selenium-webdriver', '~> 4.1', require: false
   gem 'simplecov', require: false
   gem 'simplecov-lcov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,7 +338,7 @@ GEM
     rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-rails (6.1.3)
+    rspec-rails (6.1.4)
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       railties (>= 6.1)
@@ -462,7 +462,7 @@ DEPENDENCIES
   rails-controller-testing
   rake
   rspec-json_expectations
-  rspec-rails (= 6.1.3)
+  rspec-rails
   rubocop
   rubocop-performance
   rubocop-rails


### PR DESCRIPTION
The lock was previously put in place as part of the update to Rails 7

#### Changes proposed in this pull request

- Remove the unneeded version lock
- Update the package to the latest version

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
