### PR TITLE
Y25-434 Exclude failed tubes from content report 

### DIFF
--- a/app/views/exports/pbmc_bank_tubes_content_report.csv.erb
+++ b/app/views/exports/pbmc_bank_tubes_content_report.csv.erb
@@ -32,6 +32,9 @@
     next if source_well.downstream_tubes.empty?
 
     child_tube = source_well.downstream_tubes.last
+    # skip if child tube not in passed state
+    next if child_tube.state != 'passed'
+
     child_tube_purpose = child_tube.purpose.name
 
     sample_uuid = source_well.aliquots.first.sample.uuid


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

-This pull request updates the content report feature for the LRC PBMC Bank plate to ensure that only tubes in the 'passed' state are included.

* Modified the report generation in `pbmc_bank_tubes_content_report.csv.erb` to skip any downstream tubes that are not in the 'passed' state.
* Added a new test context in `pbmc_bank_tubes_content_report.csv.erb_spec.rb` to ensure only tubes in the 'passed' state are rendered in the report, and tubes in other states (e.g., 'failed') are excluded.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
