### PR TITLE
[dev] Add log level setting to development environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,6 +48,9 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
   config.action_mailer.smtp_settings = {}
 
+  # Logging configuration
+  config.log_level = ENV.fetch('LOG_LEVEL', :debug).to_sym
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 


### PR DESCRIPTION
Make the console log levels settable, like in Sequencescape

#### Changes proposed in this pull request

- Set the environment variable `LOG_LEVEL` to set this in development, eg:
  ```sh
  LOG_LEVEL=INFO bundle exec rails server    
  ```

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
