### PR TITLE
Y26-034-3 - Add request logging middleware

### DIFF
--- a/config/initializers/request_logger.rb
+++ b/config/initializers/request_logger.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/middleware/request_logger'
+
+Rails.application.configure do
+  # Insert RequestLogger near the top, before Rails::Rack::Logger
+  config.middleware.insert_before(Rails::Rack::Logger, Middleware::RequestLogger)
+end
+
+# Add backtrace silencers for middleware so that we don't see it in backtraces.
+Rails.backtrace_cleaner.add_silencer { |line| line.include?('request_logger') }

--- a/lib/middleware/request_logger.rb
+++ b/lib/middleware/request_logger.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Middleware
+  # Log request and response details for monitoring and high-level profiling.
+  #
+  # @param log_level [Symbol] the log level to use for logging requests (default: :info)
+  # @param environment_context [Hash] additional context to include in log entries, such as host and version information
+  #
+  # Returns a JSON parseable log entry like:
+  # [INFO] [RequestLogger] {"method":"GET","path":"/samples/1234","format":"html","status_code":200,
+  #   "status_message":"OK","duration_ms":935,"client_ip":"172.21.43.210",
+  #   "request_id":"9fd18098-dea3-46f0-83c8-c41852441db3","tags":["request","success"],
+  #   "@timestamp":"2026-02-12T12:10:50.284+00:00"}
+  class RequestLogger
+    def initialize(app, log_level: :info, environment_context: nil)
+      @app = app
+      @log_level = log_level
+      @environment_context = environment_context
+    end
+
+    def call(env)
+      response, elapsed_ms = elapsed_milliseconds { @app.call(env) }
+
+      request = ActionDispatch::Request.new(env)
+      log_request(request, response, elapsed_ms)
+
+      response
+    end
+
+    private
+
+    # Get the current clock time using the Rack::Runtime clock
+    def clock_time
+      Rack::Utils.clock_time
+    end
+
+    def elapsed_milliseconds
+      start_time = clock_time
+      result = yield
+      end_time = clock_time
+
+      elapsed_ms = ((end_time - start_time) * 1000).round
+      [result, elapsed_ms]
+    end
+
+    def tag_for_status(status_code)
+      case status_code
+      when 100..199 then 'informational'
+      when 200..299 then 'success'
+      when 300..399 then 'redirection'
+      when 400..499 then 'client_error'
+      when 500..599 then 'server_error'
+      end
+    end
+
+    def tags(status_code)
+      tags = ['request']
+      tags << tag_for_status(status_code)
+      tags.compact!
+      tags
+    end
+
+    def log_request(request, response, elapsed_ms) # rubocop:disable Metrics/AbcSize
+      status_code, _headers, _body = response
+
+      status_message = Rack::Utils::HTTP_STATUS_CODES[status_code] || 'Unknown Status'
+      timestamp = Time.zone.now.iso8601(3)
+
+      record = {
+        method: request.request_method,
+        url: request.fullpath,
+        path: request.path,
+        format: request.format.symbol,
+        status_code: status_code,
+        status_message: status_message,
+        duration_ms: elapsed_ms,
+        client_ip: request.remote_ip,
+        request_id: request.request_id,
+        tags: tags(status_code),
+        '@timestamp': timestamp
+      }
+      record.merge!(@environment_context) if @environment_context.present?
+
+      Rails.logger.public_send(@log_level, "[RequestLogger] #{record.to_json}")
+    end
+  end
+end

--- a/spec/lib/middleware/request_logger_spec.rb
+++ b/spec/lib/middleware/request_logger_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Middleware::RequestLogger do
+  let(:env) do
+    Rack::MockRequest.env_for(
+      '/samples/1234?foo=bar',
+      'REQUEST_METHOD' => 'GET',
+      'REMOTE_ADDR' => '172.12.345.10',
+      'action_dispatch.request_id' => 'test-request-id',
+      'action_dispatch.request.parameters' => {},
+      'action_dispatch.request.formats' => [Mime[:html]]
+    )
+  end
+
+  let(:status_code) { 200 }
+  let(:app) { ->(_env) { [status_code, { 'Content-Type' => 'text/html' }, 'Response Body'] } }
+
+  before do
+    allow(Rack::Utils).to receive(:clock_time).and_return(1.0, 1.23) # Simulate elapsed time for request processing
+    allow(Time.zone).to receive(:now).and_return(Time.new(2026, 2, 12, 12, 10, 50, '+00:00'))
+    allow(Rails.logger).to receive(:debug)
+    allow(Rails.logger).to receive(:info)
+  end
+
+  shared_examples 'logs request with' do |log_level|
+    let(:middleware) do
+      described_class.new(app, log_level: log_level,
+                               environment_context: { host: 'www.example.com', version: '1.2.3' })
+    end
+
+    it 'calls the app and returns the response' do
+      expect(middleware.call(env)).to eq([status_code, { 'Content-Type' => 'text/html' }, 'Response Body'])
+    end
+
+    context 'when logging a request' do
+      before do
+        middleware.call(env)
+      end
+
+      it 'records the request method' do
+        expect(Rails.logger).to have_received(log_level).with(a_string_matching(/"method":"GET"/))
+      end
+
+      it 'records the request URL' do
+        expect(Rails.logger).to have_received(log_level).with(a_string_matching(%r{"url":"/samples/1234\?foo=bar"}))
+      end
+
+      it 'records the request path' do
+        expect(Rails.logger).to have_received(log_level).with(a_string_matching(%r{"path":"/samples/1234"}))
+      end
+
+      it 'records the request format' do
+        expect(Rails.logger).to have_received(log_level).with(a_string_matching(/"format":"html"/))
+      end
+
+      it 'records the response status code' do
+        expect(Rails.logger).to have_received(log_level).with(a_string_matching(/"status_code":#{status_code}/))
+      end
+
+      it 'records the response status message' do
+        status_message = Rack::Utils::HTTP_STATUS_CODES[status_code] || 'Unknown Status'
+
+        expect(Rails.logger).to have_received(log_level).with(a_string_matching(/"status_message":"#{status_message}"/))
+      end
+
+      it 'records the request duration in milliseconds' do
+        expect(Rails.logger).to have_received(log_level).with(a_string_matching(/"duration_ms":230/))
+      end
+
+      it 'records the client IP address' do
+        expect(Rails.logger).to have_received(log_level).with(a_string_matching(/"client_ip":"172\.12\.345\.10"/))
+      end
+
+      it 'records the request ID' do
+        expect(Rails.logger).to have_received(log_level).with(a_string_matching(/"request_id":"test-request-id"/))
+      end
+
+      it 'records the environment context' do
+        expect(Rails.logger).to have_received(log_level)
+          .with(a_string_matching(/"host":"www\.example\.com","version":"1\.2\.3"/))
+      end
+
+      it 'includes the request tags' do
+        request_tags = ['request']
+        request_tags << case status_code
+                        when 100..199 then 'informational'
+                        when 200..299 then 'success'
+                        when 300..399 then 'redirection'
+                        when 400..499 then 'client_error'
+                        when 500..599 then 'server_error'
+                        end
+        request_tags.compact!
+
+        expect(Rails.logger).to have_received(log_level)
+          .with(a_string_matching(/"tags":\["#{request_tags.join('","')}"\]/))
+      end
+
+      it 'records the timestamp' do
+        expect(Rails.logger).to have_received(log_level)
+          .with(a_string_matching(/"@timestamp":"2026-02-12T12:10:50\.000\+00:00"/))
+      end
+    end
+  end
+
+  context 'when response is 200 OK' do
+    let(:status_code) { 200 }
+
+    it_behaves_like 'logs request with', :info
+  end
+
+  context 'when response is 404 Not Found' do
+    let(:status_code) { 404 }
+
+    it_behaves_like 'logs request with', :info
+  end
+
+  context 'when response is 500 Internal Server Error' do
+    let(:status_code) { 500 }
+
+    it_behaves_like 'logs request with', :info
+  end
+
+  context 'when response is 789 Unknown Status' do
+    let(:status_code) { 789 }
+
+    it_behaves_like 'logs request with',  :info
+  end
+
+  context 'when log level is set to :debug' do
+    it_behaves_like 'logs request with',  :debug
+  end
+end


### PR DESCRIPTION
Contributes to https://github.com/sanger/General-Backlog-Items/issues/699

Same as https://github.com/sanger/sequencescape/pull/5546 but for Limber.

Some example logs:
```log
I, [2026-02-18T10:52:27.178304 #32791]  INFO -- : Started GET "/health" for ::1 at 2026-02-18 10:52:27 +0000
I, [2026-02-18T10:52:27.305984 #32791]  INFO -- : Processing by Rails::HealthController#show as HTML
D, [2026-02-18T10:52:27.325898 #32791] DEBUG -- :   Rendering html template
I, [2026-02-18T10:52:27.326489 #32791]  INFO -- :   Rendered html template (Duration: 0.5ms | GC: 0.0ms)
I, [2026-02-18T10:52:27.327959 #32791]  INFO -- : Completed 200 OK in 22ms (Views: 9.7ms | GC: 0.0ms)


I, [2026-02-18T10:52:27.340388 #32791]  INFO -- : [RequestLogger] {"method":"GET","url":"/health","path":"/health","format":"html","status_code":200,"status_message":"OK","duration_ms":163,"client_ip":"::1","request_id":"837ed935-932a-445a-9f45-ac1f6838d59e","tags":["request","success"],"@timestamp":"2026-02-18T10:52:27.336Z"}
I, [2026-02-18T10:54:15.359860 #32791]  INFO -- : Started GET "/not-found" for ::1 at 2026-02-18 10:54:15 +0000
E, [2026-02-18T10:54:15.456787 #32791] ERROR -- :   
ActionController::RoutingError (No route matches [GET] "/not-found"):
  
I, [2026-02-18T10:54:15.771092 #32791]  INFO -- : [RequestLogger] {"method":"GET","url":"/not-found","path":"/not-found","format":"html","status_code":404,"status_message":"Not Found","duration_ms":415,"client_ip":"::1","request_id":"ddaa933d-57d3-42ae-8735-2b525f7f313b","tags":["request","client_error"],"@timestamp":"2026-02-18T10:54:15.770Z"}
I, [2026-02-18T10:54:39.145751 #32791]  INFO -- : Started GET "/not-found?maybe" for ::1 at 2026-02-18 10:54:39 +0000
E, [2026-02-18T10:54:39.255141 #32791] ERROR -- :   
ActionController::RoutingError (No route matches [GET] "/not-found"):
  
I, [2026-02-18T10:54:39.492393 #32791]  INFO -- : [RequestLogger] {"method":"GET","url":"/not-found?maybe","path":"/not-found","format":"html","status_code":404,"status_message":"Not Found","duration_ms":347,"client_ip":"::1","request_id":"c2370d87-c105-4811-902c-61e74d91b426","tags":["request","client_error"],"@timestamp":"2026-02-18T10:54:39.491Z"}
```

#### Changes proposed in this pull request

- Add `Middleware::RequestLogger` to allow collation of request metrics to response metrics

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
