### PR TITLE
build: unpin web-console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ group :development do
   gem 'guard-rspec', require: false
   gem 'pry'
   gem 'pry-byebug'
-  gem 'web-console', '~> 4.2.1' # version 4.3.0 requires Rails 8.0
+  gem 'web-console'
 
   # MiniProfiler allows you to see the speed of a request conveniently on the page.
   gem 'rack-mini-profiler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -531,7 +531,7 @@ DEPENDENCIES
   syslog
   vite_rails
   vite_ruby
-  web-console (~> 4.2.1)
+  web-console
   webmock
   yard
 


### PR DESCRIPTION
Closes #2725

#### Changes proposed in this pull request

- Unpin `web-console` now that we've upgraded to Rails 8.0

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
