### PR TITLE
Y24-038 - Changed "Custom Pool Norm" to "Custom Norm" in purposes

### DIFF
--- a/config/pipelines/high_throughput_lcmb.yml
+++ b/config/pipelines/high_throughput_lcmb.yml
@@ -15,4 +15,4 @@ LCMB: # Top of the pipeline (Library Prep)
     LCMB End Prep: LCMB Lib PCR
     LCMB Lib PCR: LCMB Lib PCR-XP
     LCMB Lib PCR-XP: LCMB Custom Pool
-    LCMB Custom Pool: LCMB Custom Pool Norm
+    LCMB Custom Pool: LCMB Custom Norm

--- a/config/purposes/lcmb.yml
+++ b/config/purposes/lcmb.yml
@@ -42,7 +42,7 @@ LCMB Custom Pool:
   :creator_class: LabwareCreators::CustomPooledTubes
   :presenter_class: Presenters::SimpleTubePresenter
   :default_printer_type: :tube
-LCMB Custom Pool Norm:
+LCMB Custom Norm:
   :asset_type: tube
   :target: MultiplexedLibraryTube
   :type: IlluminaHtp::InitialStockTubePurpose


### PR DESCRIPTION
Closes #1656 

#### Changes proposed in this pull request

- Changed the purpose name for `Custom Pool Norm` to `Custom Norm` so it can fit on labels.
- `Custom Pool` has not been changed.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
