### PR TITLE
[dev] Hide Hashie Mash key-conflict warnings

### DIFF
--- a/config/initializers/settings.rb
+++ b/config/initializers/settings.rb
@@ -19,6 +19,7 @@ class Settings
       # Immutability is good here though, so we should probably fix that.
       # Added flag onto safe_load to allow read of anchors (aliases) in yml files.
       @instance = File.open(configuration_filename, 'r:bom|utf-8') do |config_file_descriptor|
+        # Silence verbose warnings about reused parameters while a better long-term solution is implemented
         Hashie::Mash.quiet(:max, :min, :size, :class).new(
           YAML.safe_load(config_file_descriptor, permitted_classes: [Symbol], aliases: true)
         )


### PR DESCRIPTION
Reduces log length and developer frustration.

#### Changes proposed in this pull request

Implements: https://www.rubydoc.info/gems/hashie/Hashie%2FMash.quiet

- Hide warning conflicts for keys: `min`, `max`, `size`, `class` in developer logs.
  ```txt
  2025-04-16 10:40:43 W, [2025-04-16T09:40:43.446142 #1]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#size defined in Hash. This can cause unexpected behavior when accessing the key as a property. You can still access the key via the #[] method.
  2025-04-16 10:40:43 W, [2025-04-16T09:40:43.446582 #1]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#size defined in Hash. This can cause unexpected behavior when accessing the key as a property. You can still access the key via the #[] method.
  2025-04-16 10:40:43 W, [2025-04-16T09:40:43.446950 #1]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#size defined in Hash. This can cause unexpected behavior when accessing the key as a property. You can still access the key via the #[] method.
  2025-04-16 10:40:43 W, [2025-04-16T09:40:43.453127 #1]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#size defined in Hash. This can cause unexpected behavior when accessing the key as a property. You can still access the key via the #[] method.
  2025-04-16 10:40:43 W, [2025-04-16T09:40:43.453510 #1]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#size defined in Hash. This can cause unexpected behavior when accessing the key as a property. You can still access the key via the #[] method.
  ```

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
