### PR TITLE
Y25-204 - Remove redundant production config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,5 +10,5 @@ Rails.application.configure do
 
   # Label printing services
   config.pmb_uri = ENV.fetch('PMB_URI', 'http://localhost:3002/v1/')
-  # config.sprint_uri = 'http://sprint.psd.sanger.ac.uk/graphql' # copied from development.rb
+  config.sprint_uri = 'http://sprint.psd.sanger.ac.uk/graphql' # copied from development.rb
 end


### PR DESCRIPTION
In part, closes https://github.com/sanger/deployment/issues/611

#### Changes proposed in this pull request

- Remove production config and redirect developer to deployment project

See https://github.com/sanger/deployment/pull/689 for the other half

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
