### PR TITLE
[reverted] Y24-051: Hide pools tab for stock plates

### DIFF
--- a/app/models/presenters/stock_plate_presenter.rb
+++ b/app/models/presenters/stock_plate_presenter.rb
@@ -13,6 +13,7 @@ module Presenters
     include Presenters::Statemachine::Standard
     include Presenters::StockBehaviour
 
+    self.pooling_tab = ''
     self.allow_well_failure_in_states = []
 
     # Stock style class causes well state to inherit from plate state.

--- a/spec/models/presenters/stock_plate_presenter_spec.rb
+++ b/spec/models/presenters/stock_plate_presenter_spec.rb
@@ -11,4 +11,8 @@ RSpec.describe Presenters::StockPlatePresenter do
   let(:barcode_string) { labware.human_barcode }
 
   it_behaves_like 'a stock presenter'
+
+  it 'prevents the pools tab from being displayed' do
+    expect(subject.pooling_tab).to be ''
+  end
 end


### PR DESCRIPTION
Superceeded by #2119 

#### Changes proposed in this pull request

- Hide pools tab for all stock plates

#### Screenshot

<img width="653" alt="Screenshot 2024-12-10 at 13 02 12" src="https://github.com/user-attachments/assets/f4d82b61-cc57-4313-9c65-a78f880f84e7">


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
