### PR TITLE
Y24-190: Use SS API V2 for Qcable resources

### DIFF
--- a/app/controllers/tag_plates_controller.rb
+++ b/app/controllers/tag_plates_controller.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 # Receives AJAX requests when creating tag plates, returns the
-# plate information eg. lot number, template, status
+# plate information eg. lot number, template
 # The front end makes a decision regarding suitability
 class TagPlatesController < ApplicationController
+  INCLUDES = [:labware, { lot: [{ lot_type: :target_purpose }, :template] }].freeze
+
   def show
-    qcable_resource = Sequencescape::Api::V2::Qcable.find_by(uuid: params[:id])
+    qcable_resource = Sequencescape::Api::V2::Qcable.includes(*INCLUDES).find(uuid: params[:id]).first
     qcable_presenter = Presenters::QcablePresenter.new(qcable_resource)
     respond_to { |format| format.json { render json: { 'qcable' => qcable_presenter } } }
   end

--- a/app/controllers/tag_plates_controller.rb
+++ b/app/controllers/tag_plates_controller.rb
@@ -5,7 +5,8 @@
 # The front end makes a decision regarding suitability
 class TagPlatesController < ApplicationController
   def show
-    qcable = Presenters::QcablePresenter.new(api.qcable.find(params[:id]))
-    respond_to { |format| format.json { render json: { 'qcable' => qcable } } }
+    qcable_resource = Sequencescape::Api::V2::Qcable.find_by(uuid: params[:id])
+    qcable_presenter = Presenters::QcablePresenter.new(qcable_resource)
+    respond_to { |format| format.json { render json: { 'qcable' => qcable_presenter } } }
   end
 end

--- a/app/models/presenters/qcable_presenter.rb
+++ b/app/models/presenters/qcable_presenter.rb
@@ -3,15 +3,31 @@
 module Presenters
   # Used for tag plates / tag 2 tubes. Rendered with default to_json behaviour.
   class QcablePresenter
-    def initialize(qcable) # rubocop:todo Metrics/AbcSize
-      @uuid = qcable.uuid
-      @tag_layout = qcable.lot.template_name
+    def initialize(qcable)
+      init_qcable_attributes(qcable)
+      init_lot_attributes(qcable.lot)
+      init_lot_type_attributes(qcable.lot.lot_type)
+      init_template_attributes(qcable.lot.template)
+    end
+
+    def init_qcable_attributes(qcable)
       @asset_uuid = qcable.asset.uuid
       @state = qcable.state
-      @type = qcable.lot.lot_type_name
-      @qcable_type = qcable.lot.lot_type.qcable_name
-      @template_uuid = qcable.lot.template.uuid
-      @lot_number = qcable.lot.lot_number
+      @uuid = qcable.uuid
+    end
+
+    def init_lot_attributes(lot)
+      @lot_number = lot.lot_number
+    end
+
+    def init_lot_type_attributes(lot_type)
+      @qcable_type = lot_type.target_purpose.name
+      @type = lot_type.name
+    end
+
+    def init_template_attributes(template)
+      @tag_layout = template.name
+      @template_uuid = template.uuid
     end
   end
 end

--- a/app/models/presenters/qcable_presenter.rb
+++ b/app/models/presenters/qcable_presenter.rb
@@ -11,7 +11,7 @@ module Presenters
     end
 
     def init_qcable_attributes(qcable)
-      @asset_uuid = qcable.asset.uuid
+      @asset_uuid = qcable.labware.uuid
       @state = qcable.state
       @uuid = qcable.uuid
     end

--- a/app/sequencescape/sequencescape/api/v2/lot.rb
+++ b/app/sequencescape/sequencescape/api/v2/lot.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# A Lot from sequencescape via the V2 API
+class Sequencescape::Api::V2::Lot < Sequencescape::Api::V2::Base
+  has_one :lot_type
+
+  # The template is is a polymorphic relationship in Sequencescape, but we only want to access the UUID
+  # and so we don't need a specific class since all properties are accessible via the base class.
+  has_one :template, class_name: 'Sequencescape::Api::V2::Base'
+end

--- a/app/sequencescape/sequencescape/api/v2/lot_type.rb
+++ b/app/sequencescape/sequencescape/api/v2/lot_type.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# A LotType from sequencescape via the V2 API
+class Sequencescape::Api::V2::LotType < Sequencescape::Api::V2::Base
+  has_one :target_purpose, class_name: 'Sequencescape::Api::V2::Purpose'
+end

--- a/app/sequencescape/sequencescape/api/v2/purpose.rb
+++ b/app/sequencescape/sequencescape/api/v2/purpose.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class Sequencescape::Api::V2::Purpose < Sequencescape::Api::V2::Base
-  UNKNOWN = 'UNKNOWN'
 end

--- a/app/sequencescape/sequencescape/api/v2/qcable.rb
+++ b/app/sequencescape/sequencescape/api/v2/qcable.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# A Qcable from sequencescape via the V2 API
+class Sequencescape::Api::V2::Qcable < Sequencescape::Api::V2::Base
+  has_one :lot
+  has_one :asset
+end

--- a/app/sequencescape/sequencescape/api/v2/qcable.rb
+++ b/app/sequencescape/sequencescape/api/v2/qcable.rb
@@ -2,6 +2,6 @@
 
 # A Qcable from sequencescape via the V2 API
 class Sequencescape::Api::V2::Qcable < Sequencescape::Api::V2::Base
+  has_one :labware
   has_one :lot
-  has_one :asset
 end

--- a/spec/factories/qcable_factories.rb
+++ b/spec/factories/qcable_factories.rb
@@ -1,6 +1,53 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  # API V2 QCable
+  factory :v2_qcable, class: Sequencescape::Api::V2::Qcable, traits: [:barcoded_v2] do
+    skip_create
+
+    uuid
+    state { 'available' }
+
+    transient do
+      labware { create :v2_plate }
+      lot { create :v2_lot }
+    end
+
+    after(:build) do |qcable, factory|
+      qcable._cached_relationship(:labware) { factory.labware } if factory.labware
+      qcable._cached_relationship(:lot) { factory.lot } if factory.lot
+      qcable._cached_relationship(:asset) { factory.labware } if factory.labware # alias for labware
+    end
+  end
+
+  factory :v2_lot, class: Sequencescape::Api::V2::Lot do
+    skip_create
+
+    sequence(:lot_number) { |n| "UAT12345.#{n}" }
+
+    transient do
+      lot_type { create :v2_lot_type }
+      template { create :v2_tag_layout_template }
+    end
+
+    after(:build) do |lot, factory|
+      lot._cached_relationship(:lot_type) { factory.lot_type } if factory.lot_type
+      lot._cached_relationship(:template) { factory.template } if factory.template
+    end
+  end
+
+  factory :v2_lot_type, class: Sequencescape::Api::V2::LotType do
+    skip_create
+
+    sequence(:name) { |n| "LotType#{n}" }
+
+    transient { target_purpose { create :v2_purpose } }
+
+    after(:build) do |lot_type, factory|
+      lot_type._cached_relationship(:target_purpose) { factory.target_purpose } if factory.target_purpose
+    end
+  end
+
   # API V1 Qcable (Records the QC status of eg. a tag plate)
   factory :qcable, class: Limber::Qcable, traits: %i[api_object barcoded] do
     with_belongs_to_associations 'lot', 'qcable_creator', 'asset'

--- a/spec/features/creating_a_tag_plate_spec.rb
+++ b/spec/features/creating_a_tag_plate_spec.rb
@@ -20,6 +20,7 @@ RSpec.feature 'Creating a tag plate', js: true, tag_plate: true do
       purpose_uuid: 'stock-plate-purpose-uuid'
     )
   end
+  let(:qcable) { create :v2_qcable }
 
   let(:tag_plate_barcode) { SBCF::SangerBarcode.new(prefix: 'DN', number: 2).machine_barcode.to_s }
   let(:tag_plate_qcable_uuid) { 'tag-plate-qcable' }
@@ -91,10 +92,8 @@ RSpec.feature 'Creating a tag plate', js: true, tag_plate: true do
     stub_v2_barcode_printers(create_list(:v2_plate_barcode_printer, 3))
     stub_v2_tag_layout_templates(templates)
 
-    # API v1 UUID requests for a qcable via qcable_presenter.
-    stub_api_get(tag_plate_qcable_uuid, body: tag_plate_qcable)
-    stub_api_get('lot-uuid', body: json(:tag_lot, lot_number: tag_lot_number, template_uuid: tag_template_uuid))
-    stub_api_get('tag-lot-type-uuid', body: json(:tag_lot_type))
+    # API v2 requests for the qcable
+    stub_v2_qcable(qcable)
   end
 
   shared_examples 'it supports the plate' do

--- a/spec/features/creating_a_tag_plate_spec.rb
+++ b/spec/features/creating_a_tag_plate_spec.rb
@@ -91,10 +91,6 @@ RSpec.feature 'Creating a tag plate', js: true, tag_plate: true do
     stub_v2_barcode_printers(create_list(:v2_plate_barcode_printer, 3))
     stub_v2_tag_layout_templates(templates)
 
-    # TODO: {Y24-190} Get rid of these v1 stubs after tag_layout_templates are moved to v2 in tagged_plate.rb
-    stub_api_get(tag_template_uuid, body: json(:tag_layout_template, uuid: tag_template_uuid))
-    stub_api_post(tag_template_uuid, body: json(:tag_layout_template, uuid: tag_template_uuid))
-
     # API v1 UUID requests for a qcable via qcable_presenter.
     stub_api_get(tag_plate_qcable_uuid, body: tag_plate_qcable)
     stub_api_get('lot-uuid', body: json(:tag_lot, lot_number: tag_lot_number, template_uuid: tag_template_uuid))

--- a/spec/support/api_url_helper.rb
+++ b/spec/support/api_url_helper.rb
@@ -262,8 +262,8 @@ module ApiUrlHelper
       arguments = [{ uuid: qcable.uuid }]
       query_builder = double
 
-      allow(query_builder).to receive(:find_by).with(*arguments).and_return(qcable)
       allow(Sequencescape::Api::V2::Qcable).to receive(:includes).and_return(query_builder)
+      allow(query_builder).to receive(:find).with(*arguments).and_return([qcable])
     end
 
     def stub_v2_study(study)

--- a/spec/support/api_url_helper.rb
+++ b/spec/support/api_url_helper.rb
@@ -258,6 +258,14 @@ module ApiUrlHelper
       allow(Sequencescape::Api::V2::QcFile).to receive(:find).with(*arguments).and_return([qc_file])
     end
 
+    def stub_v2_qcable(qcable)
+      arguments = [{ uuid: qcable.uuid }]
+      query_builder = double
+
+      allow(query_builder).to receive(:find_by).with(*arguments).and_return(qcable)
+      allow(Sequencescape::Api::V2::Qcable).to receive(:includes).and_return(query_builder)
+    end
+
     def stub_v2_study(study)
       arguments = [{ name: study.name }]
       allow(Sequencescape::Api::V2::Study).to receive(:find).with(*arguments).and_return([study])


### PR DESCRIPTION
Closes https://github.com/sanger/limber/issues/1818

#### Changes proposed in this pull request

- Pull Qcables from Sequencescape API v2.
- Change which attributes we extract from the Qcable to align with V2 API usage.
- Update tests to match.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  