### PR TITLE
Y26-063 - Fix multi stamp plates causing 500s

### DIFF
--- a/app/models/labware_creators/multi_stamp.rb
+++ b/app/models/labware_creators/multi_stamp.rb
@@ -28,7 +28,7 @@ module LabwareCreators
     validates :transfers, presence: true
 
     def require_active_library_requests?
-      params.fetch('require_active_library_requests', false)
+      params&.fetch('require_active_library_requests', false)
     end
 
     private


### PR DESCRIPTION
#### Changes proposed in this pull request

- prevents 500 error when multi stamp purposes do not contain params


