### PR TITLE
Y24-456 - Tube racks driver file

### DIFF
--- a/app/controllers/tube_racks/tube_racks_exports_controller.rb
+++ b/app/controllers/tube_racks/tube_racks_exports_controller.rb
@@ -43,16 +43,6 @@ class TubeRacks::TubeRacksExportsController < ApplicationController
           select_parameters,
           uuid: params[:limber_tube_rack_id]
         )
-
-    return if @tube_rack.blank?
-
-    # We need to get the plate to be able to access both Tube Racks
-    # for the LRC PBMC Bank plate split driver file
-    @plate =
-      Sequencescape::Api::V2.plate_with_custom_includes(
-        plate_include_parameters,
-        barcode: @tube_rack.ancestors.last.barcode.human
-      )
   end
 
   def include_parameters
@@ -61,10 +51,6 @@ class TubeRacks::TubeRacksExportsController < ApplicationController
 
   def select_parameters
     export.tube_rack_selects || nil
-  end
-
-  def plate_include_parameters
-    export.plate_includes || 'wells'
   end
 
   def ancestor_tube_details(ancestor_results)

--- a/app/controllers/tube_racks/tube_racks_exports_controller.rb
+++ b/app/controllers/tube_racks/tube_racks_exports_controller.rb
@@ -56,7 +56,7 @@ class TubeRacks::TubeRacksExportsController < ApplicationController
   def ancestor_tube_details(ancestor_results)
     ancestor_results.each_with_object({}) do |ancestor_result, tube_list|
       tube = Sequencescape::Api::V2::Tube.find_by(uuid: ancestor_result.uuid)
-      tube_sample_uuid = tube.aliquots.first.sample.uuid
+      tube_sample_uuid = tube&.aliquots&.first&.sample&.uuid
       tube_list[tube_sample_uuid] = tube if tube_sample_uuid.present?
     end
   end

--- a/app/controllers/tube_racks/tube_racks_exports_controller.rb
+++ b/app/controllers/tube_racks/tube_racks_exports_controller.rb
@@ -12,6 +12,7 @@ class TubeRacks::TubeRacksExportsController < ApplicationController
   def show
     @page = params.fetch(:page, 0).to_i
     @workflow = export.workflow
+    @ancestor_tubes = locate_ancestor_tubes
 
     # Set the filename for the export via the ExportsFilenameBehaviour concern
     set_filename(@labware, @page) if export.filename
@@ -42,13 +43,45 @@ class TubeRacks::TubeRacksExportsController < ApplicationController
           select_parameters,
           uuid: params[:limber_tube_rack_id]
         )
+
+    return if @tube_rack.blank?
+
+    # We need to get the plate to be able to access both Tube Racks
+    # for the LRC PBMC Bank plate split driver file
+    @plate =
+      Sequencescape::Api::V2.plate_with_custom_includes(
+        plate_include_parameters,
+        barcode: @tube_rack.ancestors.last.barcode.human
+      )
   end
 
   def include_parameters
-    export.tube_rack_includes || nil
+    export.tube_rack_includes || 'racked_tubes'
   end
 
   def select_parameters
     export.tube_rack_selects || nil
+  end
+
+  def plate_include_parameters
+    export.plate_includes || 'wells'
+  end
+
+  def ancestor_tube_details(ancestor_results)
+    ancestor_results.each_with_object({}) do |ancestor_result, tube_list|
+      tube = Sequencescape::Api::V2::Tube.find_by(uuid: ancestor_result.uuid)
+      tube_sample_uuid = tube.aliquots.first.sample.uuid
+      tube_list[tube_sample_uuid] = tube if tube_sample_uuid.present?
+    end
+  end
+
+  def locate_ancestor_tubes
+    return nil if export.ancestor_tube_purpose.blank?
+
+    ancestor_results = @tube_rack.ancestors.where(purpose_name: export.ancestor_tube_purpose)
+    return nil if ancestor_results.blank?
+
+    # create hash of sample uuid to tube
+    ancestor_tube_details(ancestor_results)
   end
 end

--- a/app/sequencescape/sequencescape/api/v2/tube.rb
+++ b/app/sequencescape/sequencescape/api/v2/tube.rb
@@ -29,8 +29,8 @@ class Sequencescape::Api::V2::Tube < Sequencescape::Api::V2::Base
 
   has_one :custom_metadatum_collection
 
-  has_one :racked_tube, class_name: 'Sequencescape::Api::V2::RackedTube'
-  has_one :tube_rack, through: :racked_tube, class_name: 'Sequencescape::Api::V2::TubeRack'
+  has_many :racked_tubes, class_name: 'Sequencescape::Api::V2::RackedTube'
+  has_many :tube_racks, through: :racked_tube, class_name: 'Sequencescape::Api::V2::TubeRack'
 
   property :created_at, type: :time
   property :updated_at, type: :time

--- a/app/sequencescape/sequencescape/api/v2/tube.rb
+++ b/app/sequencescape/sequencescape/api/v2/tube.rb
@@ -29,8 +29,8 @@ class Sequencescape::Api::V2::Tube < Sequencescape::Api::V2::Base
 
   has_one :custom_metadatum_collection
 
-  has_many :racked_tubes, class_name: 'Sequencescape::Api::V2::RackedTube'
-  has_many :tube_racks, through: :racked_tube, class_name: 'Sequencescape::Api::V2::TubeRack'
+  has_one :racked_tube, class_name: 'Sequencescape::Api::V2::RackedTube'
+  has_one :tube_rack, through: :racked_tube, class_name: 'Sequencescape::Api::V2::TubeRack'
 
   property :created_at, type: :time
   property :updated_at, type: :time

--- a/app/sequencescape/sequencescape/api/v2/tube.rb
+++ b/app/sequencescape/sequencescape/api/v2/tube.rb
@@ -29,11 +29,8 @@ class Sequencescape::Api::V2::Tube < Sequencescape::Api::V2::Base
 
   has_one :custom_metadatum_collection
 
-  has_many :racked_tubes, class_name: 'Sequencescape::Api::V2::RackedTube'
-  has_many :tube_racks, through: :racked_tubes, class_name: 'Sequencescape::Api::V2::TubeRack'
-
-  has_many :racked_tubes, class_name: 'Sequencescape::Api::V2::RackedTube'
-  has_many :tube_racks, through: :racked_tubes, class_name: 'Sequencescape::Api::V2::TubeRack'
+  has_one :racked_tube, class_name: 'Sequencescape::Api::V2::RackedTube'
+  has_one :tube_rack, through: :racked_tube, class_name: 'Sequencescape::Api::V2::TubeRack'
 
   property :created_at, type: :time
   property :updated_at, type: :time

--- a/app/sequencescape/sequencescape/api/v2/tube_rack.rb
+++ b/app/sequencescape/sequencescape/api/v2/tube_rack.rb
@@ -34,6 +34,7 @@ class Sequencescape::Api::V2::TubeRack < Sequencescape::Api::V2::Base
 
   has_many :racked_tubes, class_name: 'Sequencescape::Api::V2::RackedTube'
   has_many :tubes, through: :racked_tubes, class_name: 'Sequencescape::Api::V2::Tube'
+  has_many :ancestors, class_name: 'Sequencescape::Api::V2::Asset'
 
   has_one :custom_metadatum_collection, class_name: 'Sequencescape::Api::V2::CustomMetadatumCollection'
 

--- a/app/views/exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
+++ b/app/views/exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
@@ -34,21 +34,16 @@
     # expecting 1 sample tube
     destination_tube = source_well.downstream_tubes.last
     destination_tube_v2 = Sequencescape::Api::V2.tube_with_custom_includes(
-                            'custom_metadatum_collection',
+                            'racked_tube',
                             nil,
                             barcode: destination_tube.labware_barcode.machine
                           )
 
     # skip if destination tube not found or doesn't have metadata
-    next unless destination_tube_v2 && destination_tube_v2.custom_metadatum_collection
+    next unless destination_tube_v2 && destination_tube_v2.racked_tube
 
-    # get tube metadata from destination tube
-    metadata = destination_tube_v2.custom_metadatum_collection.metadata
-
-    next unless metadata
-
-    tube_rack_barcode = metadata['tube_rack_barcode']
-    tube_rack_position = metadata['tube_rack_position']
+    tube_rack_barcode = destination_tube_v2.racked_tube.tube_rack.barcode
+    tube_rack_position = destination_tube_v2.racked_tube.coordinate
 
     next unless tube_rack_barcode && tube_rack_position
 

--- a/app/views/tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
+++ b/app/views/tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
@@ -21,44 +21,63 @@
 %>
 <%
   rows_array = []
-  @plate.wells_in_columns.each do |source_well|
-    # skip if well empty (not all wells have samples in them)
-    next if source_well.empty?
 
-    # skip if well not in passed state
+  # Function for finding a racked_tube given a tube and set of tube racks
+  def find_racked_tube_in_tube_racks(tube_racks, tube_id)
+    tube_racks.each do |tube_rack|
+      racked_tube = tube_rack.racked_tubes.find { |rt| rt.tube.id == tube_id }
+      return racked_tube if racked_tube
+    end
+    nil
+  end
+
+  # Fetch the parent plate of the tube rack
+  parent_plate =
+      Sequencescape::Api::V2.plate_with_custom_includes(
+        [
+          'wells.downstream_tubes',
+          'wells.transfer_requests_as_source.target_asset'
+        ],
+        barcode: @tube_rack.ancestors.last.barcode.human
+      )
+
+  return if parent_plate.nil?
+
+  # Fetch the tube racks from the parent plate
+  tube_racks = parent_plate.children.map do |tr| 
+    Sequencescape::Api::V2.tube_rack_with_custom_includes(
+      'racked_tubes.tube',
+      nil,
+      barcode: tr.labware_barcode.machine
+    )
+  end
+
+  return if tube_racks.nil?
+
+  parent_plate.wells_in_columns.each do |source_well|
+    next if source_well.empty?
     next unless source_well.passed?
 
-    # skip if no downstream tubes for this well (not set up children in Limber yet)
     next if source_well.downstream_tubes.empty?
 
-    # expecting 1 sample tube
     destination_tube = source_well.downstream_tubes.last
-    destination_tube_v2 = Sequencescape::Api::V2.tube_with_custom_includes(
-                            'racked_tubes',
-                            nil,
-                            barcode: destination_tube.labware_barcode.machine
-                          )
 
-    # skip if destination tube not found or doesn't have metadata
-    next unless destination_tube_v2 && destination_tube_v2.racked_tubes.present?
+    racked_tube = find_racked_tube_in_tube_racks(tube_racks, destination_tube.id)
 
-    tube_rack_barcode = destination_tube_v2.racked_tubes.first.tube_rack.barcode
-    tube_rack_position = destination_tube_v2.racked_tubes.first.coordinate
+    # If this is nil, then the tube is not in the tube racks, likely something has gone wrong
+    next if racked_tube.nil?
 
-    next unless tube_rack_barcode && tube_rack_position
+    tube_rack_barcode = racked_tube.tube_rack.barcode
+    tube_rack_position = racked_tube.coordinate
 
     sample_uuid = source_well.aliquots.first.sample.uuid
-
     source_well_posn = source_well.position['name']
-
-    destination_tube_name_array = destination_tube_v2.name.split(':')
+    destination_tube_name_array = destination_tube.name.split(':')
     # e.g. SEQ:DESTTUBE:A1
-
     purpose = ((destination_tube_name_array[0] == 'SEQ') ? 'Sequencing' : 'Contingency')
-
     # if destination_tube_name_array.length == 3
     rows_array << [
-      @plate.labware_barcode.human,
+      parent_plate.labware_barcode.human,
       source_well_posn,
       tube_rack_barcode,
       purpose,
@@ -67,7 +86,6 @@
       @ancestor_tubes[sample_uuid].labware_barcode.human,
       source_well.aliquots.first.sample.name
     ]
-    # end
   end
 %>
 <% rows_array.sort_by{ |a| WellHelpers.well_coordinate(a[1]) }.each do |row| %>

--- a/app/views/tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
+++ b/app/views/tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
@@ -44,7 +44,7 @@
   return if parent_plate.nil?
 
   # Fetch the tube racks from the parent plate
-  tube_racks = parent_plate.children.map do |tr| 
+  tube_racks = parent_plate.children.select { |child| child.type == 'tube_racks' }.map do |tr|
     Sequencescape::Api::V2.tube_rack_with_custom_includes(
       'racked_tubes.tube',
       nil,

--- a/app/views/tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
+++ b/app/views/tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
@@ -38,7 +38,7 @@
           'wells.downstream_tubes',
           'wells.transfer_requests_as_source.target_asset'
         ],
-        barcode: @tube_rack.ancestors.last.barcode.human
+        barcode: @tube_rack.parents.last.barcode.human
       )
 
   return if parent_plate.nil?

--- a/app/views/tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
+++ b/app/views/tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
@@ -34,16 +34,16 @@
     # expecting 1 sample tube
     destination_tube = source_well.downstream_tubes.last
     destination_tube_v2 = Sequencescape::Api::V2.tube_with_custom_includes(
-                            'racked_tube',
+                            'racked_tubes',
                             nil,
                             barcode: destination_tube.labware_barcode.machine
                           )
 
     # skip if destination tube not found or doesn't have metadata
-    next unless destination_tube_v2 && destination_tube_v2.racked_tube
+    next unless destination_tube_v2 && destination_tube_v2.racked_tubes.present?
 
-    tube_rack_barcode = destination_tube_v2.racked_tube.tube_rack.barcode
-    tube_rack_position = destination_tube_v2.racked_tube.coordinate
+    tube_rack_barcode = destination_tube_v2.racked_tubes.first.tube_rack.barcode
+    tube_rack_position = destination_tube_v2.racked_tubes.first.coordinate
 
     next unless tube_rack_barcode && tube_rack_position
 

--- a/config/exports/exports.yml
+++ b/config/exports/exports.yml
@@ -156,11 +156,7 @@ scrna_core_cell_extraction_sample_arraying_tube_layout:
 hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare:
   csv: hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare
   workflow: scRNA Core PBMC Bank
-  plate_includes:
-    - wells.downstream_tubes
-    - wells.aliquots
-    - wells.aliquots.sample
-    - wells.aliquots.sample.sample_metadata
+  tube_rack_includes: racked_tubes.tube
   ancestor_tube_purpose: LRC Blood Vac
   filename:
     name: hamilton_pbmc_bank

--- a/config/purposes/scrna_core_cell_extraction.yml
+++ b/config/purposes/scrna_core_cell_extraction.yml
@@ -67,9 +67,6 @@ LRC PBMC Bank:
   :file_links:
     - name: 'Download Hamilton LRC Blood Bank plate to LRC PBMC Bank plate CSV'
       id: hamilton_lrc_blood_bank_to_lrc_pbmc_bank
-    - name: 'Download Hamilton LRC PBMC Bank plate to LRC Bank Seq and Spare tubes CSV'
-      id: hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare
-      states: [passed, qc_complete]
     - name: 'Download PBMC Bank Tubes Content Report'
       id: pbmc_bank_tubes_content_report
       states: [passed, qc_complete]
@@ -110,6 +107,8 @@ LRC TR Bank Seq:
       id: tube_rack_concentrations_ngul
     - name: Download Racked Tube Concentrations (nM) CSV
       id: tube_rack_concentrations_nm
+    - name: 'Download Hamilton LRC PBMC Bank plate to LRC Bank Seq and Spare tubes CSV'
+      id: hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare
 # Tube rack for storing LRC Bank Spare tubes
 LRC TR Bank Spare:
   :asset_type: tube_rack
@@ -127,6 +126,8 @@ LRC TR Bank Spare:
       id: tube_rack_concentrations_ngul
     - name: Download Racked Tube Concentrations (nM) CSV
       id: tube_rack_concentrations_nm
+    - name: 'Download Hamilton LRC PBMC Bank plate to LRC Bank Seq and Spare tubes CSV'
+      id: hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare
 # FluidX tube for freezing and output of cell banking protocol
 LRC Bank Seq:
   :asset_type: tube

--- a/spec/factories/tube_factories.rb
+++ b/spec/factories/tube_factories.rb
@@ -117,6 +117,7 @@ FactoryBot.define do
       aliquots { create_list aliquot_factory, aliquot_count, library_state:, outer_request: }
       parents { [] }
       purpose { create :v2_purpose, name: purpose_name, uuid: purpose_uuid }
+      racked_tube { nil }
 
       siblings_count { 0 }
       sibling_default_state { 'passed' }
@@ -156,6 +157,7 @@ FactoryBot.define do
       asset._cached_relationship(:aliquots) { evaluator.aliquots || [] }
       asset._cached_relationship(:parents) { evaluator.parents }
       asset._cached_relationship(:receptacle) { evaluator.receptacle }
+      asset._cached_relationship(:racked_tube) { evaluator.racked_tube }
 
       if evaluator.custom_metadatum_collection
         asset._cached_relationship(:custom_metadatum_collection) { evaluator.custom_metadatum_collection }

--- a/spec/factories/tube_rack_factories.rb
+++ b/spec/factories/tube_rack_factories.rb
@@ -23,6 +23,9 @@ FactoryBot.define do
       # The parent assets
       parents { [] }
 
+      # The ancestor labware
+      ancestors { [] }
+
       racked_tubes do
         tubes.map { |coordinate, tube| create :racked_tube, coordinate: coordinate, tube: tube, tube_rack: instance }
       end

--- a/spec/factories/tube_rack_factories.rb
+++ b/spec/factories/tube_rack_factories.rb
@@ -58,13 +58,19 @@ FactoryBot.define do
 
     id
     coordinate { 'A1' }
-    tube_rack { create :tube_rack }
-    tube { create :v2_tube }
+
+    transient do
+      tube_rack { create :tube_rack }
+      tube { create :v2_tube, racked_tube: instance }
+    end
 
     after(:build) do |racked_tube, evaluator|
       Sequencescape::Api::V2::RackedTube.associations.each do |association|
         racked_tube._cached_relationship(association.attr_name) { evaluator.send(association.attr_name) }
       end
+
+      racked_tube._cached_relationship(:tube_rack) { evaluator.tube_rack }
+      racked_tube._cached_relationship(:tube) { evaluator.tube }
     end
   end
 end

--- a/spec/factories/tube_rack_factories.rb
+++ b/spec/factories/tube_rack_factories.rb
@@ -23,9 +23,6 @@ FactoryBot.define do
       # The parent assets
       parents { [] }
 
-      # The ancestor labware
-      ancestors { [] }
-
       racked_tubes do
         tubes.map { |coordinate, tube| create :racked_tube, coordinate: coordinate, tube: tube, tube_rack: instance }
       end

--- a/spec/views/exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb_spec.rb
+++ b/spec/views/exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb_spec.rb
@@ -71,22 +71,6 @@ RSpec.describe 'exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
     let(:dest_aliquot5) { create(:v2_aliquot, sample: sample2) }
     let(:dest_aliquot6) { create(:v2_aliquot, sample: sample2) }
 
-    # metadata for destination tubes
-    let(:dest_tube1_metadata) { { 'tube_rack_barcode' => 'TR00000001', 'tube_rack_position' => 'A1' } }
-    let(:dest_tube2_metadata) { { 'tube_rack_barcode' => 'TR00000002', 'tube_rack_position' => 'A1' } }
-    let(:dest_tube3_metadata) { { 'tube_rack_barcode' => 'TR00000002', 'tube_rack_position' => 'B1' } }
-    let(:dest_tube4_metadata) { { 'tube_rack_barcode' => 'TR00000001', 'tube_rack_position' => 'B1' } }
-    let(:dest_tube5_metadata) { { 'tube_rack_barcode' => 'TR00000002', 'tube_rack_position' => 'C1' } }
-    let(:dest_tube6_metadata) { { 'tube_rack_barcode' => 'TR00000002', 'tube_rack_position' => 'D1' } }
-
-    # custom metadata collections for destination tubes
-    let(:dest_tube1_custom_metadata) { create(:custom_metadatum_collection, metadata: dest_tube1_metadata) }
-    let(:dest_tube2_custom_metadata) { create(:custom_metadatum_collection, metadata: dest_tube2_metadata) }
-    let(:dest_tube3_custom_metadata) { create(:custom_metadatum_collection, metadata: dest_tube3_metadata) }
-    let(:dest_tube4_custom_metadata) { create(:custom_metadatum_collection, metadata: dest_tube4_metadata) }
-    let(:dest_tube5_custom_metadata) { create(:custom_metadatum_collection, metadata: dest_tube5_metadata) }
-    let(:dest_tube6_custom_metadata) { create(:custom_metadatum_collection, metadata: dest_tube6_metadata) }
-
     # destination tube uuids
     let(:dest_tube1_uuid) { SecureRandom.uuid }
     let(:dest_tube2_uuid) { SecureRandom.uuid }
@@ -95,71 +79,75 @@ RSpec.describe 'exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
     let(:dest_tube5_uuid) { SecureRandom.uuid }
     let(:dest_tube6_uuid) { SecureRandom.uuid }
 
+    # Tube racks
+    let(:seq_tube_rack) { create(:tube_rack) }
+    let(:spr_tube_rack) { create(:tube_rack) }
+
     # destination tubes
     let(:dest_tube1) do
       create(
-        :v2_tube_with_metadata,
+        :v2_tube,
         uuid: dest_tube1_uuid,
         barcode_prefix: 'FX',
         barcode_number: 4,
         aliquots: [dest_aliquot1],
         name: 'SEQ:NT1O:A1',
-        custom_metadatum_collection: dest_tube1_custom_metadata
+        racked_tube: create(:racked_tube, coordinate: 'A1', tube_rack: seq_tube_rack)
       )
     end
     let(:dest_tube2) do
       create(
-        :v2_tube_with_metadata,
+        :v2_tube,
         uuid: dest_tube2_uuid,
         barcode_prefix: 'FX',
         barcode_number: 5,
         aliquots: [dest_aliquot2],
         name: 'SPR:NT1O:A1',
-        custom_metadatum_collection: dest_tube2_custom_metadata
+        racked_tube: create(:racked_tube, coordinate: 'A1', tube_rack: spr_tube_rack)
       )
     end
     let(:dest_tube3) do
       create(
-        :v2_tube_with_metadata,
+        :v2_tube,
         uuid: dest_tube3_uuid,
         barcode_prefix: 'FX',
         barcode_number: 6,
         aliquots: [dest_aliquot3],
         name: 'SPR:NT1O:B1',
-        custom_metadatum_collection: dest_tube3_custom_metadata
+        racked_tube: create(:racked_tube, coordinate: 'B1', tube_rack: spr_tube_rack)
       )
     end
     let(:dest_tube4) do
       create(
-        :v2_tube_with_metadata,
+        :v2_tube,
         uuid: dest_tube4_uuid,
         barcode_prefix: 'FX',
         barcode_number: 7,
         aliquots: [dest_aliquot4],
         name: 'SEQ:NT2P:B1',
-        custom_metadatum_collection: dest_tube4_custom_metadata
+        racked_tube: create(:racked_tube, coordinate: 'B1', tube_rack: seq_tube_rack)
       )
     end
     let(:dest_tube5) do
       create(
-        :v2_tube_with_metadata,
+        :v2_tube,
         uuid: dest_tube5_uuid,
         barcode_prefix: 'FX',
         barcode_number: 8,
         aliquots: [dest_aliquot5],
         name: 'SPR:NT2P:C1',
-        custom_metadatum_collection: dest_tube5_custom_metadata
+        racked_tube: create(:racked_tube, coordinate: 'C1', tube_rack: spr_tube_rack)
       )
     end
     let(:dest_tube6) do
       create(
-        :v2_tube_with_metadata,
+        :v2_tube,
         uuid: dest_tube6_uuid,
         barcode_prefix: 'FX',
         barcode_number: 9,
         aliquots: [dest_aliquot6],
         name: 'SPR:NT2P:D1',
-        custom_metadatum_collection: dest_tube6_custom_metadata
+        racked_tube: create(:racked_tube, coordinate: 'D1', tube_rack: spr_tube_rack)
       )
     end
 
@@ -181,12 +169,12 @@ RSpec.describe 'exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
           'Sample Vac Tube ID',
           'Sample Name'
         ],
-        %w[DN3U A1 TR00000001 Sequencing FX4B A1 NT1O Sample1],
-        %w[DN3U B1 TR00000001 Sequencing FX7E B1 NT2P Sample2],
-        %w[DN3U A2 TR00000002 Contingency FX5C A1 NT1O Sample1],
-        %w[DN3U B2 TR00000002 Contingency FX8F C1 NT2P Sample2],
-        %w[DN3U A3 TR00000002 Contingency FX6D B1 NT1O Sample1],
-        %w[DN3U B3 TR00000002 Contingency FX9G D1 NT2P Sample2]
+        ['DN3U', 'A1', seq_tube_rack.human_barcode, 'Sequencing', 'FX4B', 'A1', 'NT1O', 'Sample1'],
+        ['DN3U', 'B1', seq_tube_rack.human_barcode, 'Sequencing', 'FX7E', 'B1', 'NT2P', 'Sample2'],
+        ['DN3U', 'A2', spr_tube_rack.human_barcode, 'Contingency', 'FX5C', 'A1', 'NT1O', 'Sample1'],
+        ['DN3U', 'B2', spr_tube_rack.human_barcode, 'Contingency', 'FX8F', 'C1', 'NT2P', 'Sample2'],
+        ['DN3U', 'A3', spr_tube_rack.human_barcode, 'Contingency', 'FX6D', 'B1', 'NT1O', 'Sample1'],
+        ['DN3U', 'B3', spr_tube_rack.human_barcode, 'Contingency', 'FX9G', 'D1', 'NT2P', 'Sample2']
       ]
     end
 
@@ -196,7 +184,7 @@ RSpec.describe 'exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
       assign(:workflow, workflow_name)
 
       # stub the v2 child tube lookups
-      custom_includes = 'custom_metadatum_collection'
+      custom_includes = 'racked_tube'
       dest_tubes = [dest_tube1, dest_tube2, dest_tube3, dest_tube4, dest_tube5, dest_tube6]
 
       dest_tubes.each do |dest_tube|
@@ -244,7 +232,7 @@ RSpec.describe 'exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
       end
     end
 
-    context 'when destination tubes have no custom metadatum collection' do
+    context 'when destination tubes have no racked_tubes' do
       let(:dest_tube1) do
         create(
           :v2_tube,
@@ -253,7 +241,7 @@ RSpec.describe 'exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
           barcode_number: 4,
           aliquots: [dest_aliquot1],
           name: 'SEQ:NT1O:A1',
-          custom_metadatum_collection: nil
+          racked_tube: nil
         )
       end
       let(:dest_tube2) do
@@ -264,7 +252,7 @@ RSpec.describe 'exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
           barcode_number: 5,
           aliquots: [dest_aliquot2],
           name: 'SPR:NT1O:A1',
-          custom_metadatum_collection: nil
+          racked_tube: nil
         )
       end
       let(:dest_tube3) do
@@ -275,7 +263,7 @@ RSpec.describe 'exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
           barcode_number: 6,
           aliquots: [dest_aliquot3],
           name: 'SPR:NT1O:B1',
-          custom_metadatum_collection: nil
+          racked_tube: nil
         )
       end
       let(:dest_tube4) do
@@ -286,7 +274,7 @@ RSpec.describe 'exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
           barcode_number: 7,
           aliquots: [dest_aliquot4],
           name: 'SEQ:NT2P:B1',
-          custom_metadatum_collection: nil
+          racked_tube: nil
         )
       end
       let(:dest_tube5) do
@@ -297,7 +285,7 @@ RSpec.describe 'exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
           barcode_number: 8,
           aliquots: [dest_aliquot5],
           name: 'SPR:NT2P:C1',
-          custom_metadatum_collection: nil
+          racked_tube: nil
         )
       end
       let(:dest_tube6) do
@@ -308,99 +296,7 @@ RSpec.describe 'exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb
           barcode_number: 9,
           aliquots: [dest_aliquot6],
           name: 'SPR:NT2P:D1',
-          custom_metadatum_collection: nil
-        )
-      end
-
-      let(:expected_content) do
-        [
-          ['Workflow', workflow_name],
-          [],
-          [
-            'Source Plate ID',
-            'Source Plate Well',
-            'Destination Rack',
-            'Purpose',
-            'Destination Tube ID',
-            'Destination Tube Position',
-            'Sample Vac Tube ID',
-            'Sample Name'
-          ]
-        ]
-      end
-
-      it 'does not show sample rows' do
-        expect(CSV.parse(render)).to eq(expected_content)
-      end
-    end
-
-    context 'when destination tubes have inappropriate metadata' do
-      let(:useless_custom_metadata) { create(:custom_metadatum_collection, metadata: { 'somekey' => 'somevalue' }) }
-
-      let(:dest_tube1) do
-        create(
-          :v2_tube_with_metadata,
-          uuid: dest_tube1_uuid,
-          barcode_prefix: 'FX',
-          barcode_number: 4,
-          aliquots: [dest_aliquot1],
-          name: 'SEQ:NT1O:A1',
-          custom_metadatum_collection: useless_custom_metadata
-        )
-      end
-      let(:dest_tube2) do
-        create(
-          :v2_tube_with_metadata,
-          uuid: dest_tube2_uuid,
-          barcode_prefix: 'FX',
-          barcode_number: 5,
-          aliquots: [dest_aliquot2],
-          name: 'SPR:NT1O:A1',
-          custom_metadatum_collection: useless_custom_metadata
-        )
-      end
-      let(:dest_tube3) do
-        create(
-          :v2_tube_with_metadata,
-          uuid: dest_tube3_uuid,
-          barcode_prefix: 'FX',
-          barcode_number: 6,
-          aliquots: [dest_aliquot3],
-          name: 'SPR:NT1O:B1',
-          custom_metadatum_collection: useless_custom_metadata
-        )
-      end
-      let(:dest_tube4) do
-        create(
-          :v2_tube_with_metadata,
-          uuid: dest_tube4_uuid,
-          barcode_prefix: 'FX',
-          barcode_number: 7,
-          aliquots: [dest_aliquot4],
-          name: 'SEQ:NT2P:B1',
-          custom_metadatum_collection: useless_custom_metadata
-        )
-      end
-      let(:dest_tube5) do
-        create(
-          :v2_tube_with_metadata,
-          uuid: dest_tube5_uuid,
-          barcode_prefix: 'FX',
-          barcode_number: 8,
-          aliquots: [dest_aliquot5],
-          name: 'SPR:NT2P:C1',
-          custom_metadatum_collection: useless_custom_metadata
-        )
-      end
-      let(:dest_tube6) do
-        create(
-          :v2_tube_with_metadata,
-          uuid: dest_tube6_uuid,
-          barcode_prefix: 'FX',
-          barcode_number: 9,
-          aliquots: [dest_aliquot6],
-          name: 'SPR:NT2P:D1',
-          custom_metadatum_collection: useless_custom_metadata
+          racked_tube: nil
         )
       end
 

--- a/spec/views/tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb_spec.rb
+++ b/spec/views/tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb' do
+RSpec.describe 'tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb' do
   include FeatureHelpers
 
   context 'when creating a hamilton driver file csv' do

--- a/spec/views/tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb_spec.rb
+++ b/spec/views/tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb_spec.rb
@@ -71,84 +71,30 @@ RSpec.describe 'tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank
     let(:dest_aliquot5) { create(:v2_aliquot, sample: sample2) }
     let(:dest_aliquot6) { create(:v2_aliquot, sample: sample2) }
 
-    # destination tube uuids
-    let(:dest_tube1_uuid) { SecureRandom.uuid }
-    let(:dest_tube2_uuid) { SecureRandom.uuid }
-    let(:dest_tube3_uuid) { SecureRandom.uuid }
-    let(:dest_tube4_uuid) { SecureRandom.uuid }
-    let(:dest_tube5_uuid) { SecureRandom.uuid }
-    let(:dest_tube6_uuid) { SecureRandom.uuid }
-
-    # Tube racks
-    let(:seq_tube_rack) { create(:tube_rack) }
-    let(:spr_tube_rack) { create(:tube_rack) }
-
     # destination tubes
     let(:dest_tube1) do
-      create(
-        :v2_tube,
-        uuid: dest_tube1_uuid,
-        barcode_prefix: 'FX',
-        barcode_number: 4,
-        aliquots: [dest_aliquot1],
-        name: 'SEQ:NT1O:A1',
-        racked_tube: create(:racked_tube, coordinate: 'A1', tube_rack: seq_tube_rack)
-      )
+      create(:v2_tube, barcode_prefix: 'FX', barcode_number: 4, aliquots: [dest_aliquot1], name: 'SEQ:NT1O:A1')
     end
     let(:dest_tube2) do
-      create(
-        :v2_tube,
-        uuid: dest_tube2_uuid,
-        barcode_prefix: 'FX',
-        barcode_number: 5,
-        aliquots: [dest_aliquot2],
-        name: 'SPR:NT1O:A1',
-        racked_tube: create(:racked_tube, coordinate: 'A1', tube_rack: spr_tube_rack)
-      )
+      create(:v2_tube, barcode_prefix: 'FX', barcode_number: 5, aliquots: [dest_aliquot2], name: 'SPR:NT1O:A1')
     end
     let(:dest_tube3) do
-      create(
-        :v2_tube,
-        uuid: dest_tube3_uuid,
-        barcode_prefix: 'FX',
-        barcode_number: 6,
-        aliquots: [dest_aliquot3],
-        name: 'SPR:NT1O:B1',
-        racked_tube: create(:racked_tube, coordinate: 'B1', tube_rack: spr_tube_rack)
-      )
+      create(:v2_tube, barcode_prefix: 'FX', barcode_number: 6, aliquots: [dest_aliquot3], name: 'SPR:NT1O:B1')
     end
     let(:dest_tube4) do
-      create(
-        :v2_tube,
-        uuid: dest_tube4_uuid,
-        barcode_prefix: 'FX',
-        barcode_number: 7,
-        aliquots: [dest_aliquot4],
-        name: 'SEQ:NT2P:B1',
-        racked_tube: create(:racked_tube, coordinate: 'B1', tube_rack: seq_tube_rack)
-      )
+      create(:v2_tube, barcode_prefix: 'FX', barcode_number: 7, aliquots: [dest_aliquot4], name: 'SEQ:NT2P:B1')
     end
     let(:dest_tube5) do
-      create(
-        :v2_tube,
-        uuid: dest_tube5_uuid,
-        barcode_prefix: 'FX',
-        barcode_number: 8,
-        aliquots: [dest_aliquot5],
-        name: 'SPR:NT2P:C1',
-        racked_tube: create(:racked_tube, coordinate: 'C1', tube_rack: spr_tube_rack)
-      )
+      create(:v2_tube, barcode_prefix: 'FX', barcode_number: 8, aliquots: [dest_aliquot5], name: 'SPR:NT2P:C1')
     end
     let(:dest_tube6) do
-      create(
-        :v2_tube,
-        uuid: dest_tube6_uuid,
-        barcode_prefix: 'FX',
-        barcode_number: 9,
-        aliquots: [dest_aliquot6],
-        name: 'SPR:NT2P:D1',
-        racked_tube: create(:racked_tube, coordinate: 'D1', tube_rack: spr_tube_rack)
-      )
+      create(:v2_tube, barcode_prefix: 'FX', barcode_number: 9, aliquots: [dest_aliquot6], name: 'SPR:NT2P:D1')
+    end
+
+    # Tube racks
+    let(:seq_tube_rack) { create(:tube_rack, tubes: { A1: dest_tube1, B1: dest_tube4 }) }
+    let(:spr_tube_rack) do
+      create(:tube_rack, tubes: { A1: dest_tube2, B1: dest_tube3, C1: dest_tube5, D1: dest_tube6 })
     end
 
     # workflow
@@ -239,71 +185,25 @@ RSpec.describe 'tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank
       end
     end
 
-    context 'when destination tubes have no racked_tubes' do
-      let(:dest_tube1) do
+    context 'when destination tubes are not in the tube_rack' do
+      # Setup the tube racks to have different tubes that the ones from the downstream tubes
+      let(:seq_tube_rack) do
         create(
-          :v2_tube,
-          uuid: dest_tube1_uuid,
-          barcode_prefix: 'FX',
-          barcode_number: 4,
-          aliquots: [dest_aliquot1],
-          name: 'SEQ:NT1O:A1',
-          racked_tube: nil
+          :tube_rack,
+          tubes: {
+            A1: create(:v2_tube, barcode_prefix: 'FX', barcode_number: 7),
+            B1: create(:v2_tube, barcode_prefix: 'FX', barcode_number: 7)
+          }
         )
       end
-      let(:dest_tube2) do
+
+      let(:spr_tube_rack) do
         create(
-          :v2_tube,
-          uuid: dest_tube2_uuid,
-          barcode_prefix: 'FX',
-          barcode_number: 5,
-          aliquots: [dest_aliquot2],
-          name: 'SPR:NT1O:A1',
-          racked_tube: nil
-        )
-      end
-      let(:dest_tube3) do
-        create(
-          :v2_tube,
-          uuid: dest_tube3_uuid,
-          barcode_prefix: 'FX',
-          barcode_number: 6,
-          aliquots: [dest_aliquot3],
-          name: 'SPR:NT1O:B1',
-          racked_tube: nil
-        )
-      end
-      let(:dest_tube4) do
-        create(
-          :v2_tube,
-          uuid: dest_tube4_uuid,
-          barcode_prefix: 'FX',
-          barcode_number: 7,
-          aliquots: [dest_aliquot4],
-          name: 'SEQ:NT2P:B1',
-          racked_tube: nil
-        )
-      end
-      let(:dest_tube5) do
-        create(
-          :v2_tube,
-          uuid: dest_tube5_uuid,
-          barcode_prefix: 'FX',
-          barcode_number: 8,
-          aliquots: [dest_aliquot5],
-          name: 'SPR:NT2P:C1',
-          racked_tube: nil
-        )
-      end
-      let(:dest_tube6) do
-        create(
-          :v2_tube,
-          uuid: dest_tube6_uuid,
-          barcode_prefix: 'FX',
-          barcode_number: 9,
-          aliquots: [dest_aliquot6],
-          name: 'SPR:NT2P:D1',
-          racked_tube: nil
+          :tube_rack,
+          tubes: {
+            A1: create(:v2_tube, barcode_prefix: 'FX', barcode_number: 7),
+            B1: create(:v2_tube, barcode_prefix: 'FX', barcode_number: 7)
+          }
         )
       end
 

--- a/spec/views/tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb_spec.rb
+++ b/spec/views/tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare.csv.erb_spec.rb
@@ -92,9 +92,18 @@ RSpec.describe 'tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank
     end
 
     # Tube racks
-    let(:seq_tube_rack) { create(:tube_rack, tubes: { A1: dest_tube1, B1: dest_tube4 }) }
+    let(:seq_tube_rack) { create(:tube_rack, tubes: { A1: dest_tube1, B1: dest_tube4 }, parents: [source_labware]) }
     let(:spr_tube_rack) do
-      create(:tube_rack, tubes: { A1: dest_tube2, B1: dest_tube3, C1: dest_tube5, D1: dest_tube6 })
+      create(
+        :tube_rack,
+        tubes: {
+          A1: dest_tube2,
+          B1: dest_tube3,
+          C1: dest_tube5,
+          D1: dest_tube6
+        },
+        parents: [source_labware]
+      )
     end
 
     # workflow
@@ -129,7 +138,6 @@ RSpec.describe 'tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank
       assign(:tube_rack, seq_tube_rack)
       assign(:workflow, workflow_name)
 
-      allow(seq_tube_rack).to receive(:ancestors).and_return([source_labware])
       allow(source_labware).to receive(:children).and_return([seq_tube_rack, spr_tube_rack])
 
       # stub the v2 tube rack lookup
@@ -193,7 +201,8 @@ RSpec.describe 'tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank
           tubes: {
             A1: create(:v2_tube, barcode_prefix: 'FX', barcode_number: 7),
             B1: create(:v2_tube, barcode_prefix: 'FX', barcode_number: 7)
-          }
+          },
+          parents: [source_labware]
         )
       end
 
@@ -203,7 +212,8 @@ RSpec.describe 'tube_racks/tube_racks_exports/hamilton_lrc_pbmc_bank_to_lrc_bank
           tubes: {
             A1: create(:v2_tube, barcode_prefix: 'FX', barcode_number: 7),
             B1: create(:v2_tube, barcode_prefix: 'FX', barcode_number: 7)
-          }
+          },
+          parents: [source_labware]
         )
       end
 


### PR DESCRIPTION
Closes #2070 

#### Changes proposed in this pull request

- Updates `hamilton_lrc_pbmc_bank_to_lrc_bank_seq_and_spare` driver file to use tube racks.

#### Notes

- Linked Sequencescape PR: https://github.com/sanger/sequencescape/pull/4675
- Linked Integration Suite PR: https://gitlab.internal.sanger.ac.uk/psd/integration-suite/-/merge_requests/218
