### PR TITLE
Y24-198 UAT Updates LCM Triomics bed verifications

### DIFF
--- a/config/robots.rb
+++ b/config/robots.rb
@@ -3873,10 +3873,10 @@ ROBOT_CONFIG =
           parent: bed(4).barcode,
           target_state: 'started'
         },
-        car('3,4').barcode => {
+        car('4,3').barcode => {
           purpose: 'LCMT EM APOBEC Deam',
           states: ['pending'],
-          label: 'Carousel 3,4',
+          label: 'Carousel 4,3',
           parent: car('3,3').barcode,
           target_state: 'started'
         }

--- a/config/robots.rb
+++ b/config/robots.rb
@@ -3821,16 +3821,16 @@ ROBOT_CONFIG =
       require_robot: true,
       verify_robot: true,
       beds: {
-        bed(6).barcode => {
+        bed(7).barcode => {
           purpose: 'LCMT DNA Adp Lig',
           states: ['passed'],
-          label: 'Bed 6'
+          label: 'Bed 7'
         },
-        bed(7).barcode => {
+        bed(6).barcode => {
           purpose: 'LCMT DNA Lib PCR',
           states: ['pending'],
-          label: 'Bed 7',
-          parent: bed(6).barcode,
+          label: 'Bed 6',
+          parent: bed(7).barcode,
           target_state: 'passed'
         }
       }

--- a/config/robots.rb
+++ b/config/robots.rb
@@ -3731,8 +3731,8 @@ ROBOT_CONFIG =
     # LCM Triomics WGS and EMSeq bed verification
     # Verify initial setup
     custom_robot(
-      'bravo-verify-initial-setup',
-      name: 'Bravo Verify Initial Setup',
+      'bravo-lcmt-emseq-verify-initial-setup',
+      name: 'Bravo LCMT EMSeq Verify Initial Setup',
       require_robot: true, # Robot barcode must be scanned in.
       verify_robot: false, # First robot step; no previous robot.
       beds: {

--- a/config/robots.rb
+++ b/config/robots.rb
@@ -3854,23 +3854,6 @@ ROBOT_CONFIG =
     )
 
     # LCM Triomics WGS and EMSeq bed verification
-    # Bravo LCMT EM TET2 Stop Verification
-    custom_robot(
-      'bravo-lcmt-em-tet2-stop-verification',
-      name: 'Bravo LCMT EM TET2 Stop Verification',
-      require_robot: true,
-      verify_robot: true,
-      beds: {
-        bed(5).barcode => {
-          purpose: 'LCMT EM TET2 Stop',
-          states: ['started'],
-          label: 'Bed 5',
-          target_state: 'passed'
-        }
-      }
-    )
-
-    # LCM Triomics WGS and EMSeq bed verification
     # Bravo LCMT EM TET2 Stop to Denat and Deam Setup
     custom_robot(
       'bravo-lcmt-em-tet2-stop-to-denat-and-deam-setup',

--- a/config/robots.rb
+++ b/config/robots.rb
@@ -3837,23 +3837,6 @@ ROBOT_CONFIG =
     )
 
     # LCM Triomics WGS and EMSeq bed verification
-    # Bravo LCMT DNA Adp Lig Verification
-    custom_robot(
-      'bravo-lcmt-dna-adp-lig-verification',
-      name: 'Bravo LCMT DNA Adp Lig Verification',
-      require_robot: true,
-      verify_robot: true,
-      beds: {
-        bed(5).barcode => {
-          purpose: 'LCMT DNA Adp Lig',
-          states: ['started'],
-          label: 'Bed 5',
-          target_state: 'passed'
-        }
-      }
-    )
-
-    # LCM Triomics WGS and EMSeq bed verification
     # Bravo LCMT EM TET2 Ox Verification
     custom_robot(
       'bravo-lcmt-em-tet2-ox-verification',

--- a/config/robots.rb
+++ b/config/robots.rb
@@ -3901,23 +3901,6 @@ ROBOT_CONFIG =
     )
 
     # LCM Triomics WGS and EMSeq bed verification
-    # Bravo LCMT EM APOBEC Deam Verification
-    custom_robot(
-      'bravo-lcmt-em-apobec-deam-verification',
-      name: 'Bravo LCMT EM APOBEC Deam Verification',
-      require_robot: true,
-      verify_robot: true,
-      beds: {
-        bed(5).barcode => {
-          purpose: 'LCMT EM APOBEC Deam',
-          states: ['started'],
-          label: 'Bed 5',
-          target_state: 'passed'
-        }
-      }
-    )
-
-    # LCM Triomics WGS and EMSeq bed verification
     # Bravo LCMT EM APOBEC Deam => LCMT EM Lib PCR
     custom_robot(
       'bravo-lcmt-em-apobec-deam-to-lcmt-em-lib-pcr',


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

This PR covers the minor changes that can be done quickly after UAT feedback and discussions that are available at https://github.com/sanger/limber/issues/1782#issuecomment-2468324507 . 

- Feedback Item (2) Rename robot config to Bravo LCMT EMSeq Verify Initial Setup
- Feedback Item (4) Remove robot config Bravo LCMT DNA Adp Lig Verification
- Feedback Item (5) Swap beds in robot config Bravo LCMT DNA Adp Lig => LCMT DNA Lib PCR
- Feedback Item (6) Remove robot config Bravo LCMT EM TET2 Stop Verification
- Feedback Item (8) Change position for LCMT EM APOBEC Deam to (4,3) in robot config Bravo LCMT EM TET2 Stop to Denat and Deam Setup
- Feedback Item (9) Remove robot config Bravo LCMT EM APOBEC Deam Verification

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
