### PR TITLE
Y25-436 - Fix broken state badge states

### DIFF
--- a/app/frontend/stylesheets/limber/screen.scss
+++ b/app/frontend/stylesheets/limber/screen.scss
@@ -365,9 +365,8 @@ dl#samples-information {
   li.state-passed {
     @extend .list-group-item-success;
   }
-  // TODO: Update to primary when bootstrap updated
-  li.state-qc_completed {
-    @extend .list-group-item-success;
+  li.state-qc_complete {
+    @extend .list-group-item-primary;
   }
   li.state-cancelled {
     @extend .list-group-item-danger;
@@ -399,8 +398,8 @@ dl#samples-information {
 .state-badge.passed {
   @extend.bg-success;
 }
-.state-badge.qc_completed {
-  @extend.bg-success;
+.state-badge.qc_complete {
+  @extend.bg-primary;
 }
 .state-badge.cancelled {
   @extend .bg-danger;


### PR DESCRIPTION
Closes #2454 

#### Changes proposed in this pull request

- Uses correct badge class for `failed` and `cancelled` states
- Fixes potential break with `qc_complete` state badge since `qc_complete[d]` does not exist in Limber

After screenshots:
<img width="745" height="246" alt="Screenshot 2025-07-23 at 16 20 21" src="https://github.com/user-attachments/assets/f840a889-6b01-444b-b32d-2e729d7ca922" />

<img width="751" height="759" alt="Screenshot 2025-07-23 at 16 19 56" src="https://github.com/user-attachments/assets/8d2f2189-1982-439d-8210-b2cd8ec01a11" />


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
