### PR TITLE
[dev] Hide SCSS deprecation warnings from Bootstrap 5

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -8,6 +8,15 @@ export default defineConfig({
   build: {
     target: 'chrome65',
   },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        quietDeps: true,
+        silenceDeprecations: ['import', 'color-functions', 'global-builtin'],
+        verbose: false,
+      },
+    },
+  },
   plugins: [
     RubyPlugin(),
     vue(),


### PR DESCRIPTION
Removes deprecation warnings that are out of our control. They will likely be addressed in Bootstrap 6.

This will allow us to see valid warnings about code we introduce ourselves.

Config sourced and updated from https://www.reddit.com/r/bootstrap/comments/1e6i6qg/comment/mxmxx5t

#### Changes proposed in this pull request

- Hides SCSS deprecation warnings from bootstrap that we can't do anything about

```
DEPRECATION WARNING [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use color.mix instead.

More info and automated migrator: https://sass-lang.com/d/import

    ╷
212 │   @return mix(black, $color, $weight);
    │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
    node_modules/bootstrap/scss/_functions.scss 212:11    shade-color()
    node_modules/bootstrap/scss/_variables.scss 84:12     @import
    node_modules/bootstrap/scss/bootstrap.scss 8:9        @import
    app/frontend/stylesheets/limber/_bootstrap.scss 23:9  @import
    app/frontend/stylesheets/application.scss 3:9         root stylesheet

DEPRECATION WARNING [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use color.mix instead.

More info and automated migrator: https://sass-lang.com/d/import

    ╷
342 │ $light-bg-subtle:         mix($gray-100, $white) !default;
    │                           ^^^^^^^^^^^^^^^^^^^^^^
    ╵
    node_modules/bootstrap/scss/_variables.scss 342:27       @import
    node_modules/bootstrap/scss/bootstrap.scss 8:9           @import
    app/frontend/stylesheets/limber/_bootstrap.scss 23:9     @import
    app/frontend/stylesheets/limber/pipeline-graph.scss 1:9  root stylesheet

DEPRECATION WARNING [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use color.mix instead.

More info and automated migrator: https://sass-lang.com/d/import

    ╷
342 │ $light-bg-subtle:         mix($gray-100, $white) !default;
    │                           ^^^^^^^^^^^^^^^^^^^^^^
    ╵
    node_modules/bootstrap/scss/_variables.scss 342:27    @import
    node_modules/bootstrap/scss/bootstrap.scss 8:9        @import
    app/frontend/stylesheets/limber/_bootstrap.scss 23:9  @import
    app/frontend/stylesheets/application.scss 3:9         root stylesheet

DEPRECATION WARNING [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use math.unit instead.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
11 │     @if $prev-num == null or unit($num) == "%" or unit($prev-num) == "%" {
   │                              ^^^^^^^^^^
   ╵
    node_modules/bootstrap/scss/_functions.scss 11:30        -assert-ascending()
    node_modules/bootstrap/scss/_variables.scss 494:1        @import
    node_modules/bootstrap/scss/bootstrap.scss 8:9           @import
    app/frontend/stylesheets/limber/_bootstrap.scss 23:9     @import
    app/frontend/stylesheets/limber/pipeline-graph.scss 1:9  root stylesheet

DEPRECATION WARNING [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use math.unit instead.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
11 │     @if $prev-num == null or unit($num) == "%" or unit($prev-num) == "%" {
   │                              ^^^^^^^^^^
   ╵
    node_modules/bootstrap/scss/_functions.scss 11:30     -assert-ascending()
    node_modules/bootstrap/scss/_variables.scss 494:1     @import
    node_modules/bootstrap/scss/bootstrap.scss 8:9        @import
    app/frontend/stylesheets/limber/_bootstrap.scss 23:9  @import
    app/frontend/stylesheets/application.scss 3:9         root stylesheet

DEPRECATION WARNING [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use math.unit instead.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
11 │     @if $prev-num == null or unit($num) == "%" or unit($prev-num) == "%" {
   │                                                   ^^^^^^^^^^^^^^^
   ╵
    node_modules/bootstrap/scss/_functions.scss 11:51        -assert-ascending()
    node_modules/bootstrap/scss/_variables.scss 494:1        @import
    node_modules/bootstrap/scss/bootstrap.scss 8:9           @import
    app/frontend/stylesheets/limber/_bootstrap.scss 23:9     @import
    app/frontend/stylesheets/limber/pipeline-graph.scss 1:9  root stylesheet

DEPRECATION WARNING [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use math.unit instead.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
11 │     @if $prev-num == null or unit($num) == "%" or unit($prev-num) == "%" {
   │                                                   ^^^^^^^^^^^^^^^
   ╵
    node_modules/bootstrap/scss/_functions.scss 11:51     -assert-ascending()
    node_modules/bootstrap/scss/_variables.scss 494:1     @import
    node_modules/bootstrap/scss/bootstrap.scss 8:9        @import
    app/frontend/stylesheets/limber/_bootstrap.scss 23:9  @import
    app/frontend/stylesheets/application.scss 3:9         root stylesheet

DEPRECATION WARNING [color-functions]: red() is deprecated. Suggestion:

color.channel($color, "red", $space: rgb)

More info: https://sass-lang.com/d/color-functions

    ╷
185 │     "r": red($color),
    │          ^^^^^^^^^^^
    ╵
    node_modules/bootstrap/scss/_functions.scss 185:10       luminance()
    node_modules/bootstrap/scss/_functions.scss 174:8        contrast-ratio()
    node_modules/bootstrap/scss/_functions.scss 159:22       color-contrast()
    node_modules/bootstrap/scss/_variables.scss 846:42       @import
    node_modules/bootstrap/scss/bootstrap.scss 8:9           @import
    app/frontend/stylesheets/limber/_bootstrap.scss 23:9     @import
    app/frontend/stylesheets/limber/pipeline-graph.scss 1:9  root stylesheet

DEPRECATION WARNING [color-functions]: red() is deprecated. Suggestion:

color.channel($color, "red", $space: rgb)

More info: https://sass-lang.com/d/color-functions

    ╷
185 │     "r": red($color),
    │          ^^^^^^^^^^^
    ╵
    node_modules/bootstrap/scss/_functions.scss 185:10    luminance()
    node_modules/bootstrap/scss/_functions.scss 174:8     contrast-ratio()
    node_modules/bootstrap/scss/_functions.scss 159:22    color-contrast()
    node_modules/bootstrap/scss/_variables.scss 846:42    @import
    node_modules/bootstrap/scss/bootstrap.scss 8:9        @import
    app/frontend/stylesheets/limber/_bootstrap.scss 23:9  @import
    app/frontend/stylesheets/application.scss 3:9         root stylesheet
```


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
