### PR TITLE
Y25-107-4 - Migrate & Improve testing workflows

### DIFF
--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -2,8 +2,9 @@ name: Javascript testing
 
 on:
   # Warning: changing run conditions could prevent coverage report in PR, see codecov.yml for `after_n_builds`
-  - push
-  - pull_request
+  push:
+    branches:
+      - y25-107-4-migrate-actions
 
 jobs:
   js_test:

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -3,8 +3,7 @@ name: Unit tests
 on:
   # Warning: changing run conditions could prevent coverage report in PR, see codecov.yml for `after_n_builds`
   push:
-    branches:
-      - y25-107-4-migrate-actions
+  pull_request:
 
 jobs:
   js_test:

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -28,7 +28,7 @@ jobs:
         run: yarn coverage
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: sanger/.github/.github/actions/tests/codecov@master
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: javascript,${{ github.event_name }}

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -12,11 +12,12 @@ jobs:
       TZ: Europe/London
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
+      - name: Checkout Repository
+        uses: sanger/.github/.github/actions/setup/checkout@master
+
+      - name: Setup Node
+        uses: sanger/.github/.github/actions/setup/node@master
+
       - name: Node Information
         run: node --version
       - name: Install

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -28,7 +28,7 @@ jobs:
         run: yarn coverage
 
       - name: Upload coverage reports to Codecov
-        uses: sanger/.github/.github/actions/tests/codecov@master
+        uses: sanger/.github/.github/actions/tests/codecov@y25-107-4-migrate-actions
         with:
           name: ${{ github.run_id }}_${{ github.job }}_${{ github.event_name }}
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -20,10 +20,13 @@ jobs:
 
       - name: Node Information
         run: node --version
-      - name: Install
+
+      - name: Setup yarn
         run: yarn install
+
       - name: Run yarn test
         run: yarn coverage
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
@@ -32,4 +35,4 @@ jobs:
           fail_ci_if_error: true
           disable_search: true
           files: ${{ github.workspace }}/app/frontend/coverage/lcov.info
-          # Note: see codecov.yml for more additional settings
+

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   js_test:
+    name: Javascript tests
     runs-on: ubuntu-latest
     env:
       TZ: Europe/London

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: sanger/.github/.github/actions/tests/codecov@master
         with:
+          name: ${{ github.run_id }}_${{ github.job }}_${{ github.event_name }}
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: javascript,${{ github.event_name }}
           fail_ci_if_error: true

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -36,4 +36,3 @@ jobs:
           flags: javascript,${{ github.event_name }}
           disable_search: true
           files: ${{ github.workspace }}/app/frontend/coverage/lcov.info
-

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -30,7 +30,7 @@ jobs:
         run: yarn coverage
 
       - name: Upload coverage reports to Codecov
-        uses: sanger/.github/.github/actions/tests/codecov@y25-107-4-migrate-actions
+        uses: sanger/.github/.github/actions/tests/codecov@master
         with:
           name: ${{ github.run_id }}_${{ github.job }}_${{ github.event_name }}
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -34,7 +34,6 @@ jobs:
           name: ${{ github.run_id }}_${{ github.job }}_${{ github.event_name }}
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: javascript,${{ github.event_name }}
-          fail_ci_if_error: true
           disable_search: true
           files: ${{ github.workspace }}/app/frontend/coverage/lcov.info
 

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -35,5 +35,5 @@ jobs:
           name: ${{ github.run_id }}_${{ github.job }}_${{ github.event_name }}
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: javascript,${{ github.event_name }}
-          disable_search: true
+          disable-search: true
           files: ${{ github.workspace }}/app/frontend/coverage/lcov.info

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -1,4 +1,4 @@
-name: Javascript testing
+name: Unit tests
 
 on:
   # Warning: changing run conditions could prevent coverage report in PR, see codecov.yml for `after_n_builds`

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -1,4 +1,4 @@
-name: Ruby RSpec Tests
+name: Unit tests
 
 on:
   # Warning: changing run conditions could prevent coverage report in PR, see codecov.yml for `after_n_builds`

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -9,31 +9,29 @@ env:
   BUNDLE_WITHOUT: 'development lint'
 
 jobs:
-  ruby_test:
+  rspec_tests:
+    name: RSpec Ruby tests
     runs-on: ubuntu-latest
     env:
       TZ: Europe/London
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache:
-            true # Runs bundle install and caches gems. See the ruby_test.yml
-            # example if you need more control over bundler.
-      - name: Remove image-bundled Chrome
-        run: sudo apt-get purge google-chrome-stable
+      - name: Checkout Repository
+        uses: sanger/.github/.github/actions/setup/checkout@master
+
+      - name: Setup Ruby
+        uses: sanger/.github/.github/actions/setup/ruby@master
+
+      - name: Setup Node
+        uses: sanger/.github/.github/actions/setup/node@master
+
       - name: Setup stable Chrome
-        uses: browser-actions/setup-chrome@v1
+        uses: sanger/.github/.github/actions/tests/setup-chrome@master
         with:
           chrome-version: 128
           install-chromedriver: true
           install-dependencies: true
+
       - name: Additional setup
         run: bin/setup
       - name: Run rspec

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -1,10 +1,8 @@
 name: Unit tests
 
 on:
-  # Warning: changing run conditions could prevent coverage report in PR, see codecov.yml for `after_n_builds`
   push:
-    branches:
-      - y25-107-4-migrate-actions
+  pull_request:
 
 env:
   BUNDLE_WITHOUT: 'development lint'

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -38,7 +38,7 @@ jobs:
         run: bundle exec rspec
 
       - name: Upload coverage reports to Codecov
-        uses: sanger/.github/.github/actions/tests/codecov@y25-107-4-migrate-actions
+        uses: sanger/.github/.github/actions/tests/codecov@master
         with:
           name: ${{ github.run_id }}_${{ github.job }}_${{ github.event_name }}
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -34,12 +34,15 @@ jobs:
 
       - name: Additional setup
         run: bin/setup
+
       - name: Run rspec
         run: bundle exec rspec
+
       - name: Publish code coverage to Code Climate
         uses: paambaati/codeclimate-action@v5.0.0
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID || '1735fdb62543d410c5ed4469e402641a7986f1ebf62ff7398f3ab8ccc98069ef' }}
+      
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run rspec
         run: bundle exec rspec
-      
+
       - name: Upload coverage reports to Codecov
         uses: sanger/.github/.github/actions/tests/codecov@y25-107-4-migrate-actions
         with:

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -40,7 +40,7 @@ jobs:
         run: bundle exec rspec
 
       - name: Publish code coverage to Code Climate
-        uses: paambaati/codeclimate-action@v5.0.0
+        uses: sanger/.github/.github/actions/tests/code-climate@y25-107-4-migrate-actions
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID || '1735fdb62543d410c5ed4469e402641a7986f1ebf62ff7398f3ab8ccc98069ef' }}
       

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -44,7 +44,7 @@ jobs:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID || '1735fdb62543d410c5ed4469e402641a7986f1ebf62ff7398f3ab8ccc98069ef' }}
       
       - name: Upload coverage reports to Codecov
-        uses: sanger/.github/.github/actions/tests/codecov@master
+        uses: sanger/.github/.github/actions/tests/codecov@y25-107-4-migrate-actions
         with:
           name: ${{ github.run_id }}_${{ github.job }}_${{ github.event_name }}
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Publish code coverage to Code Climate
         uses: sanger/.github/.github/actions/tests/code-climate@y25-107-4-migrate-actions
         env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID || '1735fdb62543d410c5ed4469e402641a7986f1ebf62ff7398f3ab8ccc98069ef' }}
+          CC-TEST-REPORTER-ID: ${{ secrets.CC_TEST_REPORTER_ID || '1735fdb62543d410c5ed4469e402641a7986f1ebf62ff7398f3ab8ccc98069ef' }}
       
       - name: Upload coverage reports to Codecov
         uses: sanger/.github/.github/actions/tests/codecov@y25-107-4-migrate-actions

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -38,11 +38,6 @@ jobs:
 
       - name: Run rspec
         run: bundle exec rspec
-
-      - name: Publish code coverage to Code Climate
-        uses: sanger/.github/.github/actions/tests/code-climate@y25-107-4-migrate-actions
-        env:
-          CC-TEST-REPORTER-ID: ${{ secrets.CC_TEST_REPORTER_ID || '1735fdb62543d410c5ed4469e402641a7986f1ebf62ff7398f3ab8ccc98069ef' }}
       
       - name: Upload coverage reports to Codecov
         uses: sanger/.github/.github/actions/tests/codecov@y25-107-4-migrate-actions

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -2,8 +2,9 @@ name: Ruby RSpec Tests
 
 on:
   # Warning: changing run conditions could prevent coverage report in PR, see codecov.yml for `after_n_builds`
-  - push
-  - pull_request
+  push:
+    branches:
+      - y25-107-4-migrate-actions
 
 env:
   BUNDLE_WITHOUT: 'development lint'

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -50,5 +50,5 @@ jobs:
           name: ${{ github.run_id }}_${{ github.job }}_${{ github.event_name }}
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: ruby,${{ github.event_name }}
-          disable_search: true
+          disable-search: true
           files: ${{ github.workspace }}/lcov.info

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -44,10 +44,10 @@ jobs:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID || '1735fdb62543d410c5ed4469e402641a7986f1ebf62ff7398f3ab8ccc98069ef' }}
       
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: sanger/.github/.github/actions/tests/codecov@master
         with:
+          name: ${{ github.run_id }}_${{ github.job }}_${{ github.event_name }}
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: ruby,${{ github.event_name }}
-          fail_ci_if_error: true
           disable_search: true
           files: ${{ github.workspace }}/lcov.info


### PR DESCRIPTION
Closes #2216 

#### Changes proposed in this pull request

- Migrated setup steps to use the composite actions
- Migrated testing and coverage steps to use the composite actions
- Removed code climate action (we no longer use code climate)
- Improved naming and separation of the testing jobs
- Minor improvements to syntax and structure

While there aren't any new steps for these workflows, a backwards compatible change has been made to the code coverage action [here](https://github.com/sanger/.github/pull/28).

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
