### PR TITLE
ci: reduce push triggering ci actions to just develop and master

### DIFF
--- a/.github/workflows/compile_test.yml
+++ b/.github/workflows/compile_test.yml
@@ -2,6 +2,9 @@ name: Test compilation
 
 on:
   push:
+    branches:
+      - develop
+      - master
   pull_request:
 
 env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ env:
 
 on:
   push:
+    branches:
+      - develop
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -3,6 +3,9 @@ name: Unit tests
 on:
   # Warning: changing run conditions could prevent coverage report in PR, see codecov.yml for `after_n_builds`
   push:
+    branches:
+      - develop
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -2,6 +2,9 @@ name: Unit tests
 
 on:
   push:
+    branches:
+      - develop
+      - master
   pull_request:
 
 env:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
 codecov:
   notify:
     # do not notify until at least n builds have been uploaded from the CI pipeline
-    after_n_builds: 4 # js_test (push), js_test (pull_request), ruby_test (push), ruby_test (pull_request)
+    after_n_builds: 2 # js_test (pull_request), ruby_test (pull_request)


### PR DESCRIPTION
#### Changes proposed in this pull request

- Reduces ci test actions running on push to just master and develop
