### PR TITLE
Y26-214 - [PR][BUG] unknown state for child tube causing 500 server error

### DIFF
--- a/app/integrations/sequencescape/api/v2/base.rb
+++ b/app/integrations/sequencescape/api/v2/base.rb
@@ -23,6 +23,11 @@ class Sequencescape::Api::V2::Base < JsonApiClient::Resource # rubocop:todo Styl
 
   # set the api base url in an abstract base class
   self.site = Limber::Application.config.api.v2.connection_options.url
+
+  connection(true) do |conn| # connection(true) rebuilds the connection
+    conn.faraday.options[:read_timeout] = 300
+  end
+
   api_key = Limber::Application.config.api.v2.connection_options.authorisation
   connection.faraday.headers['X-Sequencescape-Client-Id'] = api_key
 


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Set Faraday read timeout to five minutes as a workaround for fresh service ticket [#SR-70229](https://sanger.freshservice.com/a/tickets/70229?current_tab=details)

This change was done on the limber production host directly, followed by restarting `limber_puma.service` . 

There is a story for improving the performance of tube creation: https://github.com/sanger/sequencescape/issues/5929

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
