### PR TITLE
[ux] Rename tube_racks to Tube Racks

### DIFF
--- a/app/views/application/_creation_dropdown.html.erb
+++ b/app/views/application/_creation_dropdown.html.erb
@@ -2,7 +2,7 @@
   <% button_id = SecureRandom.uuid %>
   <div role="d-grid w-100 gap-2">
     <button id="<%= button_id %>" class="w-100 my-1 dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      Create <%= resource_type %>
+      Create <%= resource_type.humanize.titleize %>
     </button>
     <div class="dropdown-menu" aria-labelledby="<%= button_id %>">
       <%= render partial: 'dropdown_item', collection: resources.sort_by(&:name), as: :item %>


### PR DESCRIPTION
Changes the creation dropdown to use humanised resource names.

#### Changes proposed in this pull request

- Convert underscores in resource names to spaces and capitalise the first letter of every word

See Integration Suite change (backwards compatible):
https://gitlab.internal.sanger.ac.uk/psd/integration-suite/-/merge_requests/274

Before:
<img width="744" height="451" alt="Screenshot 2025-08-04 at 10 16 39" src="https://github.com/user-attachments/assets/969000b2-890f-45ce-9b0f-bb3b881408d0" />

After:
<img width="745" height="456" alt="Screenshot 2025-08-04 at 10 16 11" src="https://github.com/user-attachments/assets/cfc7a18b-c2d5-4407-b59f-8b9cd231d37f" />


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
