### PR TITLE
Y25-241

### DIFF
--- a/app/models/ongoing_plate.rb
+++ b/app/models/ongoing_plate.rb
@@ -21,7 +21,7 @@ class OngoingPlate < AssetSearchForm
   # @note
   # This is currently only being used by the SearchController, as other usages pass in `purposes`,
   #   and therefore don't use the default_purposes method.
-  #   We are returning an empty array here, becuase there are hundreads of plate purposes in the database,
+  #   We are returning an empty array here, because there are hundreds of plate purposes in the database,
   #   and the GET query was exceeding the maximum number of bytes.
   #   Instead, the page can load, then the user can then select a purpose from the list, which will be paginated.
   def default_purposes

--- a/app/models/ongoing_plate.rb
+++ b/app/models/ongoing_plate.rb
@@ -18,7 +18,13 @@ class OngoingPlate < AssetSearchForm
     { page: page, per_page: PER_PAGE }
   end
 
+  # @note
+  # This is currently only being used by the SearchController, as other usages pass in `purposes`,
+  #   and therefore don't use the default_purposes method.
+  #   We are returning an empty array here, becuase there are hundreads of plate purposes in the database,
+  #   and the GET query was exceeding the maximum number of bytes.
+  #   Instead, the page can load, then the user can then select a purpose from the list, which will be paginated.
   def default_purposes
-    Settings.purposes.select { |_uuid, settings| settings[:asset_type] == 'plate' }.keys
+    []
   end
 end

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -65,11 +65,7 @@ RSpec.describe SearchController, type: :controller do
       let(:result) { create :v2_plate }
       context 'without parameters' do
         let(:search_parameters) do
-          {
-            state: %w[pending started passed qc_complete failed cancelled],
-            purpose_name: %w[purpose-config minimal-purpose-config],
-            include_used: false
-          }
+          { state: %w[pending started passed qc_complete failed cancelled], purpose_name: [], include_used: false }
         end
 
         it 'finds all plates' do
@@ -82,11 +78,7 @@ RSpec.describe SearchController, type: :controller do
 
       context 'with parameters' do
         let(:search_parameters) do
-          {
-            state: %w[pending started passed qc_complete failed cancelled],
-            purpose_name: %w[purpose-config minimal-purpose-config],
-            include_used: true
-          }
+          { state: %w[pending started passed qc_complete failed cancelled], purpose_name: [], include_used: true }
         end
 
         it 'finds specified plates' do

--- a/spec/features/viewing_inboxes_spec.rb
+++ b/spec/features/viewing_inboxes_spec.rb
@@ -23,11 +23,7 @@ RSpec.feature 'Viewing an inbox', js: true do
 
     stub_find_all_with_pagination(
       :plates,
-      {
-        state: %w[pending started passed qc_complete failed cancelled],
-        purpose_name: %w[purpose-config minimal-purpose-config],
-        include_used: false
-      },
+      { state: %w[pending started passed qc_complete failed cancelled], purpose_name: [], include_used: false },
       { page: 1, per_page: 30 },
       [plate_1, plate_2, plate_3]
     )


### PR DESCRIPTION
Closes #2301 

#### Changes proposed in this pull request

-   Default plate purposes to an empty array, because there are hundreds of plate purposes in the database, and the GET query was exceeding the maximum number of bytes. Instead, the page can load, then the user can then select a purpose from the list, which will be paginated.
- Intergration Suite (on Training) passed [here](https://gitlab.internal.sanger.ac.uk/psd/integration-suite/-/pipelines/375373)  

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
