### PR TITLE
Handle API error during pipeline-info grandparent plate query

### DIFF
--- a/app/models/presenters/pipeline_info_presenter.rb
+++ b/app/models/presenters/pipeline_info_presenter.rb
@@ -70,6 +70,9 @@ class Presenters::PipelineInfoPresenter
     grandparent_labwares = find_all_labware_parents_with_purposes(labwares: parent_labwares)
 
     true unless grandparent_labwares.empty?
+  rescue JsonApiClient::Errors::ClientError
+    # In case of any API errors, assume there are grandparent purposes
+    true
   end
 
   # Returns a comma-separated list of the purposes of the labware's parents.

--- a/spec/models/presenters/pipeline_info_presenter_spec.rb
+++ b/spec/models/presenters/pipeline_info_presenter_spec.rb
@@ -575,6 +575,24 @@ RSpec.describe Presenters::PipelineInfoPresenter do
         expect(presenter.grandparent_purposes?).to be true
       end
     end
+
+    context 'when an error occurs during API calls' do
+      let(:parent_purpose) { create(:purpose, name: 'Parent Purpose') }
+
+      let(:parent_tube) { create(:stock_tube, purpose: parent_purpose, uuid: 'parent-tube-uuid') }
+
+      before do
+        allow(labware).to receive_messages(parents: [parent_tube])
+        stub_labware_find_all_barcode([parent_tube])
+
+        allow(Sequencescape::Api::V2::Labware).to receive(:find_all)
+          .and_raise(JsonApiClient::Errors::ClientError.new(500, 'Internal Server Error'))
+      end
+
+      it 'returns true' do
+        expect(presenter.grandparent_purposes?).to be true
+      end
+    end
   end
 
   describe '#parent_purposes' do


### PR DESCRIPTION
Addresses error raised by visiting https://limber.psd.sanger.ac.uk/plates/f4704154-ae8c-11f0-bc1d-0242eb1badd5

#### Changes proposed in this pull request

- Rescue API error and return best assumption

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
