### PR TITLE
Y26-063 - Quad stamp scan fails when plate has no active requests

### DIFF
--- a/app/frontend/javascript/multi-stamp/components/MultiStamp.spec.js
+++ b/app/frontend/javascript/multi-stamp/components/MultiStamp.spec.js
@@ -3,7 +3,8 @@ import { shallowMount } from '@vue/test-utils'
 import MultiStamp from './MultiStamp.vue'
 import itBehavesLikeMultiStamp from './shared_examples/multi_stamp_instance.shared_spec'
 import { flushPromises } from '@vue/test-utils'
-import { plateFactory } from '@/javascript/test_support/factories.js'
+import { plateFactory, wellFactory, requestFactory } from '@/javascript/test_support/factories.js'
+import { aggregate } from '@/javascript/shared/components/scanValidators.js'
 
 describe('MultiStamp', () => {
   itBehavesLikeMultiStamp({ subject: MultiStamp })
@@ -298,6 +299,74 @@ describe('MultiStamp', () => {
 
       expect(wrapper.vm.excessTransfers.length).toEqual(4)
       expect(wrapper.vm.transfersError).toEqual('excess transfers')
+    })
+
+    // MultiStamp scanValidation is overriden by some other components, so we test it here rather than in the shared examples
+    describe('displays the correct error message when wells require active library requests', () => {
+      it('is not valid when we scan plates with wells with no requests', async () => {
+        const wrapper = wrapperFactory({ requireActiveLibraryRequests: 'true' })
+        const well1 = wellFactory({
+          uuid: 'well-1-uuid',
+          requests_as_source: [],
+          position: { name: 'A1' },
+        })
+        const plate1 = {
+          state: 'valid',
+          plate: plateFactory({ uuid: 'plate-1-uuid', wells: [well1] }),
+        }
+        wrapper.vm.updatePlate(1, plate1)
+
+        const validation = aggregate(wrapper.vm.scanValidation, plate1.plate)
+        expect(validation.message).toContain(
+          'Plate should have at least 1 wells with submissions for library preparation (0)',
+        )
+        expect(validation.valid).toEqual(false)
+      })
+
+      it('is not valid when we scan plates with wells with non-library requests', async () => {
+        const wrapper = wrapperFactory({ requireActiveLibraryRequests: 'true' })
+        const request1 = requestFactory({ uuid: 'req-1-uuid' })
+        const well1 = wellFactory({
+          uuid: 'well-1-uuid',
+          requests_as_source: [request1],
+          position: { name: 'A1' },
+        })
+        const plate1 = {
+          state: 'valid',
+          plate: plateFactory({ uuid: 'plate-1-uuid', wells: [well1] }),
+        }
+        wrapper.vm.updatePlate(1, plate1)
+
+        const validation = aggregate(wrapper.vm.scanValidation, plate1.plate)
+        expect(validation.message).toContain(
+          'Plate should have at least 1 wells with submissions for library preparation (0)',
+        )
+        expect(validation.valid).toEqual(false)
+      })
+
+      it('is valid when we scan plates with at least one well with library requests', async () => {
+        const wrapper = wrapperFactory({ requireActiveLibraryRequests: 'true' })
+        const request1 = requestFactory({ uuid: 'req-1-uuid', library_type: 'Standard' })
+        const well1 = wellFactory({
+          uuid: 'well-1-uuid',
+          requests_as_source: [request1],
+          position: { name: 'A1' },
+        })
+        // Second well with no library requests
+        const well2 = wellFactory({
+          uuid: 'well-2-uuid',
+          requests_as_source: [],
+          position: { name: 'A2' },
+        })
+        const plate1 = {
+          state: 'valid',
+          plate: plateFactory({ uuid: 'plate-1-uuid', wells: [well1, well2] }),
+        }
+        wrapper.vm.updatePlate(1, plate1)
+
+        const validation = aggregate(wrapper.vm.scanValidation, plate1.plate)
+        expect(validation.valid).toEqual(true)
+      })
     })
   })
 })

--- a/app/frontend/javascript/multi-stamp/components/MultiStamp.spec.js
+++ b/app/frontend/javascript/multi-stamp/components/MultiStamp.spec.js
@@ -23,6 +23,7 @@ describe('MultiStamp', () => {
           locationObj: options.locationObj,
           transfersLayout: 'quadrant',
           transfersCreator: 'multi-stamp',
+          requireActiveLibraryRequests: 'false',
           ...options,
         },
       })

--- a/app/frontend/javascript/multi-stamp/components/MultiStamp.vue
+++ b/app/frontend/javascript/multi-stamp/components/MultiStamp.vue
@@ -55,6 +55,7 @@ import {
   checkDuplicates,
   checkSize,
   checkForUnacceptablePlatePurpose,
+  checkMinCountRequests,
 } from '@/javascript/shared/components/plateScanValidators.js'
 import devourApi from '@/javascript/shared/devourApi.js'
 import buildPlateObjs from '@/javascript/shared/plateHelpers.js'
@@ -274,6 +275,7 @@ export default {
         checkSize(12, 8),
         checkDuplicates(currPlates),
         checkForUnacceptablePlatePurpose(this.acceptablePurposesArray),
+        checkMinCountRequests(1),
       ]
     },
   },

--- a/app/frontend/javascript/multi-stamp/components/MultiStamp.vue
+++ b/app/frontend/javascript/multi-stamp/components/MultiStamp.vue
@@ -141,6 +141,15 @@ export default {
     // If present is used in scanValidation to check if the user has scanned an
     // a plate of the correct type.
     acceptablePurposes: { type: String, required: false, default: '[]' },
+
+    // Flag to determine whether we should check if the scanned plates have active library requests. It is optional and
+    // defaults to 'false' if not provided.
+    // Also referenced as require-active-library-requests and require_active_library_requests
+    requireActiveLibraryRequests: {
+      type: String,
+      required: false,
+      default: 'false',
+    },
   },
   data() {
     return {
@@ -271,12 +280,17 @@ export default {
     },
     scanValidation() {
       const currPlates = this.plates.map((plateItem) => plateItem.plate)
-      return [
+
+      const validators = [
         checkSize(12, 8),
         checkDuplicates(currPlates),
         checkForUnacceptablePlatePurpose(this.acceptablePurposesArray),
-        checkMinCountRequests(1),
       ]
+      if (this.requireActiveLibraryRequests === 'true') {
+        validators.push(checkMinCountRequests(1))
+      }
+
+      return validators
     },
   },
   methods: {

--- a/app/frontend/javascript/multi-stamp/components/MultiStamp.vue
+++ b/app/frontend/javascript/multi-stamp/components/MultiStamp.vue
@@ -286,6 +286,8 @@ export default {
         checkDuplicates(currPlates),
         checkForUnacceptablePlatePurpose(this.acceptablePurposesArray),
       ]
+      // We can't enforce this check for all multi stamp plates because some may not be the first step of the workflow,
+      // and therefore may not have library requests yet. So we make it optional to check if the scanned plates have active library requests.
       if (this.requireActiveLibraryRequests === 'true') {
         validators.push(checkMinCountRequests(1))
       }

--- a/app/frontend/javascript/multi-stamp/components/filterProps.js
+++ b/app/frontend/javascript/multi-stamp/components/filterProps.js
@@ -24,7 +24,7 @@ const filterProps = {
   null: {
     plateFields: {
       plates: 'labware_barcode,purpose,wells,uuid,number_of_rows,number_of_columns',
-      requests: 'uuid,state',
+      requests: 'uuid,state,library_type',
       wells: 'position,requests_as_source,aliquots,uuid',
       aliquots: 'request',
     },

--- a/app/frontend/javascript/multi-stamp/components/shared_examples/multi_stamp_instance.shared_spec.js
+++ b/app/frontend/javascript/multi-stamp/components/shared_examples/multi_stamp_instance.shared_spec.js
@@ -5,6 +5,7 @@
 // Import the component being tested
 import { mount } from '@vue/test-utils'
 import { plateFactory, wellFactory, requestFactory } from '@/javascript/test_support/factories.js'
+import { aggregate } from '@/javascript/shared/components/scanValidators.js'
 
 const sharedSpecs = (args) => {
   const subject = args.subject
@@ -177,6 +178,73 @@ const sharedSpecs = (args) => {
       expect(wrapper.vm.transfersError).toEqual(
         'This would result in multiple transfers into the same well. Check if the source plates (DN1S) have more than one active submission.',
       )
+    })
+
+    describe('displays the correct error message when wells require active library requests', () => {
+      it('is not valid when we scan plates with wells with no requests', async () => {
+        const wrapper = wrapperFactory({ requireActiveLibraryRequests: 'true' })
+        const well1 = wellFactory({
+          uuid: 'well-1-uuid',
+          requests_as_source: [],
+          position: { name: 'A1' },
+        })
+        const plate1 = {
+          state: 'valid',
+          plate: plateFactory({ uuid: 'plate-1-uuid', wells: [well1] }),
+        }
+        wrapper.vm.updatePlate(1, plate1)
+
+        const validation = aggregate(wrapper.vm.scanValidation, plate1.plate)
+        expect(validation.message).toContain(
+          'Plate should have at least 1 wells with submissions for library preparation (0)',
+        )
+        expect(validation.valid).toEqual(false)
+      })
+
+      it('is not valid when we scan plates with wells with non-library requests', async () => {
+        const wrapper = wrapperFactory({ requireActiveLibraryRequests: 'true' })
+        const request1 = requestFactory({ uuid: 'req-1-uuid' })
+        const well1 = wellFactory({
+          uuid: 'well-1-uuid',
+          requests_as_source: [request1],
+          position: { name: 'A1' },
+        })
+        const plate1 = {
+          state: 'valid',
+          plate: plateFactory({ uuid: 'plate-1-uuid', wells: [well1] }),
+        }
+        wrapper.vm.updatePlate(1, plate1)
+
+        const validation = aggregate(wrapper.vm.scanValidation, plate1.plate)
+        expect(validation.message).toContain(
+          'Plate should have at least 1 wells with submissions for library preparation (0)',
+        )
+        expect(validation.valid).toEqual(false)
+      })
+
+      it('is valid when we scan plates with at least one well with library requests', async () => {
+        const wrapper = wrapperFactory({ requireActiveLibraryRequests: 'true' })
+        const request1 = requestFactory({ uuid: 'req-1-uuid', library_type: 'Standard' })
+        const well1 = wellFactory({
+          uuid: 'well-1-uuid',
+          requests_as_source: [request1],
+          position: { name: 'A1' },
+        })
+        // Second well with no library requests
+        const well2 = wellFactory({
+          uuid: 'well-2-uuid',
+          requests_as_source: [],
+          position: { name: 'A2' },
+        })
+        const plate1 = {
+          state: 'valid',
+          plate: plateFactory({ uuid: 'plate-1-uuid', wells: [well1, well2] }),
+        }
+        wrapper.vm.updatePlate(1, plate1)
+
+        const validation = aggregate(wrapper.vm.scanValidation, plate1.plate)
+        expect(validation.valid).toEqual(true)
+      })
     })
 
     describe('defaultVolume', () => {

--- a/app/frontend/javascript/multi-stamp/components/shared_examples/multi_stamp_instance.shared_spec.js
+++ b/app/frontend/javascript/multi-stamp/components/shared_examples/multi_stamp_instance.shared_spec.js
@@ -5,7 +5,6 @@
 // Import the component being tested
 import { mount } from '@vue/test-utils'
 import { plateFactory, wellFactory, requestFactory } from '@/javascript/test_support/factories.js'
-import { aggregate } from '@/javascript/shared/components/scanValidators.js'
 
 const sharedSpecs = (args) => {
   const subject = args.subject
@@ -178,73 +177,6 @@ const sharedSpecs = (args) => {
       expect(wrapper.vm.transfersError).toEqual(
         'This would result in multiple transfers into the same well. Check if the source plates (DN1S) have more than one active submission.',
       )
-    })
-
-    describe('displays the correct error message when wells require active library requests', () => {
-      it('is not valid when we scan plates with wells with no requests', async () => {
-        const wrapper = wrapperFactory({ requireActiveLibraryRequests: 'true' })
-        const well1 = wellFactory({
-          uuid: 'well-1-uuid',
-          requests_as_source: [],
-          position: { name: 'A1' },
-        })
-        const plate1 = {
-          state: 'valid',
-          plate: plateFactory({ uuid: 'plate-1-uuid', wells: [well1] }),
-        }
-        wrapper.vm.updatePlate(1, plate1)
-
-        const validation = aggregate(wrapper.vm.scanValidation, plate1.plate)
-        expect(validation.message).toContain(
-          'Plate should have at least 1 wells with submissions for library preparation (0)',
-        )
-        expect(validation.valid).toEqual(false)
-      })
-
-      it('is not valid when we scan plates with wells with non-library requests', async () => {
-        const wrapper = wrapperFactory({ requireActiveLibraryRequests: 'true' })
-        const request1 = requestFactory({ uuid: 'req-1-uuid' })
-        const well1 = wellFactory({
-          uuid: 'well-1-uuid',
-          requests_as_source: [request1],
-          position: { name: 'A1' },
-        })
-        const plate1 = {
-          state: 'valid',
-          plate: plateFactory({ uuid: 'plate-1-uuid', wells: [well1] }),
-        }
-        wrapper.vm.updatePlate(1, plate1)
-
-        const validation = aggregate(wrapper.vm.scanValidation, plate1.plate)
-        expect(validation.message).toContain(
-          'Plate should have at least 1 wells with submissions for library preparation (0)',
-        )
-        expect(validation.valid).toEqual(false)
-      })
-
-      it('is valid when we scan plates with at least one well with library requests', async () => {
-        const wrapper = wrapperFactory({ requireActiveLibraryRequests: 'true' })
-        const request1 = requestFactory({ uuid: 'req-1-uuid', library_type: 'Standard' })
-        const well1 = wellFactory({
-          uuid: 'well-1-uuid',
-          requests_as_source: [request1],
-          position: { name: 'A1' },
-        })
-        // Second well with no library requests
-        const well2 = wellFactory({
-          uuid: 'well-2-uuid',
-          requests_as_source: [],
-          position: { name: 'A2' },
-        })
-        const plate1 = {
-          state: 'valid',
-          plate: plateFactory({ uuid: 'plate-1-uuid', wells: [well1, well2] }),
-        }
-        wrapper.vm.updatePlate(1, plate1)
-
-        const validation = aggregate(wrapper.vm.scanValidation, plate1.plate)
-        expect(validation.valid).toEqual(true)
-      })
     })
 
     describe('defaultVolume', () => {

--- a/app/frontend/javascript/shared/components/plateScanValidators.spec.js
+++ b/app/frontend/javascript/shared/components/plateScanValidators.spec.js
@@ -44,18 +44,6 @@ describe('checkDuplicates', () => {
     })
   })
 
-  it.skip('fails if there are duplicate plates even when the parent has not been updated', () => {
-    // We emit the plate and state as a single event, and want to avoid the situation
-    // where plates flick from valid to invalid
-    const empty = null
-    const plate1 = { uuid: 'plate-uuid-1' }
-
-    expect(checkDuplicates([empty, plate1])(plate1)).toEqual({
-      valid: false,
-      message: 'Barcode has been scanned multiple times',
-    })
-  })
-
   it('passes if it has distinct plates and the parent has not been updated', () => {
     const empty = null
     const plate1 = { uuid: 'plate-uuid-1' }

--- a/app/frontend/javascript/shared/components/plateScanValidators.spec.js
+++ b/app/frontend/javascript/shared/components/plateScanValidators.spec.js
@@ -162,37 +162,60 @@ describe('checkMaxCountRequests', () => {
 })
 
 describe('checkMinCountRequests', () => {
-  const plate_bad = {
-    wells: [
-      { position: { name: 'A1' }, requests_as_source: [{ library_type: 'A' }] },
-      { position: { name: 'B1' }, requests_as_source: [{ library_type: 'A' }] },
-      { position: { name: 'C1' }, requests_as_source: [] },
-    ],
-  }
-  const plate_good = {
-    wells: [
-      {
-        position: { name: 'A1' },
-        requests_as_source: [{ library_type: 'A' }, { library_type: 'B' }],
-      },
-      {
-        position: { name: 'B1' },
-        requests_as_source: [{ library_type: 'A' }, { library_type: 'B' }],
-      },
-      {
-        position: { name: 'C1' },
-        requests_as_source: [{ library_type: 'A' }, { library_type: 'B' }],
-      },
-    ],
-  }
-
   const validator = checkMinCountRequests(3)
 
-  it('validates has more than minimum requests', () => {
-    expect(validator(plate_good)).toEqual({ valid: true })
+  it('passes when it has more than the minimum library requests', () => {
+    const plate = {
+      wells: [
+        { position: { name: 'A1' }, requests_as_source: [{ library_type: 'A' }] },
+        { position: { name: 'B1' }, requests_as_source: [{ library_type: 'A' }] },
+        { position: { name: 'C1' }, requests_as_source: [{ library_type: 'A' }] },
+      ],
+    }
+    const validation = validator(plate)
+    expect(validation.valid).toEqual(true)
   })
-  it('fails when has less than minimum requests', () => {
-    expect(validator(plate_bad).valid).toEqual(false)
+
+  it('fails when it has less than minimum requests', () => {
+    const plate = {
+      wells: [
+        { position: { name: 'A1' }, requests_as_source: [{ library_type: 'A' }] },
+        { position: { name: 'B1' }, requests_as_source: [{ library_type: 'A' }] },
+        { position: { name: 'C1' }, requests_as_source: [] },
+      ],
+    }
+    const validation = validator(plate)
+    expect(validation.valid).toEqual(false)
+    expect(validation.message).toEqual(
+      'Plate should have at least 3 wells with submissions for library preparation (2)',
+    )
+  })
+
+  it('fails when it has enough requests but they are not for library preparation', () => {
+    // Note: The omission of library_type is what determines that these requests are not for library preparation
+    const plate = {
+      wells: [
+        { position: { name: 'A1' }, requests_as_source: [{ uuid: 'req-uuid-1' }] },
+        { position: { name: 'B1' }, requests_as_source: [{ uuid: 'req-uuid-2' }] },
+        { position: { name: 'C1' }, requests_as_source: [{ uuid: 'req-uuid-3' }] },
+      ],
+    }
+    const validation = validator(plate)
+    expect(validation.valid).toEqual(false)
+    expect(validation.message).toEqual(
+      'Plate should have at least 3 wells with submissions for library preparation (0)',
+    )
+  })
+
+  it('fails when it has no wells', () => {
+    const plate = {
+      wells: [],
+    }
+    const validation = validator(plate)
+    expect(validation.valid).toEqual(false)
+    expect(validation.message).toEqual(
+      'Plate should have at least 3 wells with submissions for library preparation (0)',
+    )
   })
 })
 

--- a/app/frontend/javascript/shared/components/tubeScanValidators.spec.js
+++ b/app/frontend/javascript/shared/components/tubeScanValidators.spec.js
@@ -36,18 +36,6 @@ describe('checkDuplicates', () => {
     })
   })
 
-  it.skip('fails if there are duplicate tubes even when the parent has not been updated', () => {
-    // We emit the tube and state as a single event, and want to avoid the situation
-    // where tubes flick from valid to invalid
-    const empty = null
-    const tube1 = { uuid: 'tube-uuid-1' }
-
-    expect(checkDuplicates([empty, tube1])(tube1)).toEqual({
-      valid: false,
-      message: 'Barcode has been scanned multiple times',
-    })
-  })
-
   it('passes if it has distinct tubes and the parent has not been updated', () => {
     const empty = null
     const tube1 = { uuid: 'tube-uuid-1' }

--- a/app/models/labware_creators/multi_stamp.rb
+++ b/app/models/labware_creators/multi_stamp.rb
@@ -27,6 +27,10 @@ module LabwareCreators
 
     validates :transfers, presence: true
 
+    def require_active_library_requests?
+      params.fetch('require_active_library_requests', false)
+    end
+
     private
 
     def create_labware!

--- a/app/views/plate_creation/multi_stamp.html.erb
+++ b/app/views/plate_creation/multi_stamp.html.erb
@@ -9,6 +9,7 @@
      data-target-rows="<%= @labware_creator.target_rows %>"
      data-target-columns="<%= @labware_creator.target_columns %>"
      data-source-plates="<%= @labware_creator.source_plates %>"
-     data-acceptable-purposes="<%= @labware_creator.acceptable_purposes %>">
+     data-acceptable-purposes="<%= @labware_creator.acceptable_purposes %>"
+     data-require-active-library-requests="<%= @labware_creator.require_active_library_requests? %>">
   <div class="spinner-dark">Loading...</div>
 </div>

--- a/config/purposes/bioscan.yml
+++ b/config/purposes/bioscan.yml
@@ -69,7 +69,10 @@ LBSN-96 Lysate Input:
       allowed_extra_barcodes: false
 LBSN-384 PCR 1:
   :asset_type: plate
-  :creator_class: LabwareCreators::QuadrantStamp
+  :creator_class:
+    name: LabwareCreators::QuadrantStamp
+    params:
+      require_active_library_requests: yes
   :merger_plate: true
   :presenter_class: Presenters::MinimalPcrPlatePresenter
   :label_template: plate_384_single


### PR DESCRIPTION
Closes #2728

#### Changes proposed in this pull request

- Adds 'checkMinCountRequests' to MultiStamp to ensure at least one active library creation request exists on scanned plates.
- Adds 'requireActiveLibraryRequests' config attribute to multi stamp purposes. We need to do config driven instead of enforcing for every MultiStamp plate as some are not at the start of library prep so will fail the requests check.
