### PR TITLE
Remove StateChangeError rescue block

### DIFF
--- a/app/controllers/labware_controller.rb
+++ b/app/controllers/labware_controller.rb
@@ -30,18 +30,13 @@ class LabwareController < ApplicationController
     end
   end
 
-  def update # rubocop:todo Metrics/AbcSize
+  def update
     state_changer.move_to!(*update_params)
 
     notice = +"Labware: #{params[:labware_barcode]} has been changed to a state of #{params[:state].titleize}."
     notice << ' The customer will still be charged.' if update_params[2]
 
     respond_to { |format| format.html { redirect_to(search_path, notice:) } }
-  rescue StateChangers::StateChangeError => e
-    respond_to do |format|
-      format.html { redirect_to(search_path, alert: e.message) }
-      format.csv
-    end
   end
 
   private


### PR DESCRIPTION
Fixes:
![image](https://github.com/user-attachments/assets/7b48d39e-51f3-4a40-a349-f57c2a8bc479)

A follow-on from #2044

#### Changes proposed in this pull request

- Removes rescue for non-existent error type.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
