### PR TITLE
build: pin web-console due to rails upgrade requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ group :development do
   gem 'guard-rspec', require: false
   gem 'pry'
   gem 'pry-byebug'
-  gem 'web-console'
+  gem 'web-console', '~> 4.2.1' # version 4.3.0 requires Rails 8.0
 
   # MiniProfiler allows you to see the speed of a request conveniently on the page.
   gem 'rack-mini-profiler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -534,7 +534,7 @@ DEPENDENCIES
   syslog
   vite_rails
   vite_ruby
-  web-console
+  web-console (~> 4.2.1)
   webmock
   yard
 


### PR DESCRIPTION
Closes #2721

#### Changes proposed in this pull request

- Pins `web-console` to version `4.2.1` as `4.3.0` requires a Rails upgrade

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
