### PR TITLE
[ruby] Update sanger/json_api_client from upstream

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :default do
   gem 'hashie'
 
   # Communications with JSON APIs
-  gem 'json_api_client', github: 'sanger/json_api_client', branch: 'v1.21.0a'
+  gem 'json_api_client', github: 'sanger/json_api_client', tag: 'v1.23.0-sanger.1-rc.2'
 
   # Speed up json encoding/decoding with oj
   gem 'oj'

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :default do
   gem 'hashie'
 
   # Communications with JSON APIs
-  gem 'json_api_client', github: 'sanger/json_api_client', tag: 'v1.23.0-sanger.1-rc.2'
+  gem 'json_api_client', github: 'sanger/json_api_client', tag: 'v1.23.0-sanger.1'
 
   # Speed up json encoding/decoding with oj
   gem 'oj'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 GIT
   remote: https://github.com/sanger/json_api_client.git
-  revision: 2d06b4457e7c0e276736818e8d932f0691447ab6
-  branch: v1.21.0a
+  revision: 95e2a28c40d82ccd189fed7972ca45537a69d75d
+  tag: v1.23.0-sanger.1-rc.2
   specs:
-    json_api_client (1.21.0a)
-      activemodel (>= 3.2.0)
-      activesupport (>= 3.2.0)
+    json_api_client (1.23.0.pre.sanger.1)
+      activemodel (>= 6.0.0)
+      activesupport (>= 6.0.0)
       addressable (~> 2.2)
-      faraday (>= 0.15.2, < 2.0)
-      faraday_middleware (>= 0.9.0, < 2.0)
+      faraday (>= 1.10, < 3.0)
+      faraday-gzip (>= 1.0, < 3.0)
       rack (>= 0.2)
 
 GIT
@@ -177,6 +177,9 @@ GEM
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.1)
     faraday-excon (1.1.0)
+    faraday-gzip (2.0.1)
+      faraday (>= 1.0)
+      zlib (~> 3.0)
     faraday-httpclient (1.0.1)
     faraday-multipart (1.2.0)
       multipart-post (~> 2.0)
@@ -185,8 +188,6 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
     ffi (1.16.3)
     formatador (1.1.0)
     globalid (1.3.0)
@@ -487,6 +488,7 @@ GEM
       nokogiri (~> 1.8)
     yard (0.9.38)
     zeitwerk (2.7.5)
+    zlib (3.2.3)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/sanger/json_api_client.git
-  revision: 95e2a28c40d82ccd189fed7972ca45537a69d75d
-  tag: v1.23.0-sanger.1-rc.2
+  revision: efd4c46b04bd8344c4ff0f318b5642baeeba6a01
+  tag: v1.23.0-sanger.1
   specs:
     json_api_client (1.23.0.pre.sanger.1)
       activemodel (>= 6.0.0)


### PR DESCRIPTION


#### Changes proposed in this pull request

- `gem 'json_api_client', github: 'sanger/json_api_client', tag: 'v1.23.0-sanger.1'`

See release notes: https://github.com/sanger/json_api_client/releases/tag/v1.23.0-sanger.1

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
