### PR TITLE
[perf] Perform a single lookup for parent and child relatives

### DIFF
--- a/app/models/presenters/presenter.rb
+++ b/app/models/presenters/presenter.rb
@@ -111,11 +111,11 @@ module Presenters::Presenter # rubocop:todo Style/Documentation
     parent_labwares.filter { |labware| labware.purpose.present? }
   end
 
-  # A collection of children labwares for this labware including purposes.
+  # A collection of child labwares for this labware including purposes.
   # Returns an empty array if there are no children.
   #
   # @return [Array<Sequencescape::Api::V2::Labware>] Array of child labwares with purposes.
-  def children_labwares
+  def child_labwares
     children = labware.children || []
     child_uuids = children.compact.map(&:uuid).uniq
     return [] if child_uuids.empty?

--- a/app/views/labware/_relatives_list.html.erb
+++ b/app/views/labware/_relatives_list.html.erb
@@ -1,33 +1,33 @@
 <%# locals: (presenter:) %>
 <%
-  valid_parents = presenter.parent_labwares
-  valid_children = presenter.children_labwares
+  parent_labwares = presenter.parent_labwares
+  child_labwares = presenter.child_labwares
 %>
 <div id="relatives-information" class="list-group list-group-flush">
 
   <div class="list-group-item">
     <strong>Parents</strong>
-    <%= content_tag :span, valid_parents.size, class: "badge badge-pill badge-secondary" %>
+    <%= content_tag :span, parent_labwares.size, class: "badge badge-pill badge-secondary" %>
   </div>
 
   <div id="parents-list" class="border-bottom">
-    <% if valid_parents.empty? %>
+    <% if parent_labwares.empty? %>
       <div class="list-group-item text-muted">No parents found</div>
     <% else %>
-      <%= render partial: 'labware/parent_labware_item', collection: valid_parents, as: :labware %>
+      <%= render partial: 'labware/parent_labware_item', collection: parent_labwares, as: :labware %>
     <% end %>
   </div>
 
   <div class="list-group-item">
     <strong>Children</strong>
-    <%= content_tag :span, valid_children.size, class: "badge badge-pill badge-secondary" %>
+    <%= content_tag :span, child_labwares.size, class: "badge badge-pill badge-secondary" %>
   </div>
 
   <div id="children-list" class="rounded-bottom">
-    <% if valid_children.empty? %>
+    <% if child_labwares.empty? %>
       <div class="list-group-item text-muted">No children found</div>
     <% else %>
-      <%= render partial: 'labware/child_labware_item', collection: valid_children, as: :labware, locals: { presenter: presenter, open_in_new_window: true } %>
+      <%= render partial: 'labware/child_labware_item', collection: child_labwares, as: :labware, locals: { presenter: presenter, open_in_new_window: true } %>
     <% end %>
   </div>
 

--- a/spec/models/presenters/presenter_spec.rb
+++ b/spec/models/presenters/presenter_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Presenters::Presenter, type: :model do
     end
   end
 
-  describe '#children_labwares' do
+  describe '#child_labwares' do
     let(:child_labware_uuids) { (child_labwares || []).map(&:uuid) }
 
     before do
@@ -64,7 +64,7 @@ RSpec.describe Presenters::Presenter, type: :model do
       let(:child_labwares) { nil }
 
       it 'returns an empty array' do
-        expect(presenter.children_labwares).to eq([])
+        expect(presenter.child_labwares).to eq([])
       end
     end
 
@@ -75,7 +75,7 @@ RSpec.describe Presenters::Presenter, type: :model do
       let(:child_labwares) { [child_labware1, child_labware2] }
 
       it 'returns the child labwares' do
-        expect(presenter.children_labwares).to eq([child_labware1, child_labware2])
+        expect(presenter.child_labwares).to eq([child_labware1, child_labware2])
       end
 
       context 'where some children do not have a purpose' do
@@ -83,7 +83,7 @@ RSpec.describe Presenters::Presenter, type: :model do
         let(:child_labwares) { [child_labware1, child_labware2, child_labware3] }
 
         it 'returns only the children with a purpose' do
-          expect(presenter.children_labwares).to eq([child_labware1, child_labware2])
+          expect(presenter.child_labwares).to eq([child_labware1, child_labware2])
         end
       end
     end


### PR DESCRIPTION
Makes a 0-3 second decrease in loading times for labware pages

#### Changes proposed in this pull request

- Combine requests for data on relative-tab labware parents into a single request.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
