### PR TITLE
y25-304 Bioscan bug fix - removed unneeded stock plate call and name attribute

### DIFF
--- a/app/models/labware_creators/pooled_tubes_from_whole_plates.rb
+++ b/app/models/labware_creators/pooled_tubes_from_whole_plates.rb
@@ -21,7 +21,9 @@ module LabwareCreators
           .create!(
             child_purpose_uuids: [purpose_uuid],
             parent_uuids: [parents.first.uuid],
-            tube_attributes: [{ name: "#{stock_plate_barcode}+" }],
+            # NB. name is overridden in the after_create method in Transfer::FromPlateToTube
+            # in Sequencescape, to use the stock plate barcode and well range, so not set here
+            tube_attributes: [{}],
             user_uuid: user_uuid
           )
           .children
@@ -33,10 +35,6 @@ module LabwareCreators
 
     def barcodes=(input)
       @barcodes = (input || []).map(&:strip).compact_blank
-    end
-
-    def stock_plate_barcode
-      "#{parents.first.stock_plate.barcode.prefix}#{parents.first.stock_plate.barcode.number}"
     end
 
     def redirection_target

--- a/spec/features/pooling_multiple_plates_into_one_tube_spec.rb
+++ b/spec/features/pooling_multiple_plates_into_one_tube_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature 'Pooling multiple plates into a tube', :js do
   let(:child_tube) { create :v2_tube, purpose_uuid: 'child-purpose-0', purpose_name: 'Pool tube' }
 
   let(:specific_tubes_attributes) do
-    [{ uuid: child_tube.purpose.uuid, child_tubes: [child_tube], tube_attributes: [{ name: 'DN2+' }] }]
+    [{ uuid: child_tube.purpose.uuid, child_tubes: [child_tube], tube_attributes: [{}] }]
   end
 
   # Used to fetch the pools. This is the kind of thing we could pass through from a custom form

--- a/spec/models/labware_creators/pooled_tubes_from_whole_plates_spec.rb
+++ b/spec/models/labware_creators/pooled_tubes_from_whole_plates_spec.rb
@@ -52,9 +52,7 @@ RSpec.describe LabwareCreators::PooledTubesFromWholePlates, with: :uploader do
     let(:form_attributes) { { user_uuid:, purpose_uuid:, parent_uuid:, barcodes: } }
 
     let(:child_tube) { create :v2_tube }
-    let(:specific_tubes_attributes) do
-      [{ uuid: purpose_uuid, child_tubes: [child_tube], tube_attributes: [{ name: 'DN2+' }] }]
-    end
+    let(:specific_tubes_attributes) { [{ uuid: purpose_uuid, child_tubes: [child_tube], tube_attributes: [{}] }] }
 
     let(:transfers_attributes) do
       [parent_uuid, parent2_uuid, parent3_uuid, parent4_uuid].map do |source_uuid|


### PR DESCRIPTION
Closes #2363 

#### Changes proposed in this pull request
Removed tube name attribute and failing stock plate method
