### PR TITLE
y24-324 bug around duped aliquots

### DIFF
--- a/app/integrations/sequencescape/api/v2/well.rb
+++ b/app/integrations/sequencescape/api/v2/well.rb
@@ -70,7 +70,14 @@ class Sequencescape::Api::V2::Well < Sequencescape::Api::V2::Base # rubocop:todo
   end
 
   def tagged?
-    aliquots.any?(&:tagged?)
+    return false if aliquots.blank?
+
+    # checking for a mixture of tagged and untagged aliquots in the same well, this is not allowed
+    if aliquots.any?(&:tagged?) && aliquots.any? { |aliquot| !aliquot.tagged? }
+      raise "Detected a mixture of tagged and untagged aliquots in well #{location}"
+    end
+
+    aliquots.all?(&:tagged?)
   end
 
   def empty?

--- a/app/models/labware_creators/tagged_plate.rb
+++ b/app/models/labware_creators/tagged_plate.rb
@@ -21,6 +21,7 @@ module LabwareCreators
     self.default_transfer_template_name = 'Custom pooling'
 
     validates :purpose_uuid, :parent_uuid, :user_uuid, :tag_plate_barcode, :tag_plate, presence: true
+    validate :check_tag_plate_is_not_already_used
 
     delegate :size, :number_of_columns, :number_of_rows, to: :labware
 
@@ -36,6 +37,7 @@ module LabwareCreators
     end
 
     def create_plate!
+      # NOTE: passes the child to this method. Uses transfers.
       transfer_material_from_parent!(tag_plate.asset_uuid)
 
       yield(tag_plate.asset_uuid) if block_given?
@@ -62,6 +64,21 @@ module LabwareCreators
     end
 
     private
+
+    # Check that the tag plate is not already used (i.e. has aliquots in any wells).
+    # If it is already used, add an error to the model.
+    # Added to prevent creation of child with duplicate aliquots.
+    def check_tag_plate_is_not_already_used
+      return if tag_plate.blank?
+
+      tag_plate_in_db = Sequencescape::Api::V2::Plate.find_by(uuid: tag_plate.asset_uuid)
+      return if tag_plate_in_db.blank?
+
+      # tag plate should not already contain any aliquots in any wells
+      return if tag_plate_in_db.wells.none? { |well| well.aliquots.present? }
+
+      errors.add(:tag_plate_barcode, 'This tag plate appears to already have been used.')
+    end
 
     #
     # Convert the tag plate to the new purpose.

--- a/spec/integrations/sequencescape/api/v2/well_spec.rb
+++ b/spec/integrations/sequencescape/api/v2/well_spec.rb
@@ -3,6 +3,35 @@
 require 'rails_helper'
 
 RSpec.describe Sequencescape::Api::V2::Well do
+  describe '#tagged?' do
+    context 'when all aliquots are tagged' do
+      let(:well) { create(:well, aliquots: [create(:tagged_aliquot), create(:tagged_aliquot)]) }
+
+      it 'returns true' do
+        expect(well.tagged?).to be(true)
+      end
+    end
+
+    context 'when only some aliquots are tagged' do
+      let(:well) { create(:well, aliquots: [create(:tagged_aliquot), create(:aliquot)]) }
+
+      it 'raises an error' do
+        expect { well.tagged? }.to raise_error(
+          RuntimeError,
+          'Detected a mixture of tagged and untagged aliquots in well A1'
+        )
+      end
+    end
+
+    context 'when there are no aliquots' do
+      let(:well) { create(:well, aliquot_count: 0) }
+
+      it 'returns false' do
+        expect(well.tagged?).to be(false)
+      end
+    end
+  end
+
   describe '#contains_control?' do
     let(:well) { create :well }
 

--- a/spec/models/labware_creators/tagged_plate_spec.rb
+++ b/spec/models/labware_creators/tagged_plate_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe LabwareCreators::TaggedPlate, :tag_plate do
 
   it_behaves_like 'it only allows creation from plates'
 
-  let(:plate_uuid) { 'example-plate-uuid' }
-  let(:plate_barcode) { SBCF::SangerBarcode.new(prefix: 'DN', number: 2).machine_barcode.to_s }
+  let(:parent_plate_uuid) { 'parent-plate-uuid' }
+  let(:parent_plate_barcode) { SBCF::SangerBarcode.new(prefix: 'DN', number: 2).machine_barcode.to_s }
   let(:pools) { 0 }
   let(:plate) do
     create(
       :plate,
       :has_pooling_metadata,
-      uuid: plate_uuid,
+      uuid: parent_plate_uuid,
       barcode_number: 2,
       pool_sizes: [8, 8],
       submission_pools_count: pools
@@ -43,18 +43,18 @@ RSpec.describe LabwareCreators::TaggedPlate, :tag_plate do
   end
 
   context 'on new' do
-    let(:form_attributes) { { purpose_uuid: child_purpose_uuid, parent_uuid: plate_uuid } }
+    let(:form_attributes) { { purpose_uuid: child_purpose_uuid, parent_uuid: parent_plate_uuid } }
 
     it 'can be created' do
       expect(subject).to be_a described_class
     end
 
     it 'describes the parent barcode' do
-      expect(subject.parent.barcode.ean13).to eq(plate_barcode)
+      expect(subject.parent.barcode.ean13).to eq(parent_plate_barcode)
     end
 
     it 'describes the parent uuid' do
-      expect(subject.parent_uuid).to eq(plate_uuid)
+      expect(subject.parent_uuid).to eq(parent_plate_uuid)
     end
 
     it 'describes the purpose uuid' do
@@ -139,7 +139,8 @@ RSpec.describe LabwareCreators::TaggedPlate, :tag_plate do
     let(:tag_template_uuid) { 'tag-layout-template' }
 
     let(:plate_conversions_attributes) do
-      [{ parent_uuid: plate_uuid, purpose_uuid: child_purpose_uuid, target_uuid: tag_plate_uuid, user_uuid: user_uuid }]
+      [{ parent_uuid: parent_plate_uuid, purpose_uuid: child_purpose_uuid, target_uuid: tag_plate_uuid,
+         user_uuid: user_uuid }]
     end
 
     let(:state_changes_attributes) do
@@ -169,7 +170,7 @@ RSpec.describe LabwareCreators::TaggedPlate, :tag_plate do
         {
           arguments: {
             user_uuid: user_uuid,
-            source_uuid: plate_uuid,
+            source_uuid: parent_plate_uuid,
             destination_uuid: tag_plate_uuid,
             transfer_template_uuid: transfer_template_uuid,
             transfers: expected_transfers
@@ -182,7 +183,7 @@ RSpec.describe LabwareCreators::TaggedPlate, :tag_plate do
       let(:form_attributes) do
         {
           purpose_uuid: child_purpose_uuid,
-          parent_uuid: plate_uuid,
+          parent_uuid: parent_plate_uuid,
           user_uuid: user_uuid,
           tag_plate_barcode: tag_plate_barcode,
           tag_plate: {
@@ -192,30 +193,56 @@ RSpec.describe LabwareCreators::TaggedPlate, :tag_plate do
         }
       end
 
-      it_behaves_like 'it has a custom page', 'tagged_plate'
+      context 'which has not been used' do
+        let(:tag_plate) { create(:plate, size: 384, uuid: tag_plate_uuid, barcode: tag_plate_barcode) }
 
-      it 'can be created' do
-        expect(subject).to be_a described_class
-      end
-
-      context 'on save' do
-        it 'creates a tag plate' do
-          expect_plate_conversion_creation
-          expect_state_change_creation
-          expect_tag_layout_creation
-          expect_transfer_creation
-
-          expect(subject.save).to be true
+        before do
+          stub_plate(tag_plate)
         end
 
-        it 'has the correct child (and uuid)' do
-          expect_plate_conversion_creation # We need the return value and this expectation mocks it for us.
-          stub_post('StateChange')
-          stub_post('TagLayout')
-          stub_post('Transfer')
+        it_behaves_like 'it has a custom page', 'tagged_plate'
 
-          expect(subject.save).to be true
-          expect(subject.child.uuid).to eq(tag_plate_uuid)
+        it 'can be created' do
+          expect(subject).to be_a described_class
+        end
+
+        context 'on save' do
+          it 'creates a tagged child plate' do
+            expect_plate_conversion_creation
+            expect_state_change_creation
+            expect_tag_layout_creation
+            expect_transfer_creation
+
+            expect(subject.save).to be true
+          end
+
+          it 'has the correct child (and uuid)' do
+            expect_plate_conversion_creation # We need the return value and this expectation mocks it for us.
+            stub_post('StateChange')
+            stub_post('TagLayout')
+            stub_post('Transfer')
+
+            expect(subject.save).to be true
+            expect(subject.child.uuid).to eq(tag_plate_uuid)
+          end
+        end
+      end
+
+      context 'which has already been used' do
+        let(:tag_plate) do
+          create(:plate_for_submission,
+                 size: 384,
+                 uuid: tag_plate_uuid,
+                 barcode: tag_plate_barcode)
+        end
+
+        before do
+          stub_plate(tag_plate)
+        end
+
+        it 'cannot be created' do
+          expect(subject.save).to be false
+          expect(subject.errors[:tag_plate_barcode]).to include('This tag plate appears to already have been used.')
         end
       end
     end


### PR DESCRIPTION
Closes #1919 

#### Changes proposed in this pull request
Adds a validation to prevent use of an already used tag plate