### PR TITLE
Y24-394 BGE - Post blending pipeline config

### DIFF
--- a/config/pipelines/high_throughput_bge.wip.yml
+++ b/config/pipelines/high_throughput_bge.wip.yml
@@ -50,9 +50,10 @@ BGE ISC MX:
 
 BGE Blend:
   pipeline_group: BGE
+  # NB. no filters here as no submission is used for this section
+  # The multiplexing requests are closed off on the two parents of the
+  # Blended Cap Lib Pool before being nerged here.
   relationships:
     BGE Lib Pool: BGE Blended Cap Lib Pool
     BGE Cap Lib Pool Norm: BGE Blended Cap Lib Pool
     BGE Blended Cap Lib Pool: BGE Lib Pool Norm
-    # 1:1 transfer here, not a pool as such
-    BGE Lib Pool Norm: BGE Custom Pool

--- a/config/purposes/bge.wip.yml
+++ b/config/purposes/bge.wip.yml
@@ -53,6 +53,8 @@ BGE Lib Pool:
   :creator_class: LabwareCreators::PooledTubesBySubmission
   :presenter_class: Presenters::SimpleTubePresenter
   :default_printer_type: :tube
+  :state_changer_class: StateChangers::AutomaticTubeStateChanger
+  :work_completion_request_type: 'limber_multiplexing_bge_pcr_free'
 BGE Lib PCR:
   :asset_type: plate
 # 'Limber-Htp - BGE ISC' manual submission is on BGE Lib PCR XP
@@ -120,12 +122,5 @@ BGE Lib Pool Norm:
   :target: MultiplexedLibraryTube
   :type: IlluminaHtp::MxTubePurpose
   :creator_class: LabwareCreators::TubeFromTube
-  :presenter_class: Presenters::SimpleTubePresenter
-  :default_printer_type: :tube
-BGE Custom Pool:
-  :asset_type: tube
-  :target: StockMultiplexedLibraryTube
-  :type: IlluminaHtp::InitialStockTubePurpose
-  :creator_class: LabwareCreators::CustomPooledTubes
   :presenter_class: Presenters::SimpleTubePresenter
   :default_printer_type: :tube


### PR DESCRIPTION
Final part of pipeline.
Closed off PCR free multiplexing request and removed unneeded Custom Pool tube.
BGE Lib Pool Norm was already present.

Closes #2000
