### PR TITLE
Y26-007 - Adds LCM Triomics WGS only branch

### DIFF
--- a/app/models/concerns/presenters/submission_behaviour.rb
+++ b/app/models/concerns/presenters/submission_behaviour.rb
@@ -21,7 +21,9 @@ module Presenters::SubmissionBehaviour
 
   # Determine whether the Choose Workflow buttons should be displayed
   def allow_new_submission?
-    !(pending_submissions? || active_submissions? || labware.active_requests.any?)
+    !(pending_submissions? || active_submissions? || labware.active_requests.any? do |req|
+      %w[pending started passed].include? req.state
+    end)
   end
 
   private

--- a/app/models/concerns/presenters/submission_behaviour.rb
+++ b/app/models/concerns/presenters/submission_behaviour.rb
@@ -21,7 +21,7 @@ module Presenters::SubmissionBehaviour
 
   # Determine whether the Choose Workflow buttons should be displayed
   def allow_new_submission?
-    !(pending_submissions? || active_submissions?)
+    !(pending_submissions? || active_submissions? || labware.active_requests.any?)
   end
 
   private

--- a/app/models/concerns/presenters/submission_behaviour.rb
+++ b/app/models/concerns/presenters/submission_behaviour.rb
@@ -26,6 +26,12 @@ module Presenters::SubmissionBehaviour
 
   private
 
+  def submittable_pipelines
+    return [] if purpose_config[:presenter_class].is_a?(String)
+
+    purpose_config.dig(:presenter_class, :args, :submittable_pipelines) || []
+  end
+
   # Determine whether the plate has any submittable pipelines configured and
   # if so that at least one of those pipelines is active for the labware
   def pipeline_submittable?

--- a/app/models/concerns/presenters/submission_behaviour.rb
+++ b/app/models/concerns/presenters/submission_behaviour.rb
@@ -21,9 +21,7 @@ module Presenters::SubmissionBehaviour
 
   # Determine whether the Choose Workflow buttons should be displayed
   def allow_new_submission?
-    !(pending_submissions? || active_submissions? || labware.active_requests.any? do |req|
-      %w[pending started passed].include? req.state
-    end)
+    !(pending_submissions? || active_submissions?)
   end
 
   private

--- a/app/models/concerns/presenters/submission_behaviour.rb
+++ b/app/models/concerns/presenters/submission_behaviour.rb
@@ -37,9 +37,8 @@ module Presenters::SubmissionBehaviour
   def pipeline_submittable?
     return true if submittable_pipelines.empty?
 
-    submittable_pipelines.any? do |pipeline|
-      Settings.pipelines.active_pipelines_for_in_progress_requests(labware).collect(&:name).include?(pipeline)
-    end
+    active_pipeline_names = Settings.pipelines.active_pipelines_for_in_progress_requests(labware).map(&:name)
+    submittable_pipelines.any? { |pipeline| active_pipeline_names.include?(pipeline) }
   end
 
   def asset_groups

--- a/app/models/concerns/presenters/submission_behaviour.rb
+++ b/app/models/concerns/presenters/submission_behaviour.rb
@@ -21,10 +21,20 @@ module Presenters::SubmissionBehaviour
 
   # Determine whether the Choose Workflow buttons should be displayed
   def allow_new_submission?
-    !(pending_submissions? || active_submissions?)
+    !(pending_submissions? || active_submissions? || !pipeline_submittable?)
   end
 
   private
+
+  # Determine whether the plate has any submittable pipelines configured and
+  # if so that at least one of those pipelines is active for the labware
+  def pipeline_submittable?
+    return true if submittable_pipelines.empty?
+
+    submittable_pipelines.any? do |pipeline|
+      Settings.pipelines.active_pipelines_for_in_progress_requests(labware).collect(&:name).include?(pipeline)
+    end
+  end
 
   def asset_groups
     @asset_groups ||=

--- a/app/models/presenters/permissive_submission_plate_presenter.rb
+++ b/app/models/presenters/permissive_submission_plate_presenter.rb
@@ -26,6 +26,12 @@ module Presenters
     validates_with Validators::SuboptimalValidator
     validates_with Validators::ActiveRequestValidator
 
+    def submittable_pipelines
+      return [] if purpose_config[:presenter_class].is_a?(String)
+
+      purpose_config.dig(:presenter_class, :args, :submittable_pipelines) || []
+    end
+
     # Stock style class causes well state to inherit from plate state.
     self.style_class = 'stock'
 

--- a/app/models/presenters/permissive_submission_plate_presenter.rb
+++ b/app/models/presenters/permissive_submission_plate_presenter.rb
@@ -26,12 +26,6 @@ module Presenters
     validates_with Validators::SuboptimalValidator
     validates_with Validators::ActiveRequestValidator
 
-    def submittable_pipelines
-      return [] if purpose_config[:presenter_class].is_a?(String)
-
-      purpose_config.dig(:presenter_class, :args, :submittable_pipelines) || []
-    end
-
     # Stock style class causes well state to inherit from plate state.
     self.style_class = 'stock'
 

--- a/config/pipelines/high_throughput_lcm_triomics.yml
+++ b/config/pipelines/high_throughput_lcm_triomics.yml
@@ -34,6 +34,8 @@ LCM Triomics WGS:
     library_type: LCMB
   library_pass: LCMT DNA PCR XP
   relationships:
+    LCMT Lysate: LCMT DNA Frag
+    LCMT DNA Frag: LCMT DNA Adp Lig
     LCMT DNA Adp Lig: LCMT DNA Lib PCR
     LCMT DNA Lib PCR: LCMT DNA PCR XP
 LCM Triomics WGS Custom Pooling:

--- a/config/purposes/lcm_triomics.yml
+++ b/config/purposes/lcm_triomics.yml
@@ -25,6 +25,13 @@ LCMT Lysate:
         library_type: 'Combined LCM RNA'
         fragment_size_required_from: '100'
         fragment_size_required_to: '500'
+    WGS Branch - Automated Submission:
+      template_name: 'Limber-Htp - LCM Triomics WGS'
+      allowed_extra_barcodes: false
+      request_options:
+        library_type: 'LCMB'
+        fragment_size_required_from: '450'
+        fragment_size_required_to: '450'
   :size: 96
 LCMT DNA Frag:
   :asset_type: plate

--- a/config/purposes/lcm_triomics.yml
+++ b/config/purposes/lcm_triomics.yml
@@ -52,7 +52,13 @@ LCMT DNA Adp Lig:
   :stock_plate: false
   :cherrypickable_target: false
   :input_plate: false
-  :presenter_class: Presenters::PermissiveSubmissionPlatePresenter
+  :presenter_class:
+    name: Presenters::PermissiveSubmissionPlatePresenter
+    args:
+      # Adp Lig is used in both EM-seq and WGS only pipelines
+      # But we only want auto-submission from EMSeq
+      submittable_pipelines:
+        - 'LCM Triomics EMSeq'
   :submission_options:
     WGS Branch - Automated Submission:
       template_name: 'Limber-Htp - LCM Triomics WGS'

--- a/config/robots.rb
+++ b/config/robots.rb
@@ -4059,6 +4059,35 @@ ROBOT_CONFIG =
       }
     )
 
+    # LCM Triomics WGS verify initial setup
+    custom_robot(
+      'bravo-lcmt-wgs-verify-initial-setup',
+      name: 'Bravo LCMT WGS Verify Initial Setup',
+      require_robot: true, # Robot barcode must be scanned in.
+      verify_robot: false, # First robot step; no previous robot.
+      beds: {
+        bed(4).barcode => {
+          purpose: 'LCMT Lysate',
+          states: ['passed'],
+          label: 'Bed 4'
+        },
+        car('1,4').barcode => {
+          purpose: 'LCMT DNA Frag',
+          states: ['pending'],
+          label: 'Carousel 1,4',
+          parent: bed(4).barcode,
+          target_state: 'started'
+        },
+        car('3,5').barcode => {
+          purpose: 'LCMT DNA Adp Lig',
+          states: ['pending'],
+          label: 'Carousel 3,5',
+          parent: car('1,4').barcode,
+          target_state: 'started'
+        }
+      }
+    )
+
     # LCM Triomics WGS and EMSeq bed verification
     # Bravo LCMT DNA Frag Verification
     custom_robot(

--- a/spec/models/presenters/permissive_submission_presenter_spec.rb
+++ b/spec/models/presenters/permissive_submission_presenter_spec.rb
@@ -275,16 +275,19 @@ RSpec.describe Presenters::PermissiveSubmissionPlatePresenter do
       create :stock_plate,
              purpose_name: purpose_name,
              barcode_number: 2,
-             pool_sizes: [2],
+             well_count: 2,
              direct_submissions: submissions,
-             state: state
+             state: state,
+             outer_requests: outer_requests
     end
+
     let(:submissions) { create_list :submission, 1, state: }
     let(:barcode_string) { 'DN2T' }
     let(:purpose_name) { 'Test Plate' }
     let(:title) { purpose_name }
     let(:state) { 'cancelled' }
     let(:sidebar_partial) { 'default' }
+    let(:outer_requests) { Array.new(2) { |i| create :library_request, state: 'cancelled', uuid: "request-p2-#{i}" } }
     let(:summary_tab) do
       [
         %w[Barcode DN2T],
@@ -312,8 +315,6 @@ RSpec.describe Presenters::PermissiveSubmissionPlatePresenter do
   end
 
   context 'with failed submissions' do
-    # If our requests have been failed, then we're back at square 1
-
     it_behaves_like 'a labware presenter'
     it_behaves_like 'a stock presenter'
 
@@ -321,16 +322,19 @@ RSpec.describe Presenters::PermissiveSubmissionPlatePresenter do
       create :stock_plate,
              purpose_name: purpose_name,
              barcode_number: 2,
-             pool_sizes: [2],
+             well_count: 2,
              direct_submissions: submissions,
-             state: state
+             state: state,
+             outer_requests: outer_requests
     end
+
     let(:submissions) { create_list :submission, 1, state: }
     let(:barcode_string) { 'DN2T' }
     let(:purpose_name) { 'Test Plate' }
     let(:title) { purpose_name }
     let(:state) { 'failed' }
     let(:sidebar_partial) { 'default' }
+    let(:outer_requests) { Array.new(2) { |i| create :library_request, state: 'failed', uuid: "request-p2-#{i}" } }
     let(:summary_tab) do
       [
         %w[Barcode DN2T],
@@ -347,13 +351,56 @@ RSpec.describe Presenters::PermissiveSubmissionPlatePresenter do
     end
 
     it 'has no pending submissions' do
-      # We have submissions, but they are built. pending_submissions? controls aspects like the
-      # refresh, that would be a nightmare if you were trying to set up a submission
+      # We have failed submissions but they are built
       expect(presenter.pending_submissions?).to be false
     end
 
     it 'allows a new submission to be created' do
       expect(presenter.allow_new_submission?).to be true
+    end
+  end
+
+  context 'with active requests' do
+    it_behaves_like 'a labware presenter'
+    it_behaves_like 'a stock presenter'
+
+    let(:labware) do
+      create :stock_plate,
+             purpose_name: purpose_name,
+             barcode_number: 2,
+             well_count: 2,
+             direct_submissions: [],
+             outer_requests: outer_requests
+    end
+
+    let(:barcode_string) { 'DN2T' }
+    let(:purpose_name) { 'Test Plate' }
+    let(:title) { purpose_name }
+    let(:state) { 'passed' }
+    let(:sidebar_partial) { 'submission_default' }
+    let(:outer_requests) { Array.new(2) { |i| create :library_request, state: 'started', uuid: "request-p2-#{i}" } }
+    let(:summary_tab) do
+      [
+        %w[Barcode DN2T],
+        ['Number of wells', '2/96'],
+        ['Plate type', purpose_name],
+        ['Current plate state', state],
+        ['Input plate barcode', barcode_string],
+        ['Created on', '2017-06-29']
+      ]
+    end
+
+    it 'renders the submission options' do
+      expect { |b| presenter.each_submission_option(&b) }.to yield_successive_args(*template_options)
+    end
+
+    it 'has no pending submissions' do
+      # We have no submissions so this should return false
+      expect(presenter.pending_submissions?).to be false
+    end
+
+    it 'does not allow a new submission to be created' do
+      expect(presenter.allow_new_submission?).to be false
     end
   end
 end

--- a/spec/models/presenters/permissive_submission_presenter_spec.rb
+++ b/spec/models/presenters/permissive_submission_presenter_spec.rb
@@ -359,48 +359,4 @@ RSpec.describe Presenters::PermissiveSubmissionPlatePresenter do
       expect(presenter.allow_new_submission?).to be true
     end
   end
-
-  context 'with active requests' do
-    it_behaves_like 'a labware presenter'
-    it_behaves_like 'a stock presenter'
-
-    let(:labware) do
-      create :stock_plate,
-             purpose_name: purpose_name,
-             barcode_number: 2,
-             well_count: 2,
-             direct_submissions: [],
-             outer_requests: outer_requests
-    end
-
-    let(:barcode_string) { 'DN2T' }
-    let(:purpose_name) { 'Test Plate' }
-    let(:title) { purpose_name }
-    let(:state) { 'passed' }
-    let(:sidebar_partial) { 'submission_default' }
-    let(:outer_requests) { Array.new(2) { |i| create :library_request, state: 'started', uuid: "request-p2-#{i}" } }
-    let(:summary_tab) do
-      [
-        %w[Barcode DN2T],
-        ['Number of wells', '2/96'],
-        ['Plate type', purpose_name],
-        ['Current plate state', state],
-        ['Input plate barcode', barcode_string],
-        ['Created on', '2017-06-29']
-      ]
-    end
-
-    it 'renders the submission options' do
-      expect { |b| presenter.each_submission_option(&b) }.to yield_successive_args(*template_options)
-    end
-
-    it 'has no pending submissions' do
-      # We have no submissions so this should return false
-      expect(presenter.pending_submissions?).to be false
-    end
-
-    it 'does not allow a new submission to be created' do
-      expect(presenter.allow_new_submission?).to be false
-    end
-  end
 end

--- a/spec/models/presenters/permissive_submission_presenter_spec.rb
+++ b/spec/models/presenters/permissive_submission_presenter_spec.rb
@@ -7,13 +7,19 @@ RSpec.describe Presenters::PermissiveSubmissionPlatePresenter do
   subject(:presenter) { described_class.new(labware:) }
 
   let(:purpose_name) { 'Example purpose' }
+  let(:presenter_class) { 'Presenters::PermissiveSubmissionPlatePresenter' }
   let(:labware) { create :plate, state: state, purpose_name: purpose_name, pool_sizes: [1] }
 
   before(:each) do
     create :purpose_config, uuid: 'child-purpose', name: 'Child purpose'
     create :purpose_config, uuid: 'other-purpose', name: 'Other purpose'
     create :pipeline, relationships: { purpose_name => 'Child purpose' }
-    create(:purpose_config, uuid: labware.purpose.uuid, submission_options: submission_options)
+    create(
+      :purpose_config,
+      uuid: labware.purpose.uuid,
+      presenter_class: presenter_class,
+      submission_options: submission_options
+    )
     Settings.submission_templates = { 'example' => example_template_uuid, 'example2' => example2_template_uuid }
   end
 
@@ -357,6 +363,58 @@ RSpec.describe Presenters::PermissiveSubmissionPlatePresenter do
 
     it 'allows a new submission to be created' do
       expect(presenter.allow_new_submission?).to be true
+    end
+  end
+
+  context 'with active requests and submittable pipelines configured' do
+    let(:state) { 'pending' }
+    let(:purpose_name) { 'Test Plate' }
+    let(:submittable_pipeline) { 'Submittable pipeline' }
+    let(:presenter_class) do
+      {
+        name: 'Presenters::PermissiveSubmissionPlatePresenter',
+        args: { submittable_pipelines: [submittable_pipeline] }
+      }
+    end
+    let(:labware) do
+      create :stock_plate,
+             purpose_name: purpose_name,
+             barcode_number: 2,
+             well_count: 2,
+             state: state,
+             direct_submissions: [],
+             outer_requests: outer_requests
+    end
+    let(:request_type) { create :library_request_type, key: 'limber_wgs', name: 'Limber WGS' }
+    let(:outer_requests) do
+      Array.new(2) do |i|
+        create :library_request, state: 'pending', uuid: "request-p2-#{i}", request_type: request_type
+      end
+    end
+
+    before do
+      create(
+        :pipeline,
+        name: submittable_pipeline,
+        relationships: { purpose_name => 'Child purpose' },
+        filters: { request_type_key: [pipeline_request_type_key] }
+      )
+    end
+
+    context 'when the pipeline request type matches' do
+      let(:pipeline_request_type_key) { 'limber_wgs' }
+
+      it 'allows a new submission to be created' do
+        expect(presenter.allow_new_submission?).to be true
+      end
+    end
+
+    context 'when the pipeline request type does not match' do
+      let(:pipeline_request_type_key) { 'other_req_type' }
+
+      it 'does not allow a new submission to be created' do
+        expect(presenter.allow_new_submission?).to be false
+      end
     end
   end
 end

--- a/spec/models/presenters/permissive_submission_presenter_spec.rb
+++ b/spec/models/presenters/permissive_submission_presenter_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe Presenters::PermissiveSubmissionPlatePresenter do
     end
   end
 
-  context 'with active requests and submittable pipelines configured' do
+  context 'with submittable pipelines configured' do
     let(:state) { 'pending' }
     let(:purpose_name) { 'Test Plate' }
     let(:submittable_pipeline) { 'Submittable pipeline' }
@@ -401,7 +401,7 @@ RSpec.describe Presenters::PermissiveSubmissionPlatePresenter do
       )
     end
 
-    context 'when the pipeline request type matches' do
+    context 'when active requests are present and the pipeline request type matches' do
       let(:pipeline_request_type_key) { 'limber_wgs' }
 
       it 'allows a new submission to be created' do
@@ -409,8 +409,21 @@ RSpec.describe Presenters::PermissiveSubmissionPlatePresenter do
       end
     end
 
-    context 'when the pipeline request type does not match' do
+    context 'when active requests are present and the pipeline request type does not match' do
       let(:pipeline_request_type_key) { 'other_req_type' }
+
+      it 'does not allow a new submission to be created' do
+        expect(presenter.allow_new_submission?).to be false
+      end
+    end
+
+    context 'when there are inactive requests and the pipeline request type matches' do
+      let(:pipeline_request_type_key) { 'limber_wgs' }
+      let(:outer_requests) do
+        Array.new(2) do |i|
+          create :library_request, state: 'cancelled', uuid: "request-p2-#{i}", request_type: request_type
+        end
+      end
 
       it 'does not allow a new submission to be created' do
         expect(presenter.allow_new_submission?).to be false


### PR DESCRIPTION
Closes #2667 
SS PR https://github.com/sanger/sequencescape/pull/5950
Int suite PR https://gitlab.internal.sanger.ac.uk/psd/integration-suite/-/merge_requests/325

#### Changes proposed in this pull request

- Adds upstream WGS changes (Lysate plate) to LCM triomics wgs pipeline
- Adds check to only show automated submissions if the current plate has active requests matching the given pipeline
    - This is to prevent WGS automated submission showing up on the WGS only branch. 


See notes for lucid diagram and research: https://github.com/sanger/limber/issues/2671#issuecomment-5103815997
