### PR TITLE
Y25-101 Display visual reminder LRC GEM-X 5p GEMs Input CITE plates

### DIFF
--- a/app/frontend/stylesheets/limber/screen.scss
+++ b/app/frontend/stylesheets/limber/screen.scss
@@ -573,6 +573,19 @@ footer.version-info {
   }
 }
 
+.asset-info {
+  @extend .card-body;
+  @extend .bg-info;
+  @extend .text-white;
+
+  h3 {
+    @extend .col-xl-3;
+  }
+  ul {
+    @extend .col-xl-9;
+  }
+}
+
 .aliquot.suboptimal {
   position: relative;
 }

--- a/app/models/presenters/presenter.rb
+++ b/app/models/presenters/presenter.rb
@@ -20,7 +20,6 @@ module Presenters::Presenter # rubocop:todo Style/Documentation
     self.summary_partial = ''
     self.pooling_tab = ''
 
-
     def csv
       purpose_config[:csv_template]
     end
@@ -112,5 +111,4 @@ module Presenters::Presenter # rubocop:todo Style/Documentation
   def info_messages
     @info_messages
   end
-
 end

--- a/app/models/presenters/presenter.rb
+++ b/app/models/presenters/presenter.rb
@@ -12,7 +12,7 @@ module Presenters::Presenter # rubocop:todo Style/Documentation
 
     class_attribute :summary_items, :sidebar_partial, :summary_partial, :pooling_tab
 
-    attr_accessor :labware
+    attr_accessor :labware, :info_messages
 
     self.page = 'show'
     self.sidebar_partial = 'default'
@@ -20,12 +20,18 @@ module Presenters::Presenter # rubocop:todo Style/Documentation
     self.summary_partial = ''
     self.pooling_tab = ''
 
+
     def csv
       purpose_config[:csv_template]
     end
   end
 
   delegate :state, :uuid, :id, :purpose_name, to: :labware
+
+  def initialize(*args)
+    super
+    @info_messages = []
+  end
 
   def suggest_library_passing?
     active_pipelines.any? { |pl| pl.library_pass?(purpose_name) }
@@ -98,4 +104,13 @@ module Presenters::Presenter # rubocop:todo Style/Documentation
     end
     metadata.present? ? metadata.fetch('stock_barcode', barcode) : 'N/A'
   end
+
+  def add_info_message(message)
+    @info_messages << message
+  end
+
+  def info_messages
+    @info_messages
+  end
+
 end

--- a/app/models/presenters/stock_plate_presenter_with_info.rb
+++ b/app/models/presenters/stock_plate_presenter_with_info.rb
@@ -8,8 +8,10 @@ module Presenters
   class StockPlatePresenterWithInfo < StockPlatePresenter
     def initialize(*args)
       super
-      add_info_message("Please ensure you use the CITE-seq-compatible primer " \
-                       "when working with 'LRC GEM-X 5p GEMs Input CITE' plates")
+      add_info_message(
+        'Please ensure you use the CITE-seq-compatible primer ' \
+          "when working with 'LRC GEM-X 5p GEMs Input CITE' plates"
+      )
     end
   end
 end

--- a/app/models/presenters/stock_plate_presenter_with_info.rb
+++ b/app/models/presenters/stock_plate_presenter_with_info.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+#
+module Presenters
+  # A stock plate presenter with additional informational messages.
+  # This subclass of StockPlatePresenter adds specific informational messages
+  # to provide additional context information to the user.
+  class StockPlatePresenterWithInfo < StockPlatePresenter
+    def initialize(*args)
+      super
+      add_info_message("Please ensure you use the CITE-seq-compatible primer " \
+                       "when working with 'LRC GEM-X 5p GEMs Input CITE' plates")
+    end
+  end
+end

--- a/app/views/application/_info.html.erb
+++ b/app/views/application/_info.html.erb
@@ -1,0 +1,12 @@
+<% if @presenter.respond_to?(:info_messages) && @presenter.info_messages.present? %>
+  <div class="asset-info">
+    <div class="row">
+      <h3>Information:</h3>
+      <ul>
+        <% @presenter.info_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>

--- a/app/views/plates/show.html.erb
+++ b/app/views/plates/show.html.erb
@@ -5,6 +5,7 @@
     <%= card without_block: true, id: 'main-content' do %>
       <%= render 'content_header', presenter: @presenter, type: 'plate' %>
       <%= render 'warnings', presenter: @presenter %>
+      <%= render 'info', presenter: @presenter %>
       <% if @presenter.well_failing_applicable? %>
         <div id="labware-well-failing" class='well-fail-toggle collapse'>
           <%= render 'fail_wells', presenter: @presenter %>

--- a/config/purposes/scrna_core_cdna_prep.yml
+++ b/config/purposes/scrna_core_cdna_prep.yml
@@ -130,3 +130,9 @@ LRC GEM-X 5p cDNA Input:
   :presenter_class: Presenters::StockPlatePresenter
   # will not be creatable in Limber (created by manifest in Sequencescape)
   :creator_class: LabwareCreators::Uncreatable
+LRC GEM-X 5p GEMs Input CITE:
+  :asset_type: plate
+  :stock_plate: true
+  :input_plate: true
+  :presenter_class: Presenters::StockPlatePresenterWithInfo
+  :creator_class: LabwareCreators::Uncreatable

--- a/spec/models/presenters/shared_labware_presenter_examples.rb
+++ b/spec/models/presenters/shared_labware_presenter_examples.rb
@@ -24,6 +24,10 @@ RSpec.shared_examples 'a labware presenter' do
   it 'responds to child_assets' do
     expect(subject).to respond_to(:child_assets)
   end
+
+  it 'initializes with an empty array' do
+    expect(subject.info_messages).to eq([])
+  end
 end
 
 RSpec.shared_examples 'a stock presenter' do

--- a/spec/models/presenters/stock_plate_presenter_with_info_spec.rb
+++ b/spec/models/presenters/stock_plate_presenter_with_info_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+#
+require 'spec_helper'
+require_relative 'shared_labware_presenter_examples'
+
+RSpec.describe Presenters::StockPlatePresenterWithInfo do
+  let(:labware) { create :v2_stock_plate }
+
+  subject { Presenters::StockPlatePresenterWithInfo.new(labware:) }
+
+  let(:barcode_string) { labware.human_barcode }
+
+  it_behaves_like 'a stock presenter'
+
+  it 'initializes with informational messages' do
+    expected_messages = [
+      "Please ensure you use the CITE-seq-compatible primer when working with 'LRC GEM-X 5p GEMs Input CITE' plates"
+    ]
+    expect(subject.info_messages).to match_array(expected_messages)
+  end
+end


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

 Displays an info box on the plate page for 'LRC GEM-X 5p GEMs Input CITE' plates to remind users to use the CITE-seq-compatible primer. The message displayed is:

"Please ensure you use the CITE-seq-compatible primer when working with 'LRC GEM-X 5p GEMs Input CITE' plates."

The following changes have been made:
Added info_messages and associated methods for retrieving and adding information messages in base Presenter class.
Created a specialized presenter for 'LRC GEM-X 5p GEMs Input CITE' plates, which adds the information message upon initialization.
HTML Updates:

- Added new HTML to display info_messages if defined in the Presenter class.
- Updated the presenter page HTML to include the info message display.
- Added a new css  style for the blue info box.
![Screenshot 2025-02-27 at 10 29 08](https://github.com/user-attachments/assets/11db95ee-7bae-43a3-9f73-afcbdb3238fa)

#### Instructions for Reviewers
The story says the message to be displayed is to be confirmed. So please confirm if the is appropriate.


_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
