### PR TITLE
Y25-226 [PR] creating bge lib prepool after wells on bge lib pcr xp failed

### DIFF
--- a/config/purposes/bge.wip.yml
+++ b/config/purposes/bge.wip.yml
@@ -19,14 +19,7 @@ BGE Lib:
   :presenter_class: Presenters::PermissivePresenter
   :creator_class: LabwareCreators::TaggedPlate
   :tag_layout_templates:
-    - 'IDT for Illumina UDI v1'
     - 'IDT for Illumina UDI v2'
-    - 'NEXTflex-96 barcoded adapters tags in rows (first oligo: AACGTGAT)'
-    - 'PF_adapters_UDI_96_A'
-    - 'PF_adapters_UDI_96_B_ROWS'
-    - 'PF_adapters_UDI_96_B'
-    - 'PF_adapters_UDI_96_C'
-    - 'PF_adapters_UDI_96_D'
 # 'Limber-Htp - BGE Transition - Automated' submission is on BGE Lib XP2
 BGE Lib XP2:
   :asset_type: plate

--- a/config/purposes/bge.wip.yml
+++ b/config/purposes/bge.wip.yml
@@ -31,8 +31,6 @@ BGE Lib:
 BGE Lib XP2:
   :asset_type: plate
   :label_template: plate_xp
-  # TODO (Y24-367): Customise the submission presenter for BGE Lib XP2.
-  # It uses the permissive submission presenter for now.
   :presenter_class: Presenters::PermissiveSubmissionPlatePresenter
   # NOTE: We use automatic plate state changer rather than Charge and Pass.
   :state_changer_class: StateChangers::AutomaticPlateStateChanger

--- a/config/purposes/bge.wip.yml
+++ b/config/purposes/bge.wip.yml
@@ -18,7 +18,6 @@ BGE Lib:
   :asset_type: plate
   :presenter_class: Presenters::PermissivePresenter
   :creator_class: LabwareCreators::TaggedPlate
-  # TODO: (Y24-367) Update the tag_layout_template_names for 'BGE Lib'
   :tag_layout_templates:
     - 'IDT for Illumina UDI v1'
     - 'IDT for Illumina UDI v2'


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Review BGE TODO comments and remove them.
- For BGE Lib, use the tag layout template `IDT for Illumina UDI v2` only. 
Confirmed by email. Subject: RE: Acceptable Tag Layout Templates for, From: Jamie, Date: 11 June 2025

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
