### PR TITLE
Y24-512 - Added results of the donor pooling algorithm

### DIFF
--- a/app/models/presenters/donor_pooling_plate_presenter.rb
+++ b/app/models/presenters/donor_pooling_plate_presenter.rb
@@ -11,16 +11,7 @@ module Presenters
     self.pooling_tab = ''
 
     def study_project_groups_from_wells
-      groups = Hash.new { |h, k| h[k] = [] }
-
-      wells.compact
-        .reject { |well| well.aliquots.empty? }
-        .each do |well|
-        key = "#{well.aliquots.first.study.name} / #{well.aliquots.first.project.name}"
-        groups[key] << well # Store the well itself
-      end
-
-      groups.to_a
+      grouped_wells.each.to_a
     end
 
     def num_samples_per_pool(group)
@@ -28,8 +19,27 @@ module Presenters
     end
 
     def get_source_wells(group)
-      binding.pry
       group.map { |well| well.position['name'] || 'Unknown' }.join(', ')
+    end
+
+    private
+
+    def grouped_wells
+      wells.each_with_object(Hash.new { |h, k| h[k] = [] }) do |well, groups|
+        next unless valid_well?(well)
+
+        key = study_project_key(well)
+        groups[key] << well
+      end
+    end
+
+    def valid_well?(well)
+      well && !well.aliquots.empty?
+    end
+
+    def study_project_key(well)
+      aliquot = well.aliquots.first
+      "#{aliquot.study.name} / #{aliquot.project.name}"
     end
 
     self.page = 'show_pooling_info'

--- a/app/models/presenters/donor_pooling_plate_presenter.rb
+++ b/app/models/presenters/donor_pooling_plate_presenter.rb
@@ -7,8 +7,32 @@ module Presenters
   class DonorPoolingPlatePresenter < StandardPresenter
     # The pooling tab is not relevant for this presenter as the wells are already pooled (tab shows future pooling
     # by submission strategy)
+    #
     self.pooling_tab = ''
 
+    def study_project_groups_from_wells
+      groups = Hash.new { |h, k| h[k] = [] }
+
+      wells.compact
+        .reject { |well| well.aliquots.empty? }
+        .each do |well|
+        key = "#{well.aliquots.first.study.name} / #{well.aliquots.first.project.name}"
+        groups[key] << well # Store the well itself
+      end
+
+      groups.to_a
+    end
+
+    def num_samples_per_pool(group)
+      group.map { |well| well&.aliquots&.size }.join(', ')
+    end
+
+    def get_source_wells(group)
+      binding.pry
+      group.map { |well| well.position['name'] || 'Unknown' }.join(', ')
+    end
+
+    self.page = 'show_pooling_info'
     # Override the samples tab to display additional sample information for the pooled wells
     self.samples_partial = 'plates/pooled_wells_samples_tab'
   end

--- a/app/models/presenters/donor_pooling_plate_presenter.rb
+++ b/app/models/presenters/donor_pooling_plate_presenter.rb
@@ -28,6 +28,13 @@ module Presenters
       group.map { |well| well.position['name'] || 'Unknown' }.join(', ')
     end
 
+    def cells_per_chip_well(group)
+      value = group.first.aliquots.first.request&.request_metadata&.cells_per_chip_well
+
+      # The cleanest way I could find to format numbers
+      value.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse if value
+    end
+
     private
 
     def grouped_wells

--- a/app/models/presenters/donor_pooling_plate_presenter.rb
+++ b/app/models/presenters/donor_pooling_plate_presenter.rb
@@ -10,6 +10,12 @@ module Presenters
     #
     self.pooling_tab = ''
 
+    # A clone of the default 'show' page, but with the pooling information displayed
+    self.page = 'show_pooling_info'
+
+    # Override the samples tab to display additional sample information for the pooled wells
+    self.samples_partial = 'plates/pooled_wells_samples_tab'
+
     def study_project_groups_from_wells
       grouped_wells.each.to_a
     end
@@ -41,9 +47,5 @@ module Presenters
       aliquot = well.aliquots.first
       "#{aliquot.study.name} / #{aliquot.project.name}"
     end
-
-    self.page = 'show_pooling_info'
-    # Override the samples tab to display additional sample information for the pooled wells
-    self.samples_partial = 'plates/pooled_wells_samples_tab'
   end
 end

--- a/app/views/application/_pooling_info.html.erb
+++ b/app/views/application/_pooling_info.html.erb
@@ -30,7 +30,7 @@
               <td><%= group[0] %></td>
               <td><%= presenter.num_samples_per_pool(group[1])%></td>
               <td><%= presenter.get_source_wells(group[1])%></td>
-              <td>90,000</td>
+              <td><%= presenter.cells_per_chip_well(group[1])%></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/application/_pooling_info.html.erb
+++ b/app/views/application/_pooling_info.html.erb
@@ -1,0 +1,40 @@
+<% if @presenter %>
+  <style>
+    .asset-info h3 {
+      white-space: nowrap;       /* Prevent wrapping */
+      margin-bottom: 10px;
+    }
+
+    .asset-info th,
+    .asset-info td {
+      text-align: center;
+      vertical-align: middle;
+    }
+  </style>
+
+  <div class="asset-info">
+    <h3 class="n">Pooling Information</h3>
+    <div class="row">
+      <table cellspacing="20" cellpadding="5" border="0">
+        <thead>
+          <tr>
+            <th>Study / Project Group</th>
+            <th>No. Samples Per Pool</th>
+            <th>Source Wells</th>
+            <th>Cells Per Chip Well</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% presenter.study_project_groups_from_wells.each do |group| %>
+            <tr>
+              <td><%= group[0] %></td>
+              <td><%= presenter.num_samples_per_pool(group[1])%></td>
+              <td><%= presenter.get_source_wells(group[1])%></td>
+              <td>90,000</td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% end %>

--- a/app/views/application/_pooling_info.html.erb
+++ b/app/views/application/_pooling_info.html.erb
@@ -28,9 +28,9 @@
           <% presenter.study_project_groups_from_wells.each do |group| %>
             <tr>
               <td><%= group[0] %></td>
-              <td><%= presenter.num_samples_per_pool(group[1])%></td>
-              <td><%= presenter.get_source_wells(group[1])%></td>
-              <td><%= presenter.cells_per_chip_well(group[1])%></td>
+              <td><%= presenter.num_samples_per_pool(group[1]) %></td>
+              <td><%= presenter.get_source_wells(group[1]) %></td>
+              <td><%= presenter.cells_per_chip_well(group[1]) %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/plates/show_pooling_info.html.erb
+++ b/app/views/plates/show_pooling_info.html.erb
@@ -6,7 +6,7 @@
   <%= render 'content_header', presenter: @presenter, type: 'plate' %>
   <%= render 'warnings', presenter: @presenter %>
   <%= render 'info', presenter: @presenter %>
-  <%= render 'pooling_info', presenter: @presenter %> 
+  <%= render 'pooling_info', presenter: @presenter %>
 
   <% if @presenter.well_failing_applicable? %>
     <div id="labware-well-failing" class='well-fail-toggle collapse'>

--- a/app/views/plates/show_pooling_info.html.erb
+++ b/app/views/plates/show_pooling_info.html.erb
@@ -1,0 +1,22 @@
+<%= content_for(:title, @presenter.document_title) %>
+
+<%= content_for(:page_id, :'plate-show-page') %>
+
+<%= content_for(:labware_content) do %>
+  <%= render 'content_header', presenter: @presenter, type: 'plate' %>
+  <%= render 'warnings', presenter: @presenter %>
+  <%= render 'info', presenter: @presenter %>
+
+  <% if @presenter.well_failing_applicable? %>
+    <div id="labware-well-failing" class='well-fail-toggle collapse'>
+      <%= render 'fail_wells', presenter: @presenter %>
+    </div>
+  <% end %>
+  <div id="labware-summary" class='well-fail-toggle collapse show'>
+    <%= render @presenter.summary_partial, presenter: @presenter %>
+  </div>
+<% end %>
+
+<%= content_for(:labware_sidebar) do %>
+  <%= render 'plates/sidebars/container', presenter: @presenter %>
+<% end %>

--- a/app/views/plates/show_pooling_info.html.erb
+++ b/app/views/plates/show_pooling_info.html.erb
@@ -6,6 +6,7 @@
   <%= render 'content_header', presenter: @presenter, type: 'plate' %>
   <%= render 'warnings', presenter: @presenter %>
   <%= render 'info', presenter: @presenter %>
+  <%= render 'pooling_info', presenter: @presenter %> 
 
   <% if @presenter.well_failing_applicable? %>
     <div id="labware-well-failing" class='well-fail-toggle collapse'>


### PR DESCRIPTION
Closes #2129 

#### Changes proposed in this pull request

- Added helper methods to the `donor_pooling_plate_presenter`
    - Regrouping wells into groups for ease
    - A method to grab the source wells for each group
    - A method to grab the number of samples per pool
    - A method to grab the `cells per chip well` value from aliquot metadata

- Added a new pooling information view with a table to display the results

- Added a copy of the default `show` view to be used with the pooling info view

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
